### PR TITLE
cleaned g++ flags

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -45,10 +45,10 @@
             # operating system specific parameters
             ['OS == "linux"', {
                 'libraries': [ '-lrt', '-luuid', '-fopenmp', '<(LIN_ALG_LIB)' ],
-                 # GCC flags
+                # GCC flags
                 'cflags_cc!': [ '-fno-rtti', '-fno-exceptions' ],
                 'cflags_cc': [ '-std=c++0x', '-frtti', '-fexceptions' ],
-                'cflags': [ '-g', '-fexceptions', '-frtti', '-Wall', '-Wno-deprecated-declarations', '-fopenmp' ],
+                'cflags': [ '-Wno-deprecated-declarations', '-fopenmp' ]
             }],
             ['OS == "win"', {
                 'msbuild_toolset': 'v120',


### PR DESCRIPTION
 -Wall is set by default in common.gypi that comes with node. -frtti and -fexceptions was duplicated.  we do not need to specify -g: it is used by default for debug configuration and ommited for realese for smaller binary size (used for publish). this is set in common.gypi