### PR TITLE
Location of field-join fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ binding-1.gyp
 /examples/streamaggregate/node_modules
 *.opendb
 /test/nodejs/store_and_index.js
+/test/nodejs/jointest.dbg.js

--- a/src/qminer/qminer_core.cpp
+++ b/src/qminer/qminer_core.cpp
@@ -1097,6 +1097,42 @@ uint64 TStore::GetRecId(const PJsonVal& RecVal) const {
 	return TUInt64::Mx;
 }
 
+/// Returns record-id of given field join
+uint64 TStore::GetFieldJoinRecId(const uint64& RecId, const int& JoinId) {
+    QmAssertR(IsJoinId(JoinId), "Invalid JoinId");
+    const TJoinDesc& JoinDesc = GetJoinDesc(JoinId);
+    return GetFieldJoinRecId(RecId, JoinDesc);
+}
+/// Returns record-id of given field join
+uint64 TStore::GetFieldJoinRecId(const uint64& RecId, const TJoinDesc& JoinDesc) {
+    QmAssertR(JoinDesc.IsFieldJoin(), "Join is not field-join");
+    // get join weight
+    const int JoinRecFieldId = JoinDesc.GetJoinRecFieldId();
+    const TRec Rec = GetRec(RecId);
+    if (Rec.IsFieldNull(JoinRecFieldId)) {
+        return TUInt64::Mx;
+    }
+    return Rec.GetFieldUInt64Safe(JoinRecFieldId);
+}
+/// Returns frequency of given field join
+int TStore::GetFieldJoinFq(const uint64& RecId, const int& JoinId) {
+    QmAssertR(IsJoinId(JoinId), "Invalid JoinId");
+    const TJoinDesc& JoinDesc = GetJoinDesc(JoinId);
+    return GetFieldJoinFq(RecId, JoinDesc);
+}
+/// Returns frequency of given field join
+int TStore::GetFieldJoinFq(const uint64& RecId, const TJoinDesc& JoinDesc) {
+    QmAssertR(JoinDesc.IsFieldJoin(), "Join is not field-join");
+    // get join weight
+    const int JoinFqFieldId = JoinDesc.GetJoinFqFieldId();
+    int JoinRecFq = 1;
+    if (JoinFqFieldId > 0) {
+        const TRec Rec = GetRec(RecId);
+        JoinRecFq = Rec.GetFieldIntSafe(JoinFqFieldId);
+    }
+    return JoinRecFq;
+}
+
 void TStore::PrintRecSet(const TWPt<TBase>& Base, const PRecSet& RecSet, TSOut& SOut) const {
 	// print records
 	SOut.PutStrFmtLn("Records: %d", RecSet->GetRecs());

--- a/src/qminer/qminer_core.h
+++ b/src/qminer/qminer_core.h
@@ -825,6 +825,19 @@ public:
 	virtual PJsonVal GetStoreJson(const TWPt<TBase>& Base) const;
 	/// Parse out record id from record JSon serialization
 	uint64 GetRecId(const PJsonVal& RecVal) const;
+
+    /// Returns record-id of given field join
+    uint64 GetFieldJoinRecId(const uint64& RecId, const int& JoinId);
+    /// Returns record-id of given field join
+    uint64 GetFieldJoinRecId(const uint64& RecId, const TStr& JoinNm) { return GetFieldJoinRecId(RecId, GetJoinId(JoinNm)); }
+    /// Returns record-id of given field join
+    uint64 GetFieldJoinRecId(const uint64& RecId, const TJoinDesc& JoinDesc);
+    /// Returns frequency of given field join
+    int GetFieldJoinFq(const uint64& RecId, const int& JoinId);
+    /// Returns frequency of given field join
+    int GetFieldJoinFq(const uint64& RecId, const TStr& JoinNm) { return GetFieldJoinFq(RecId, GetJoinId(JoinNm)); }
+    /// Returns frequency of given field join
+    int GetFieldJoinFq(const uint64& RecId, const TJoinDesc& JoinDesc);
 	
 	/// Prints record set with all the field values, useful for debugging
 	void PrintRecSet(const TWPt<TBase>& Base, const PRecSet& RecSet, TSOut& SOut) const;

--- a/src/qminer/qminer_storage.h
+++ b/src/qminer/qminer_storage.h
@@ -104,8 +104,10 @@ public:
     /// Type of field that contains join frequency (for field join).
     /// Value "oftUndef" means no field.
     TFieldType FreqFieldType;
+    /// Field-join only - Where will the fields be stored
+    TStoreLoc FieldStoreLoc;
 public:
-    TJoinDescEx() : JoinType(osjtUndef) {}
+    TJoinDescEx() : JoinType(osjtUndef), FieldStoreLoc(slMemory){}
 };
 
 ///////////////////////////////

--- a/test/nodejs/jointest.js
+++ b/test/nodejs/jointest.js
@@ -68,14 +68,14 @@ describe('Index-Join Test', function () {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // utility functions
 
-function CreateBase(type, type2) {
+function CreateBase(type, type2, sloc) {
     var base = new qm.Base({
         mode: 'createClean',
         schema: [
             {
                 name: 'People',
                 fields: [{ name: 'name', type: 'string', primary: true }],
-                joins: [{ name: 'parent', type: 'field', store: 'People', storage: type + "-" + type2 }]
+                joins: [{ name: 'parent', type: 'field', store: 'People', storage: type + "-" + type2, storage_location: sloc || "memory" }]
             }
         ]
     });    
@@ -122,15 +122,18 @@ describe('Different join-field-type tests', function () {
         var rec_id_types = ["uint64", "uint", "uint16", "byte"];
         var freq_types = ["uint16", "byte", "int", "int16", ""];
 
-        for (var i = 0 ; i < rec_id_types.length; i++) {
-            for (var j = 0 ; j < freq_types.length; j++) {
-                var rec_id_type = rec_id_types[i];
-                var freq_type = freq_types[j]; 
-                
-                console.log(rec_id_type, "-", freq_type);
-                var base = CreateBase(rec_id_type, freq_type);
-                FillAndCheck(base, rec_id_type, freq_type);
-            }    
+        for (var k = 0; k < 2; k++) {
+            var sloc = (k == 0 ? "memory" : "cache");
+            for (var i = 0 ; i < rec_id_types.length; i++) {
+                for (var j = 0 ; j < freq_types.length; j++) {
+                    var rec_id_type = rec_id_types[i];
+                    var freq_type = freq_types[j]; 
+                    
+                    console.log(rec_id_type, "-", freq_type, " ", sloc);
+                    var base = CreateBase(rec_id_type, freq_type, sloc);
+                    FillAndCheck(base, rec_id_type, freq_type);
+                }    
+            }            
         }
     })
 });


### PR DESCRIPTION
Added support for changing location of field-join fields (rec-id and frequency). So far they were always in memory, now they can be stored in cache using `storage_location` property of join. Possible values are `memory` and `cache` - the same as flag `store` for ordinary fields.

Also exposed some field-join related methods from `TRec` to `TStore`.