### PR TITLE
Faster codebook string fields access

### DIFF
--- a/src/qminer/qminer_core.cpp
+++ b/src/qminer/qminer_core.cpp
@@ -237,7 +237,7 @@ TStr TJoinSeq::GetJoinPathStr(const TWPt<TBase>& Base, const TStr& SepStr) const
 ///////////////////////////////
 // QMiner-Field-Description
 TFieldDesc::TFieldDesc(const TWPt<TBase>& Base, const TStr& _FieldNm, TFieldType _FieldType,
-    const bool& PrimaryP, const bool& NullP, const bool& InternalP) :
+    const bool& PrimaryP, const bool& NullP, const bool& InternalP, const bool& CodebookP):
     FieldId(-1), FieldNm(_FieldNm), FieldType(_FieldType) {
 
     Base->AssertValidNm(FieldNm);
@@ -245,6 +245,7 @@ TFieldDesc::TFieldDesc(const TWPt<TBase>& Base, const TStr& _FieldNm, TFieldType
     if (PrimaryP) { Flags.Val |= ofdfPrimary; }
     if (NullP) { Flags.Val |= ofdfNull; }
     if (InternalP) { Flags.Val |= ofdfInternal; }
+    if (CodebookP) { Flags.Val |= ofdfCodebook; }
 }
 
 TFieldDesc::TFieldDesc(TSIn& SIn) {
@@ -3051,7 +3052,7 @@ void TRecSet::FilterByFieldBool(const int& FieldId, const bool& Val) {
 void TRecSet::FilterByFieldInt(const int& FieldId, const int& MinVal, const int& MaxVal) {
     // get store and field type
     const TFieldDesc& Desc = Store->GetFieldDesc(FieldId);
-    QmAssertR(Desc.IsInt(), "Wrong field type, integer expected");
+    QmAssertR(Desc.IsInt() || (Desc.IsStr() && Desc.IsCodebook()), "Wrong field type, integer or codebook string expected");
     // apply the filter
     FilterBy(TRecFilterByFieldInt(Store, FieldId, MinVal, MaxVal));
 }

--- a/src/qminer/qminer_core.h
+++ b/src/qminer/qminer_core.h
@@ -237,7 +237,8 @@ private:
     typedef enum {
         ofdfNull = (1 << 0),
         ofdfInternal = (1 << 1),
-        ofdfPrimary = (1 << 2)
+        ofdfPrimary = (1 << 2),
+        ofdfCodebook = (1 << 3)
     } TFieldDescFlags;
 
 private:
@@ -260,7 +261,7 @@ public:
     /// @param NullP Can field be empty for some records
     /// @param InternalP Filed was created is and being used internally by QMiner (E.g. for field joins)
     TFieldDesc(const TWPt<TBase>& Base, const TStr& _FieldNm, TFieldType _FieldType, const bool& Primary,
-        const bool& NullP, const bool& InternalP);
+        const bool& NullP, const bool& InternalP, const bool& CodebookP);
     
     TFieldDesc(TSIn& SIn);
     void Save(TSOut& SOut) const;
@@ -298,6 +299,7 @@ public:
     bool IsNullable() const { return ((Flags & ofdfNull) != 0); }
     bool IsInternal() const { return ((Flags & ofdfInternal) != 0); }
     bool IsPrimary() const { return ((Flags & ofdfPrimary) != 0); }
+    bool IsCodebook() const { return ((Flags & ofdfCodebook) != 0); }
 
     /// Link index key with ID `KeyId` to this field
     void AddKey(const int& KeyId) { KeyIdV.AddUnique(KeyId); }

--- a/src/qminer/qminer_storage.h
+++ b/src/qminer/qminer_storage.h
@@ -717,6 +717,9 @@ public:
     void SetFieldTMem(const TMemBase& InRecMem, TMem& OutRecMem, const int& FieldId, const TMem& Mem);
     /// Field setter
     void SetFieldJsonVal(const TMemBase& InRecMem, TMem& OutRecMem, const int& FieldId, const PJsonVal& Json);
+
+    /// Get codebook id
+    int GetCodebookId(const int& FieldId, const TStr& Str) const;
 };
 
 ///////////////////////////////
@@ -1069,6 +1072,9 @@ public:
 
     /// Helper function for returning JSon definition of store
     PJsonVal GetStoreJson(const TWPt<TBase>& Base) const;
+
+    /// Get codebook mappings for given string field
+    int GetCodebookId(const int& FieldId, const TStr& Str) const;
 
     /// Save part of the data, given time-window
     int PartialFlush(int WndInMsec = 500);


### PR DESCRIPTION
`TStoreImpl` can tell integer ID for codebook strings. `TFieldDesc` can tell if field is encoded using codebook.