### PR TITLE
Move constructors

### DIFF
--- a/src/glib/base/ds.h
+++ b/src/glib/base/ds.h
@@ -373,6 +373,7 @@ public:
 public:
   TKeyDat(): Key(), Dat(){}
   TKeyDat(const TKeyDat& KeyDat): Key(KeyDat.Key), Dat(KeyDat.Dat){}
+  TKeyDat(TKeyDat&& KeyDat): Key(std::move(KeyDat.Key)), Dat(std::move(KeyDat.Dat)){}
   explicit TKeyDat(const TKey& _Key): Key(_Key), Dat(){}
   TKeyDat(const TKey& _Key, const TDat& _Dat): Key(_Key), Dat(_Dat){}
   explicit TKeyDat(TSIn& SIn): Key(SIn), Dat(SIn){}
@@ -381,7 +382,9 @@ public:
   void SaveXml(TSOut& SOut, const TStr& Nm) const;
 
   TKeyDat& operator=(const TKeyDat& KeyDat){
-  if (this!=&KeyDat){Key=KeyDat.Key; Dat=KeyDat.Dat;} return *this;}
+    if (this!=&KeyDat){Key=KeyDat.Key; Dat=KeyDat.Dat;} return *this;}
+  TKeyDat& operator=(TKeyDat&& KeyDat){
+    if (this!=&KeyDat){Key=std::move(KeyDat.Key); Dat=std::move(KeyDat.Dat);} return *this;}
   bool operator==(const TKeyDat& KeyDat) const {return Key==KeyDat.Key;}
   bool operator<(const TKeyDat& KeyDat) const {return Key<KeyDat.Key;}
 

--- a/src/glib/base/hash.h
+++ b/src/glib/base/hash.h
@@ -39,6 +39,12 @@ public:
       Next=HashKeyDat.Next; HashCd=HashKeyDat.HashCd;
       Key=HashKeyDat.Key; Dat=HashKeyDat.Dat;}
     return *this;}
+  THashKeyDat& operator=(THashKeyDat&& HashKeyDat){
+    if (this!=&HashKeyDat){
+      Next=HashKeyDat.Next; HashCd=HashKeyDat.HashCd;
+      Key=std::move(HashKeyDat.Key); Dat=std::move(HashKeyDat.Dat);}
+    return *this;}
+
   uint64 GetMemUsed() const {
 	  return uint64(2 * sizeof(TInt)) + Key.GetMemUsed() + Dat.GetMemUsed();
   }

--- a/src/nodejs/analytics/analytics.cpp
+++ b/src/nodejs/analytics/analytics.cpp
@@ -2942,7 +2942,7 @@ PJsonVal TNodeJsMDS::GetParams() const {
 	case vdtSqrtCos:
 		ParamVal->AddToObj("distType", "SqrtCos"); break;
 	default:
-		throw TExcept::New("MDS.GetParams: unsupported distance type " + (int)DistType);
+		throw TExcept::New("MDS.GetParams: unsupported distance type " + TInt::GetStr((int)DistType));
 	}
 	return ParamVal;
 }

--- a/src/qminer/qminer_aggr.cpp
+++ b/src/qminer/qminer_aggr.cpp
@@ -463,7 +463,6 @@ PJsonVal TTimeLine::SaveJson() const {
 // QMiner-Aggregator-TimeSpan
 
 PJsonVal TTimeSpan::GetJsonList(const TUInt64H& DataH) const {
-    const double FltCount = (Count > 0) ? double(Count) : 1.0;
     PJsonVal JsonVal = TJsonVal::NewArr();
     int KeyId = DataH.FFirstKeyId();
     while (DataH.FNextKeyId(KeyId)) {


### PR DESCRIPTION
New feature:
- Added move constructor and assignment operator to `TKeyDat`
- Added move assignment operator to `THashKeyDat`

Bug fixes:
- Removed clang compile warnings for MDS and TTimeSpan.