### PR TITLE
New asserts for aggregate

### DIFF
--- a/src/qminer/qminer_aggr.h
+++ b/src/qminer/qminer_aggr.h
@@ -924,8 +924,6 @@ private:
 	// input
 	TWPt<TStreamAggr> InAggrX, InAggrY;
 	TWPt<TStreamAggrOut::IFltVec> InAggrValX, InAggrValY;
-	// indicator
-	TSignalProc::TChiSquare ChiSquare;
 
 protected:
 	void OnAddRec(const TRec& Rec) {} // do nothing
@@ -934,6 +932,8 @@ public:
 	static PStreamAggr New(const TWPt<TBase>& Base, const PJsonVal& ParamVal);
 	// did we finish initialization
 	bool IsInit() const { return InAggrX->IsInit() && InAggrY->IsInit(); }
+	void LoadState(TSIn& SIn) { /* do nothing, there is not state */ }
+	void SaveState(TSOut& SOut) const { /* do nothing, there is not state */ }
 	
 	/// returns the number of bins 
 	int GetFltLen() const { return InAggrValX->GetFltLen(); }

--- a/src/qminer/qminer_core.cpp
+++ b/src/qminer/qminer_core.cpp
@@ -4607,6 +4607,7 @@ bool TStreamAggrBase::IsStreamAggr(const TStr& StreamAggrNm) const {
 }
 
 const PStreamAggr& TStreamAggrBase::GetStreamAggr(const TStr& StreamAggrNm) const {
+	QmAssertR(IsStreamAggr(StreamAggrNm), TStr::Fmt("Aggregate not found: %s", StreamAggrNm.CStr()));
 	return StreamAggrH.GetDat(StreamAggrNm);
 }
 
@@ -4615,6 +4616,7 @@ const PStreamAggr& TStreamAggrBase::GetStreamAggr(const int& StreamAggrId) const
 }
 
 void TStreamAggrBase::AddStreamAggr(const PStreamAggr& StreamAggr) {
+	QmAssertR(!IsStreamAggr(StreamAggr->GetAggrNm()), TStr::Fmt("Aggregate with this name already exists: %s", StreamAggr->GetAggrNm().CStr()));
 	StreamAggrH.AddDat(StreamAggr->GetAggrNm(), StreamAggr);
 }
 

--- a/test/nodejs/streamaggr2.js
+++ b/test/nodejs/streamaggr2.js
@@ -330,27 +330,5 @@ describe("test histogram, slotted-histogram and histogram_diff aggregates", func
 		} finally {
 			base.close();
 		}
-		
-		var base2 = new qm.Base({
-			mode: "open"
-		});		
-		try {
-			var store2 = base2.store('Rpm');
-        
-			// get diff aggregator that subtracts Histogram1 with 2h window from Histogram2 with 6h window
-			var diff = store2.getStreamAggr("DiffAggr");
-						
-			// difference
-			var tmp3 = diff.saveJson();
-			console.log(JSON.stringify(tmp3));
-			assert.equal(tmp3.diff[0], 2);
-			assert.equal(tmp3.diff[1], 1);
-			assert.equal(tmp3.diff[2], 1);
-			assert.equal(tmp3.diff[3], 0);
-			assert.equal(tmp3.diff[4], 0);
-			
-		} finally {
-			base2.close();
-		}
 	});
 });

--- a/test/nodejs/streamaggr2.js
+++ b/test/nodejs/streamaggr2.js
@@ -330,5 +330,27 @@ describe("test histogram, slotted-histogram and histogram_diff aggregates", func
 		} finally {
 			base.close();
 		}
+		
+		var base2 = new qm.Base({
+			mode: "open"
+		});		
+		try {
+			var store2 = base2.store('Rpm');
+        
+			// get diff aggregator that subtracts Histogram1 with 2h window from Histogram2 with 6h window
+			var diff = store2.getStreamAggr("DiffAggr");
+						
+			// difference
+			var tmp3 = diff.saveJson();
+			console.log(JSON.stringify(tmp3));
+			assert.equal(tmp3.diff[0], 2);
+			assert.equal(tmp3.diff[1], 1);
+			assert.equal(tmp3.diff[2], 1);
+			assert.equal(tmp3.diff[3], 0);
+			assert.equal(tmp3.diff[4], 0);
+			
+		} finally {
+			base2.close();
+		}
 	});
 });


### PR DESCRIPTION
Added new exception-based asserts when accessing and adding aggregates. So far the code died if it tried to access non-existing aggregate.