### PR TITLE
Ported tokenizer

### DIFF
--- a/src/nodejs/analytics/analytics.cpp
+++ b/src/nodejs/analytics/analytics.cpp
@@ -802,6 +802,79 @@ void TNodeJsHMChain::save(const v8::FunctionCallbackInfo<v8::Value>& Args) {
 }
 
 ///////////////////////////////
+// QMiner-JavaScript-Tokenizer
+v8::Persistent <v8::Function> TNodeJsTokenizer::constructor;
+
+void TNodeJsTokenizer::Init(v8::Handle<v8::Object> exports) {
+	v8::Isolate* Isolate = v8::Isolate::GetCurrent();
+
+	v8::Local<v8::FunctionTemplate> tpl = v8::FunctionTemplate::New(Isolate, _New);
+	tpl->SetClassName(v8::String::NewFromUtf8(Isolate, "Tokenizer"));
+	tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+	NODE_SET_PROTOTYPE_METHOD(tpl, "getTokens", _getTokens);
+	NODE_SET_PROTOTYPE_METHOD(tpl, "getSentences", _getSentences);
+	NODE_SET_PROTOTYPE_METHOD(tpl, "getParagraphs", _getParagraphs);
+
+	constructor.Reset(Isolate, tpl->GetFunction());
+	exports->Set(v8::String::NewFromUtf8(Isolate, "TTokenizer"), tpl->GetFunction());
+}
+
+v8::Local<v8::Object> TNodeJsTokenizer::New(const PTokenizer& Tokenizer) {
+	v8::Isolate* Isolate = v8::Isolate::GetCurrent();
+	v8::EscapableHandleScope EscapableHandleScope(Isolate);
+
+	v8::Local<v8::Function> cons = v8::Local<v8::Function>::New(Isolate, constructor);
+	v8::Local<v8::Object> Instance = cons->NewInstance();
+
+	TNodeJsTokenizer* JsTokenizer = new TNodeJsTokenizer(Tokenizer);
+	JsTokenizer->Wrap(Instance);
+
+	return EscapableHandleScope.Escape(Instance);
+}
+
+void TNodeJsTokenizer::New(const v8::FunctionCallbackInfo<v8::Value>& Args) {
+	v8::Isolate* Isolate = v8::Isolate::GetCurrent();
+	v8::HandleScope HandleScope(Isolate);
+	EFailR("Use analytics.newTokenizer() instead of new Tokenizer();");
+	Args.GetReturnValue().Set(v8::Undefined(Isolate));
+}
+
+void TNodeJsTokenizer::getTokens(const v8::FunctionCallbackInfo<v8::Value>& Args) {
+	v8::Isolate* Isolate = v8::Isolate::GetCurrent();
+	v8::HandleScope HandleScope(Isolate);
+
+	EAssertR(Args.Length() == 1 && Args[0]->IsString(), "Expected a string as the argument.");
+	TNodeJsTokenizer* JsTokenizer = ObjectWrap::Unwrap<TNodeJsTokenizer>(Args.Holder());
+	TStr TextStr = TNodeJsUtil::GetArgStr(Args, 0);
+	TStrV TokenV; JsTokenizer->Tokenizer->GetTokens(TextStr, TokenV);
+
+	Args.GetReturnValue().Set(TNodeJsUtil::GetStrArr(TokenV));
+}
+
+void TNodeJsTokenizer::getSentences(const v8::FunctionCallbackInfo<v8::Value>& Args) {
+	v8::Isolate* Isolate = v8::Isolate::GetCurrent();
+	v8::HandleScope HandleScope(Isolate);
+
+	EAssertR(Args.Length() == 1 && Args[0]->IsString(), "Expected a string as the argument.");
+	TStr TextStr = TNodeJsUtil::GetArgStr(Args, 0);
+	TStrV SentenceV; TTokenizerUtil::Sentencize(TextStr, SentenceV);
+
+	Args.GetReturnValue().Set(TNodeJsUtil::GetStrArr(SentenceV));
+}
+
+void TNodeJsTokenizer::getParagraphs(const v8::FunctionCallbackInfo<v8::Value>& Args) {
+	v8::Isolate* Isolate = v8::Isolate::GetCurrent();
+	v8::HandleScope HandleScope(Isolate);
+
+	EAssertR(Args.Length() == 1 && Args[0]->IsString(), "Expected a string as the argument.");
+	TStr TextStr = TNodeJsUtil::GetArgStr(Args, 0);
+	TStrV ParagraphV; TTokenizerUtil::Sentencize(TextStr, ParagraphV);
+
+	Args.GetReturnValue().Set(TNodeJsUtil::GetStrArr(ParagraphV));
+}
+
+///////////////////////////////
 // Register functions, etc.
 #ifndef MODULE_INCLUDE_ANALYTICS
 
