### PR TITLE
Added submat and clear functions to SparseMatrix

### DIFF
--- a/src/nodejs/la/la_structures_nodejs.cpp
+++ b/src/nodejs/la/la_structures_nodejs.cpp
@@ -1158,6 +1158,8 @@ void TNodeJsSpMat::Init(v8::Handle<v8::Object> exports) {
     NODE_SET_PROTOTYPE_METHOD(tpl, "plus", _plus);
     NODE_SET_PROTOTYPE_METHOD(tpl, "minus", _minus);
     NODE_SET_PROTOTYPE_METHOD(tpl, "transpose", _transpose);
+    NODE_SET_PROTOTYPE_METHOD(tpl, "submat", _submat);
+    NODE_SET_PROTOTYPE_METHOD(tpl, "clear", _clear);
     NODE_SET_PROTOTYPE_METHOD(tpl, "colNorms", _colNorms);
     NODE_SET_PROTOTYPE_METHOD(tpl, "normalizeCols", _normalizeCols);
     NODE_SET_PROTOTYPE_METHOD(tpl, "full", _full);
@@ -1653,6 +1655,43 @@ void TNodeJsSpMat::transpose(const v8::FunctionCallbackInfo<v8::Value>& Args) {
     TLinAlg::Transpose(JsSpMat->Mat, Result);
 
 	Args.GetReturnValue().Set(TNodeJsUtil::NewInstance<TNodeJsSpMat>(new TNodeJsSpMat(Result)));
+}
+
+void TNodeJsSpMat::submat(const v8::FunctionCallbackInfo<v8::Value>& Args) {
+    v8::Isolate* Isolate = v8::Isolate::GetCurrent();
+    v8::HandleScope HandleScope(Isolate);
+
+    TNodeJsSpMat* JsSpMat = ObjectWrap::Unwrap<TNodeJsSpMat>(Args.Holder());
+    const TVec<TIntFltKdV>& Mat = JsSpMat->Mat;
+
+    // get int vector with col ids
+    EAssertR(Args.Length() == 1, "SparseMatrix.submat expects one parameter");
+    TNodeJsVec<TInt, TAuxIntV>* ColIdJsVec = TNodeJsUtil::GetArgUnwrapObj<TNodeJsVec<TInt, TAuxIntV> >(Args, 0);
+    const TIntV& ColIdV = ColIdJsVec->Vec;
+
+    // create new matrix
+    TNodeJsSpMat* JsSubMat = new TNodeJsSpMat;
+    TVec<TIntFltKdV>& SubMat = JsSubMat->Mat;
+
+    // load selected columns
+    SubMat.Gen(ColIdV.Len(), 0);
+    for (const int ColId : ColIdV) {
+        EAssertR(0 <= ColId && ColId < Mat.Len(), "SparseMatrix.submat column id out of range");
+        SubMat.Add(Mat[ColId]);
+    }
+
+	Args.GetReturnValue().Set(TNodeJsUtil::NewInstance<TNodeJsSpMat>(JsSubMat));
+}
+
+void TNodeJsSpMat::clear(const v8::FunctionCallbackInfo<v8::Value>& Args) {
+    v8::Isolate* Isolate = v8::Isolate::GetCurrent();
+    v8::HandleScope HandleScope(Isolate);
+
+    TNodeJsSpMat* JsSpMat = ObjectWrap::Unwrap<TNodeJsSpMat>(Args.Holder());
+    JsSpMat->Mat.Clr();
+    JsSpMat->Rows = -1;
+
+	Args.GetReturnValue().Set(Args.Holder());
 }
 
 void TNodeJsSpMat::colNorms(const v8::FunctionCallbackInfo<v8::Value>& Args) {

--- a/src/nodejs/la/la_structures_nodejs.h
+++ b/src/nodejs/la/la_structures_nodejs.h
@@ -959,6 +959,21 @@ public:
 	//# exports.SparseMatrix.prototype.transpose = function () { return Object.create(require('qminer').la.SparseMatrix.prototype); }
 	JsDeclareFunction(transpose);
 
+    /**
+    * Returns a submatrix containing only selected columns.
+    * Columns are identified by a vector of ids.
+	* @param {module:la.IntVector} columnIdVec - Integer vector containing selected column ids.
+    * @returns {module:la.SparseMatrix}
+    */
+	//# exports.SparseMatrix.prototype.submat = function (columnIdVec) { return Object.create(require('qminer').la.SparseMatrix.prototype); }
+    JsDeclareFunction(submat);
+
+    /**
+    * Clear content of the matrix and sets its row dimension to -1.
+    */
+    //# exports.SparseMatrix.prototype.clear = function () { }
+    JsDeclareFunction(clear);
+
 	/**
 	* Returns the vector of column norms of sparse matrix.
 	* @returns {module:la.Vector} Vector of column norms. Ihe i-th value of the return vector is the norm of i-th column of sparse matrix.

--- a/src/qminer/qminer_aggr.h
+++ b/src/qminer/qminer_aggr.h
@@ -189,7 +189,6 @@ private:
     TStr FieldNm;
     TStr JoinPathStr;
     // aggregations
-    TInt Count;
     TUInt64 SlotLen;
     TUInt64H CountsH;
 

--- a/test/nodejs/linearalgebra.js
+++ b/test/nodejs/linearalgebra.js
@@ -4267,6 +4267,48 @@ describe('Rectangle Sparse Matrix Tests', function () {
             })
         })
 
+        describe('Submatrix Test', function () {
+            var mat = new RSparseMatrix();
+            it('should get a submatrix', function () {
+                var fullMat = new la.SparseMatrix([[[0, 1]], [[1, 2]], [[2, 3]], [[3, 4]]]);
+                var subMat = fullMat.submat(new la.IntVector([1, 2]));
+
+                assert.equal(subMat.cols, 2);
+                assert.equal(subMat.rows, -1);
+
+                assert.eqtol(subMat.at(1, 0), 2);
+                assert.eqtol(subMat.at(2, 1), 3);
+            })
+            it('should throw exception for column id out of range', function () {
+                var fullMat = new la.SparseMatrix([[[0, 1]], [[1, 2]], [[2, 3]], [[3, 4]]]);
+                assert.throws(function () {
+                    fullMat.submat(new la.IntVector([1, 2, 4]))
+                });
+            })
+        })
+
+        describe('Clear Test', function () {
+            var mat = new RSparseMatrix();
+            it('should get empty matrix', function () {
+                var fullMat1 = new la.SparseMatrix([[[0, 1]], [[1, 2]], [[2, 3]], [[3, 4]]]);
+                fullMat1.clear();
+                assert.equal(fullMat1.cols, 0);
+                assert.equal(fullMat1.rows, -1);
+
+                var fullMat2 = new la.SparseMatrix([[[0, 1]], [[1, 2]], [[2, 3]], [[3, 4]]]);
+                fullMat2.setRowDim(4);
+                fullMat2.clear();
+                assert.equal(fullMat2.cols, 0);
+                assert.equal(fullMat2.rows, -1);
+            })
+            it('should throw exception for column id out of range', function () {
+                var fullMat = new la.SparseMatrix([[[0, 1]], [[1, 2]], [[2, 3]], [[3, 4]]]);
+                assert.throws(function () {
+                    fullMat.submat(new la.IntVector([1, 2, 4]))
+                });
+            })
+        })
+
         describe('ColNorms Test', function () {
             var mat = new RSparseMatrix();
             it('should return a vector containing the norms of columns in spMat', function () {


### PR DESCRIPTION
Features:
- Added `submat` function to `SparseMatrix` that gets `IntVector` of column ids and returns sparse matrix constructed from selected columns.
- Added `clear` function to `SparseMatrix` that clears its content and sets rows to -1.

Bug fix:
- Removed unused member `Count` from `TTimeSpan`