### PR TITLE
important bug fix related to Json serialization

### DIFF
--- a/src/glib/base/json.cpp
+++ b/src/glib/base/json.cpp
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2015, Jozef Stefan Institute, Quintelligence d.o.o. and contributors
  * All rights reserved.
- * 
+ *
  * This source code is licensed under the FreeBSD license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -9,7 +9,7 @@
 /////////////////////////////////////////////////
 // Json-Value
 TJsonVal::TJsonVal(TSIn& SIn):
-  JsonValType((TJsonValType)(TInt(SIn).Val)), Bool(SIn), 
+  JsonValType((TJsonValType)(TInt(SIn).Val)), Bool(SIn),
   Num(SIn), Str(SIn), ValV(SIn), KeyValH(SIn) { }
 
 void TJsonVal::Save(TSOut& SOut) const {
@@ -19,8 +19,8 @@ void TJsonVal::Save(TSOut& SOut) const {
   KeyValH.Save(SOut);
 }
 
-TStr TJsonVal::SaveStr() { 
-  return GetStrFromVal(this); 
+TStr TJsonVal::SaveStr() {
+  return GetStrFromVal(this);
 }
 
 bool TJsonVal::operator==(const TJsonVal& JsonVal) const {
@@ -28,8 +28,8 @@ bool TJsonVal::operator==(const TJsonVal& JsonVal) const {
     Bool == JsonVal.Bool &&
     Num == JsonVal.Num &&
     Str == JsonVal.Str &&
-    ValV == JsonVal.ValV && 
-    KeyValH == JsonVal.KeyValH;    
+    ValV == JsonVal.ValV &&
+    KeyValH == JsonVal.KeyValH;
 }
 
 bool TJsonVal::operator!=(const TJsonVal& JsonVal) const {
@@ -185,42 +185,42 @@ void TJsonVal::GetArrStrV(TStrV& StrV) const {
 
 PJsonVal TJsonVal::GetObjKey(const TStr& Key) const {
   EAssert(IsObj());
-  EAssertR(IsObjKey(Key), "Unknown key '" + Key + "'"); 
+  EAssertR(IsObjKey(Key), "Unknown key '" + Key + "'");
   return KeyValH.GetDat(Key);
 }
 
 PJsonVal TJsonVal::GetObjKey(const char *Key) const {
   EAssert(IsObj());
-  EAssertR(IsObjKey(Key), TStr::Fmt("Unknown key '%s'", Key)); 
+  EAssertR(IsObjKey(Key), TStr::Fmt("Unknown key '%s'", Key));
   return KeyValH.GetDat(Key);
 }
 
-bool TJsonVal::GetObjBool(const TStr& Key, const bool& DefBool) const { 
+bool TJsonVal::GetObjBool(const TStr& Key, const bool& DefBool) const {
   EAssert(IsObj());
   return (IsObjKey(Key)) ? KeyValH.GetDat(Key)->GetBool() : DefBool;
 }
 
-bool TJsonVal::GetObjBool(const char *Key, const bool& DefBool) const { 
+bool TJsonVal::GetObjBool(const char *Key, const bool& DefBool) const {
   EAssert(IsObj());
   return (IsObjKey(Key)) ? KeyValH.GetDat(Key)->GetBool() : DefBool;
 }
 
-double TJsonVal::GetObjNum(const TStr& Key, const double& DefNum) const { 
-  EAssert(IsObj());
-  return (IsObjKey(Key)) ? KeyValH.GetDat(Key)->GetNum() : DefNum;
-} 
-
-double TJsonVal::GetObjNum(const char *Key, const double& DefNum) const { 
+double TJsonVal::GetObjNum(const TStr& Key, const double& DefNum) const {
   EAssert(IsObj());
   return (IsObjKey(Key)) ? KeyValH.GetDat(Key)->GetNum() : DefNum;
 }
 
-int TJsonVal::GetObjInt(const TStr& Key, const int& DefInt) const { 
+double TJsonVal::GetObjNum(const char *Key, const double& DefNum) const {
+  EAssert(IsObj());
+  return (IsObjKey(Key)) ? KeyValH.GetDat(Key)->GetNum() : DefNum;
+}
+
+int TJsonVal::GetObjInt(const TStr& Key, const int& DefInt) const {
   EAssert(IsObj());
   return (IsObjKey(Key)) ? KeyValH.GetDat(Key)->GetInt() : DefInt;
-} 
+}
 
-int TJsonVal::GetObjInt(const char *Key, const int& DefInt) const { 
+int TJsonVal::GetObjInt(const char *Key, const int& DefInt) const {
   EAssert(IsObj());
   return (IsObjKey(Key)) ? KeyValH.GetDat(Key)->GetInt() : DefInt;
 }
@@ -268,7 +268,7 @@ const TStr& TJsonVal::GetObjStr(const TStr& Key, const TStr& DefStr) const {
   return (IsObjKey(Key)) ? KeyValH.GetDat(Key)->GetStr() : DefStr;
 }
 
-const TStr& TJsonVal::GetObjStr(const char *Key, const TStr& DefStr) const { 
+const TStr& TJsonVal::GetObjStr(const char *Key, const TStr& DefStr) const {
   EAssert(IsObj());
   return (IsObjKey(Key)) ? KeyValH.GetDat(Key)->GetStr() : DefStr;
 }
@@ -321,8 +321,8 @@ PJsonVal TJsonVal::GetValFromLx(TILx& Lx){
       forever{
         PJsonVal SubVal=TJsonVal::GetValFromLx(Lx);
         Val->AddToArr(SubVal);
-        if (Lx.Sym==syComma){Lx.GetSym(ValExpect);} 
-        else if (Lx.Sym==syRBracket){break;} 
+        if (Lx.Sym==syComma){Lx.GetSym(ValExpect);}
+        else if (Lx.Sym==syRBracket){break;}
         else {TExcept::Throw("JSON Array not properly formed.");}
       }
     }
@@ -331,13 +331,13 @@ PJsonVal TJsonVal::GetValFromLx(TILx& Lx){
     Val->PutObj(); Lx.GetSym(TFSet()|syRBrace|syQStr);
     if (Lx.Sym!=syRBrace){
       forever{
-        TStr SubKey=Lx.Str; 
-        Lx.GetSym(syColon); 
+        TStr SubKey=Lx.Str;
+        Lx.GetSym(syColon);
         Lx.GetSym(ValExpect);
         PJsonVal SubVal=TJsonVal::GetValFromLx(Lx);
         Val->AddToObj(SubKey, SubVal);
-        if (Lx.Sym==syComma){Lx.GetSym(TFSet()|syQStr);} 
-        else if (Lx.Sym==syRBrace){break;} 
+        if (Lx.Sym==syComma){Lx.GetSym(TFSet()|syQStr);}
+        else if (Lx.Sym==syRBrace){break;}
         else {TExcept::Throw("JSON Object not properly formed.");}
       }
     }
@@ -424,7 +424,7 @@ void TJsonVal::AddEscapeChAFromStr(const TStr& Str, TChA& ChA){
 					default : ChA.AddCh(Ch);
 				}
 			} else {
-                printf("Warning: no TUnicodeDef, possible errors when escaping unicode characters!");                        
+                printf("Warning: no TUnicodeDef, possible errors when escaping unicode characters!");
 				// escape
 				ChA += "\\u";
 				ChA += TStr::Fmt("%02x", (int)Ch);
@@ -440,8 +440,9 @@ void TJsonVal::AddQChAFromStr(const TStr& Str, TChA& ChA){
 }
 
 void TJsonVal::GetChAFromVal(const PJsonVal& Val, TChA& ChA){
+  bool First = true;
   switch (Val->GetJsonValType()){
-    case jvtNull: 
+    case jvtNull:
       ChA+="null"; break;
     case jvtBool:
       if (Val->GetBool()){ChA+="true";} else {ChA+="false";} break;
@@ -460,18 +461,19 @@ void TJsonVal::GetChAFromVal(const PJsonVal& Val, TChA& ChA){
         if (ArrValN>0){ChA+=", ";}
         GetChAFromVal(Val->GetArrVal(ArrValN), ChA);
       }
-      ChA+="]"; 
+      ChA+="]";
       break;
     case jvtObj:
       ChA+="{";
 	  for (int ObjKeyN = Val->KeyValH.FFirstKeyId(); Val->KeyValH.FNextKeyId(ObjKeyN);) {
-        if (ObjKeyN>0){ChA+=", ";}
+        if (!First){ChA+=", ";}
+		First = false;
         TStr ObjKey; PJsonVal ObjVal; Val->GetObjKeyVal(ObjKeyN, ObjKey, ObjVal);
         AddQChAFromStr(ObjKey, ChA);
         ChA+=":";
         GetChAFromVal(ObjVal, ChA);
       }
-      ChA+="}"; 
+      ChA+="}";
       break;
 	default: TExcept::Throw("Error serializing json to string");
   }
@@ -502,7 +504,7 @@ uint64 TJsonVal::GetMSecsFromJsonVal(const PJsonVal& Val) {
         }
     } else {
         throw TExcept::New("Invalid window size parameter");
-    }    
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////
@@ -514,7 +516,7 @@ int64 TBsonObj::GetMemUsedRecursive(const TJsonVal& JsonVal, bool UseVoc) {
 	else if (t == jvtNull) {  }
 	else if (t == jvtBool) { res += 1; }
 	else if (t == jvtNum) { res += 8; }
-	else if (t == jvtStr) { 
+	else if (t == jvtStr) {
 		res += (UseVoc ? 4 : 4 + JsonVal.GetStr().Len() + 1);
 	} else if (t == jvtArr) {
 		res += 4; // array length
@@ -540,12 +542,12 @@ void TBsonObj::CreateBsonRecursive(const TJsonVal& JsonVal, TStrHash<TInt, TBigS
 	else if (t == jvtNull) { SOut.Save((char)1); }
 	else if (t == jvtBool) { SOut.Save((char)2); SOut.Save(JsonVal.GetBool()); }
 	else if (t == jvtNum) { SOut.Save((char)3); SOut.Save(JsonVal.GetNum()); }
-	else if (t == jvtStr) { 
-		SOut.Save((char)4); 
+	else if (t == jvtStr) {
+		SOut.Save((char)4);
 		TStr s = JsonVal.GetStr();
 		if (Voc == NULL) {
 			s.Save(SOut, false);
-		} else {            
+		} else {
 			if (Voc->IsKey(s)) {
 				TInt id = Voc->GetKeyId(s);
 				id.Save(SOut);
@@ -556,8 +558,8 @@ void TBsonObj::CreateBsonRecursive(const TJsonVal& JsonVal, TStrHash<TInt, TBigS
 		}
 	} else if (t == jvtArr) {
 		int arr_len = JsonVal.GetArrVals();
-		SOut.Save((char)5); 
-		SOut.Save(arr_len); 
+		SOut.Save((char)5);
+		SOut.Save(arr_len);
 		for (int i=0; i<arr_len; i++) {
 			CreateBsonRecursive(*JsonVal.GetArrVal(i), Voc, SOut);
 		}
@@ -566,8 +568,8 @@ void TBsonObj::CreateBsonRecursive(const TJsonVal& JsonVal, TStrHash<TInt, TBigS
 		TStr curr_name;
 		PJsonVal curr_val_pt;
 
-		SOut.Save((char)6); 
-		SOut.Save(obj_len);  
+		SOut.Save((char)6);
+		SOut.Save(obj_len);
 		for (int i=0; i<obj_len; i++) {
 			JsonVal.GetObjKeyVal(i, curr_name, curr_val_pt);
 			if (Voc == NULL) {
@@ -588,40 +590,40 @@ void TBsonObj::CreateBsonRecursive(const TJsonVal& JsonVal, TStrHash<TInt, TBigS
 
 PJsonVal TBsonObj::GetJsonRecursive(TSIn& SIn, TStrHash<TInt, TBigStrPool>* Voc) {
 	PJsonVal res = TJsonVal::New();
-	char c = SIn.GetCh();    
+	char c = SIn.GetCh();
 
 	if (c == 0) {
 		// do nothing, undefined is default
 	} else if (c == 1) {
-		res->PutNull(); 
+		res->PutNull();
 	} else if (c == 2) {
-		TBool b; 
-		b.Load(SIn); 
-		res->PutBool(b); 
+		TBool b;
+		b.Load(SIn);
+		res->PutBool(b);
 	} else if (c == 3) {
-		TFlt f; 
-		f.Load(SIn); 
+		TFlt f;
+		f.Load(SIn);
 		res->PutNum(f);
 	} else if (c == 4) {
 		if (Voc == NULL){
-			TStr s; 
-			s.Load(SIn, false); 
+			TStr s;
+			s.Load(SIn, false);
 			res->PutStr(s);
 		} else {
 			TInt i;
-			i.Load(SIn); 
+			i.Load(SIn);
 			res->PutStr(Voc->GetKey(i));
 		}
 	} else if (c == 5) {
 		res->PutArr();
-		TInt ti; 
+		TInt ti;
 		ti.Load(SIn);
 		for (int i=0; i<ti; i++) {
 			res->AddToArr(GetJsonRecursive(SIn, Voc));
 		}
 	} else if (c == 6) {
 		res->PutObj();
-		TInt ti; 
+		TInt ti;
 		ti.Load(SIn);
 		if (Voc == NULL){
 			TStr s;


### PR DESCRIPTION
. Calling DelObjKey on key that is first in KeyValH makes following serialization invalid. ObjKeyN starts with 1 which makes invalid json object. Relevant change is in TJsonVal::GetChAFromVal()
