### PR TITLE
Allow an object that's an instance of a ClassTPE*()-defined class to be managed by both parent and child class shared pointers

### DIFF
--- a/src/glib/Makefile
+++ b/src/glib/Makefile
@@ -18,7 +18,7 @@ BASE = ./base/
 MINE = ./mine/
 MISC = ./misc/
 # main object files
-MAINOBJS = base.o net.o mine.o thread.o
+MAINOBJS = base.o net.o mine.o thread.o sole.o
 
 #entry point
 all: libuv glib
@@ -52,6 +52,9 @@ mine.o: ./mine/*.h ./mine/*.cpp
 
 thread.o: ./concurrent/*.h ./concurrent/*.cpp ./concurrent/posix/*.h ./concurrent/posix/*.cpp
 	$(CC) -c $(CXXFLAGS) ./concurrent/thread.cpp -I$(BASE) $(LIBS)
+
+sole.o: $(SOLE_DIR)/sole.cpp $(SOLE_DIR)/sole.hpp
+	$(CC) -c $(CXXFLAGS) $(SOLE_DIR)/sole.cpp -I$(SOLE_DIR)
 
 clean:
 	rm -f *.o *.gch *.a

--- a/src/glib/Makefile.config
+++ b/src/glib/Makefile.config
@@ -13,17 +13,18 @@
 UNAME := $(shell uname)
 GLIB_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 LIBUV_DIR := $(GLIB_DIR)../third_party/libuv/
+SOLE_DIR := $(GLIB_DIR)../third_party/sole/
 
 ifeq ($(UNAME), Linux)
   # Linux flags
   CC = g++
   #CC = clang
-  CXXFLAGS += -std=c++1y -Wall -fopenmp -I$(GLIB_DIR)base -I$(GLIB_DIR)mine -I$(GLIB_DIR)net -I$(LIBUV_DIR)src
+  CXXFLAGS += -std=c++1y -Wall -fopenmp -I$(GLIB_DIR)base -I$(GLIB_DIR)mine -I$(GLIB_DIR)net -I$(LIBUV_DIR)src -I$(SOLE_DIR)
   CXXFLAGS += -O3
   # turn on for crash debugging, get symbols with <prog> 2>&1 | c++filt
   CXXFLAGS += -g -rdynamic -DMEMORYCHECK
   LDFLAGS += -fopenmp
-  LIBS += -lrt -luuid
+  LIBS += -lrt
 
 else ifeq ($(UNAME), Darwin)
   # OS X flags

--- a/src/glib/base/bd.h
+++ b/src/glib/base/bd.h
@@ -139,7 +139,7 @@ class TNm{
 class TNm; \
 typedef TPt<TNm> PNm; \
 class TNm{ \
-private: \
+protected: \
   TCRef CRef; \
 public: \
   friend class TPt<TNm>;
@@ -152,8 +152,6 @@ typedef TPt<TNm> PNm;
 class TNm; \
 typedef TPt<TNm> PNm; \
 class TNm: public ENm{ \
-private: \
-  TCRef CRef; \
 public: \
   friend class TPt<TNm>;
 
@@ -161,8 +159,6 @@ public: \
 class TNm; \
 typedef TPt<TNm> PNm; \
 class TNm: public ENm1, public ENm2{ \
-private: \
-  TCRef CRef; \
 public: \
   friend class TPt<TNm>;
 
@@ -176,7 +172,7 @@ class TNm; \
 typedef TPt<TNm> PNm; \
 typedef TVec<PNm> TNmV; \
 class TNm{ \
-private: \
+protected: \
   TCRef CRef; \
 public: \
   friend class TPt<TNm>;
@@ -193,7 +189,7 @@ typedef TVec<PNm> TNmV; \
 typedef TLst<PNm> TNmL; \
 typedef TLstNd<PNm>* TNmLN; \
 class TNm{ \
-private: \
+protected: \
   TCRef CRef; \
 public: \
   friend class TPt<TNm>;

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -27,7 +27,8 @@ MAIN = run-all-tests
 TEST_SRCS = \
 	test-TStr.cpp \
 	test-THash.cpp \
-	test-zipfl.cpp
+	test-zipfl.cpp \
+	test-tpt.cpp
 
 TEST_OBJS = $(TEST_SRCS:.cpp=.o)
 

--- a/test/cpp/Makefile.debian
+++ b/test/cpp/Makefile.debian
@@ -33,7 +33,8 @@ MAIN = run-all-tests
 TEST_SRCS = \
 	test-TStr.cpp \
 	test-THash.cpp \
-	test-zipfl.cpp
+	test-zipfl.cpp \
+	test-tpt.cpp
 
 TEST_OBJS = $(TEST_SRCS:.cpp=.o) $(GTEST_SRCS:.cc=.o)
 

--- a/test/cpp/test-tpt.cpp
+++ b/test/cpp/test-tpt.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+
+#include <base.h>
+
+// Test parent class
+
+ClassTP(TTestParent, PTestParent)//{
+private:
+    UndefCopyAssign(TTestParent);
+protected:
+    TTestParent() {}
+public:
+    virtual ~TTestParent() {}
+    static PTestParent New() { return new TTestParent(); }
+};
+
+TEST(TPt, Parent) {
+    PTestParent Parent = TTestParent::New();
+}
+
+// Test child class
+
+ClassTPE(TTestChild, PTestChild, TTestParent)//{
+private:
+    UndefCopyAssign(TTestChild);
+    TTestChild() {}
+public:
+    static PTestChild New() { return new TTestChild(); }
+    static PTestParent NewAsParent() { return new TTestChild(); }
+};
+
+TEST(TPt, Child) {
+    PTestChild Child = TTestChild::New();
+    PTestParent ChildAsParent = TTestChild::NewAsParent();
+}
+
+TEST(TPt, ParentFromChild) {
+    PTestChild Child = TTestChild::New();
+    PTestParent ParentFromChild = Child();
+}
+
+// Test multiple-inheritance child class
+
+ClassT(TTestParentOther)//{
+private:
+    UndefCopyAssign(TTestParentOther);
+protected:
+    TTestParentOther() {}
+public:
+    virtual ~TTestParentOther() {}
+};
+
+ClassTPEE(TTestChildMulti, PTestChildMulti, TTestParent, TTestParentOther)//{
+private:
+    UndefCopyAssign(TTestChildMulti);
+    TTestChildMulti() {}
+public:
+    static PTestChildMulti New() { return new TTestChildMulti(); }
+    static PTestParent NewAsParent() { return new TTestChildMulti(); }
+};
+
+TEST(TPt, ChildMulti) {
+    PTestChildMulti Child = TTestChildMulti::New();
+    PTestParent ChildAsParent = TTestChildMulti::NewAsParent();
+}
+
+TEST(TPt, ParentFromChildMulti) {
+    PTestChildMulti Child = TTestChildMulti::New();
+    PTestParent ParentFromChild = Child();
+}

--- a/test/cpp/tests.vcxproj
+++ b/test/cpp/tests.vcxproj
@@ -106,6 +106,7 @@
     <ClCompile Include="test-THash.cpp" />
     <ClCompile Include="test-TStr.cpp" />
     <ClCompile Include="test-zipfl.cpp" />
+    <ClCompile Include="test-tpt.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
# Use case:

* A class `Child` is declared with one of the `ClassTPE*()` macros and inherits from a `Parent` class.
* Instances of `Child` are created exclusively within `TPt<Child>` (aka `PChild`) shared pointers using `Child::New()` (as is common in GLib-style code).

We now want to create some generic function that accepts instances of any `TPt<Parent>` (aka `PParent`) object even if it's really an instance of a derived class.

# Problem:

Currently, classes declared with the `ClassTP*()` macros must always be shared with `TPt` pointers that share the same type.  Eg: if there is a Child class that inherits from a Parent class, any individual Child instance must always be owned/managed by a set of shared pointers of type `TPt<Child>` (aka `PChild`) *or* `TPt<Parent>` (aka `PParent), but not a combination of the two.

If one instance of a `Child` object is managed by both `TPt<Child>` and `TPt<Parent>` shared pointers simultaneously, the former will update the `Child.CRef` reference count and the latter will update `Parent.CRef`.  When either of those drops to zero, the object will be erroneously deleted early, and, if in debug mode, an assert will fire, otherwise there will be a use-after-free problem.

# Solution:

This patch keeps a `CRef` member only in the parent-most class.