@@ -810,6 +883,7 @@ void init(v8::Handle<v8::Object> exports) {
 	TNodeJsSvmModel::Init(exports);
 	TNodeJsRecLinReg::Init(exports);
 	TNodeJsHMChain::Init(exports);
+	TNodeJsTokenizer::Init(exports);
 }
 
 NODE_MODULE(analytics, init)

--- a/src/nodejs/analytics/analytics.h
+++ b/src/nodejs/analytics/analytics.h
@@ -170,4 +170,35 @@ public:
 	JsDeclareFunction(save);
 };
 
+///////////////////////////////
+// QMiner-JavaScript-Tokenizer
+//#
+//# ### Tokenizer
+//#
+//# Breaks text into tokens (i.e. words).
+class TNodeJsTokenizer : public node::ObjectWrap {
+public:
+	/// Tokenizer Model
+	PTokenizer Tokenizer;
+	static v8::Persistent <v8::Function> constructor;
+private:
+	TNodeJsTokenizer(const PTokenizer& _Tokenizer): 
+		Tokenizer(_Tokenizer) { }
+public:
+	static void Init(v8::Handle<v8::Object> exports);
+	static v8::Local<v8::Object> New(const PTokenizer& Tokenizer);
+
+	//#
+	//# **Functions and properties:**
+	//#
+	JsDeclareFunction(New);
+	//#- `arr = tokenizer.getTokens(string)` -- tokenizes given strings and returns it as an array of strings.
+	JsDeclareFunction(getTokens);
+	//#- `arr = tokenizer.getSentences(string)` -- breaks text into sentence and returns them as an array of strings.
+	JsDeclareFunction(getSentences);
+	//#- `arr = tokenizer.getParagraphs(string)` -- breaks text into paragraphs and returns them as an array of strings.
+	JsDeclareFunction(getParagraphs);
+};
+
 #endif /* ANALYTICS_H_ */
+

--- a/src/nodejs/analytics/run.js
+++ b/src/nodejs/analytics/run.js
@@ -1,0 +1,4 @@
+var analytics = require('../../../build/Release/analytics.node');
+
+var tt = new analytics.TTokenizer();
+

--- a/src/nodejs/la/la_nodejs.cpp
+++ b/src/nodejs/la/la_nodejs.cpp
@@ -1646,6 +1646,7 @@ void TNodeJsSpMat::Init(v8::Handle<v8::Object> exports) {
     NODE_SET_PROTOTYPE_METHOD(tpl, "load", _load);
 
     // Properties 
+    tpl->InstanceTemplate()->SetIndexedPropertyHandler(_indexGet, _indexSet);
     tpl->InstanceTemplate()->SetAccessor(v8::String::NewFromUtf8(Isolate, "rows"), _rows);
     tpl->InstanceTemplate()->SetAccessor(v8::String::NewFromUtf8(Isolate, "cols"), _cols);
 
@@ -1826,6 +1827,26 @@ void TNodeJsSpMat::put(const v8::FunctionCallbackInfo<v8::Value>& Args) {
     }
 
     Args.GetReturnValue().Set(v8::Boolean::New(Isolate, true));
+}
+
+void TNodeJsSpMat::indexGet(uint32_t Index, const v8::PropertyCallbackInfo<v8::Value>& Info) {
+    v8::Isolate* Isolate = v8::Isolate::GetCurrent();
+    v8::HandleScope HandleScope(Isolate);
+
+    TNodeJsSpMat* JsSpMat = ObjectWrap::Unwrap<TNodeJsSpMat>(Info.Holder());
+    EAssertR(Index < (uint32_t)JsSpMat->Mat.Len(), "Sparse matrix index at: index out of bounds");
+    Info.GetReturnValue().Set(TNodeJsSpVec::New(JsSpMat->Mat[Index], JsSpMat->Rows));
+}
+
+void TNodeJsSpMat::indexSet(uint32_t Index, v8::Local<v8::Value> Value, const v8::PropertyCallbackInfo<v8::Value>& Info) {
+    v8::Isolate* Isolate = v8::Isolate::GetCurrent();
+    v8::HandleScope HandleScope(Isolate);
+
+    TNodeJsSpMat* JsSpMat = ObjectWrap::Unwrap<TNodeJsSpMat>(Info.Holder());
+    // EAssertR(Index < (uint32_t)JsSpMat->Mat.Len(), "Sparse matrix index set: index out of bounds");
+    v8::Handle<v8::Object> ValObj = v8::Handle<v8::Object>::Cast(Value);
+    JsSpMat->Mat[Index] = ObjectWrap::Unwrap<TNodeJsSpVec>(ValObj)->Vec;
+    Info.GetReturnValue().Set(v8::Undefined(Isolate));
 }
 
 void TNodeJsSpMat::push(const v8::FunctionCallbackInfo<v8::Value>& Args) {

--- a/src/nodejs/la/run.js
+++ b/src/nodejs/la/run.js
@@ -151,6 +151,7 @@ var M12_x = new la.matrix();
 M12_x.load(fs.openRead("test-mat.bin"));
 console.log(M12_x.toString());
 console.log(" ==== ");
+fs.del("test-mat.bin");
 
 console.log(M12.transpose().toString());
 console.log(" *** ");
@@ -181,6 +182,7 @@ fout.close();
 var u = la.newVec();
 u.load(fs.openRead("test-vec.bin"));
 console.log("u: " + u.toString());
+fs.del("test-vec.bin");
 
 // The code below crashes because V8 imposes memory limit on
 // standard JS arrays. 

--- a/src/nodejs/nodeutil.cpp
+++ b/src/nodejs/nodeutil.cpp
@@ -378,3 +378,14 @@ v8::Local<v8::Value> TNodeJsUtil::V8JsonToV8Str(const v8::Handle<v8::Value>& Jso
 	if (JsonStr.IsEmpty()) { Isolate->ThrowException(TryCatch.Exception()); }
 	return HandleScope.Escape(JsonStr);
 }
+
+v8::Local<v8::Value> TNodeJsUtil::GetStrArr(const TStrV& StrV) {
+    v8::Isolate* Isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope EscapableHandleScope(Isolate);
+    v8::Local<v8::Array> JsStrV = v8::Array::New(Isolate, StrV.Len());
+    for (int StrN = 0; StrN < StrV.Len(); StrN++) {
+        JsStrV->Set(StrN, v8::String::NewFromUtf8(Isolate, StrV[StrN].CStr()));
+    }
+    return EscapableHandleScope.Escape(JsStrV);
+}
+

--- a/src/nodejs/nodeutil.h
+++ b/src/nodejs/nodeutil.h
@@ -43,8 +43,8 @@
             v8::String::NewFromUtf8(Isolate, TStr("[addon] Exception: " + Except->GetMsgStr()).CStr()))); \
         } \
     } \
-    static void FunctionSetter(uint32_t Index, v8::Local<v8::Value> Value, const v8::PropertyCallbackInfo<void>& Info); \
-    static void _ ## FunctionSetter(uint32_t Index, v8::Local<v8::Value> Value, const v8::PropertyCallbackInfo<void>& Info) { \
+    static void FunctionSetter(uint32_t Index, v8::Local<v8::Value> Value, const v8::PropertyCallbackInfo<v8::Value>& Info); \
+    static void _ ## FunctionSetter(uint32_t Index, v8::Local<v8::Value> Value, const v8::PropertyCallbackInfo<v8::Value>& Info) { \
         v8::Isolate* Isolate = v8::Isolate::GetCurrent(); \
         v8::HandleScope HandleScope(Isolate); \
         try { \

--- a/src/nodejs/nodeutil.h
+++ b/src/nodejs/nodeutil.h
@@ -189,6 +189,9 @@ public:
 
 	static v8::Local<v8::Value> V8JsonToV8Str(const v8::Handle<v8::Value>& Json);
 	static TStr JSONStringify(const v8::Handle<v8::Value>& Json) { return GetStr(V8JsonToV8Str(Json)->ToString()); }
+
+    /// TStrV -> v8 string array
+    static v8::Local<v8::Value> GetStrArr(const TStrV& StrV);
 };
 
 template <class TWrap>


### PR DESCRIPTION
Summary of changes:
 - ported tokenizer from the old QM JS API to analytics addon;
 - added indexed property handlers to vector and sparse matrix objects from the LA addon;
 - fixed bug in `JsDeclareSetIndexedProperty(FunctionGetter, FunctionSetter)` macro in `nodeutil.h`. 
