### PR TITLE
KMeans.fit for distanceType: "Cos" Fix and Unit tests 

### DIFF
--- a/src/glib/base/linalg.hpp
+++ b/src/glib/base/linalg.hpp
@@ -428,7 +428,7 @@ TSizeTy TLinAlgSearch::GetColMinIdx(const TVVec<TNum<TType>, TSizeTy, ColMajor>&
 			MinIdx = RowN;
 		}
 	}
-	EAssertR(MinIdx >= 0, "Mininum index not set!");
+	EAssertR(MinIdx >= 0, "Minimum index not set!");
 	return MinIdx;
 }
 
@@ -1528,7 +1528,7 @@ void TLinAlg::QRbasis(TVVec<TNum<TType>, TSizeTy, ColMajor>& A) {
 	TSizeTy m = A.GetRows(); TSizeTy n = A.GetCols(); TSizeTy k = A.GetCols();
 	TSizeTy lda = ColMajor ? m : n;
 	int Matrix_Layout = ColMajor ? LAPACK_COL_MAJOR : LAPACK_ROW_MAJOR;
-	TVec<TType, TSizeTy> tau; tau.Gen(MAX(1, MIN(m, n)));
+	TVec<TNum<TType>, TSizeTy> tau; tau.Gen(MAX(1, MIN(m, n)));
 	LAPACKE_dgeqrf(Matrix_Layout, m, n, &A(0, 0).Val, lda, &tau[0].Val);
 	LAPACKE_dorgqr(Matrix_Layout, m, n, k, &A(0, 0).Val, lda, &tau[0].Val);
 }
@@ -1547,7 +1547,7 @@ void TLinAlg::QRcolpbasis(TVVec<TNum<TType>, TSizeTy, ColMajor>& A) {
 	TSizeTy m = A.GetRows(); TSizeTy n = A.GetCols(); TSizeTy k = A.GetCols();
 	TSizeTy lda = ColMajor ? m : n;
 	TSizeTy Matrix_Layout = ColMajor ? LAPACK_COL_MAJOR : LAPACK_ROW_MAJOR;
-	TVec<TType, TSizeTy> tau(MAX(1, MIN(m, n)));
+	TVec<TNum<TType>, TSizeTy> tau(MAX(1, MIN(m, n)));
 	TVec<TInt, TSizeTy> jvpt(MAX(1, n));
 	LAPACKE_dgeqp3(Matrix_Layout, m, n, &A(0, 0).Val, lda, &jvpt[0].Val, &tau[0].Val);
 	LAPACKE_dorgqr(Matrix_Layout, m, n, k, &A(0, 0).Val, lda, &tau[0].Val);
@@ -1575,7 +1575,7 @@ void TLinAlg::ThinSVD(const TVVec<TNum<TType>, TSizeTy, ColMajor>& A,
 	int ldu = ColMajor ? m : thin_dim;
 	int ldvt = ColMajor ? thin_dim : n;
 
-	TVec<TType, TSizeTy> superb(MAX(1, MIN(m, n)));
+	TVec<TNum<TType>, TSizeTy> superb(MAX(1, MIN(m, n)));
 	int opt = ColMajor ? LAPACK_COL_MAJOR : LAPACK_ROW_MAJOR;
 
 	/*int lda, ldu, ldvt;

--- a/src/glib/mine/clustering.h
+++ b/src/glib/mine/clustering.h
@@ -217,19 +217,19 @@ public:
     void GetDist2VV(const TVec<TIntFltKdV>& X, const TVec<TIntFltKdV>& Y, TFltVV& D) const { GetDist2VV<TVec<TIntFltKdV>, TVec<TIntFltKdV>>(X, Y, D); }
 
     void GetDist2VV(const TFltVV& X, const TFltVV& Y, const TFltV& NormX2,
-        const TFltV& NormY2, TFltVV& D) const { GetDist2VV<TFltVV, TFltVV>(X, Y, D); }
+        const TFltV& NormY2, TFltVV& D) const { GetDist2VV<TFltVV, TFltVV>(X, Y, NormX2, NormY2, D); }
     void GetDist2VV(const TFltVV& X, const TVec<TIntFltKdV>& Y, const TFltV& NormX2,
-        const TFltV& NormY2, TFltVV& D) const {
-        GetDist2VV<TFltVV, TVec<TIntFltKdV>>(X, Y, D);
-    }
+        const TFltV& NormY2, TFltVV& D) const { GetDist2VV<TFltVV, TVec<TIntFltKdV>>(X, Y, NormX2, NormY2, D); }
     void GetDist2VV(const TVec<TIntFltKdV>& X, const TFltVV& Y, const TFltV& NormX2,
-        const TFltV& NormY2, TFltVV& D) const {
-        GetDist2VV<TVec<TIntFltKdV>, TFltVV>(X, Y, D);
-    }
+        const TFltV& NormY2, TFltVV& D) const { GetDist2VV<TVec<TIntFltKdV>, TFltVV>(X, Y, NormX2, NormY2, D); }
     void GetDist2VV(const TVec<TIntFltKdV>& X, const TVec<TIntFltKdV>& Y, const TFltV& NormX2,
-        const TFltV& NormY2, TFltVV& D) const {
-        GetDist2VV<TVec<TIntFltKdV>, TVec<TIntFltKdV>>(X, Y, D);
-    }
+        const TFltV& NormY2, TFltVV& D) const { GetDist2VV<TVec<TIntFltKdV>, TVec<TIntFltKdV>>(X, Y, NormX2, NormY2, D); }
+
+    void UpdateNormX2(const TFltVV& FtrVV, TFltV& NormX2) const { UpdateNormX2<TFltVV>(FtrVV, NormX2); }
+    void UpdateNormX2(const TVec<TIntFltKdV>& FtrVV, TFltV& NormX2) const { UpdateNormX2<TVec<TIntFltKdV>>(FtrVV, NormX2); }
+
+    void UpdateNormC2(const TFltVV& CentroidVV, TFltV& NormC2) const { UpdateNormC2<TFltVV>(CentroidVV, NormC2); }
+    void UpdateNormC2(const TVec<TIntFltKdV>& CentroidVV, TFltV& NormC2) const { UpdateNormC2<TVec<TIntFltKdV>>(CentroidVV, NormC2); }
 
     const TStr& GetType() const { return TYPE; }
 
@@ -255,6 +255,9 @@ private:
     // D_ij is the distance between x_i and y_j
     template <class TXMatType, class TYMatType>
     void GetDist2VV(const TXMatType& X, const TYMatType& Y, TFltVV& D) const;
+
+    template <class TXMatType, class TYMatType>
+    void GetDist2VV(const TXMatType& X, const TYMatType& Y, const TFltV& NormX2, const TFltV& NormY2, TFltVV& D) const;
 };
 
 
@@ -310,6 +313,12 @@ void TCosDist::UpdateNormC2(const TMatType& CentroidVV, TFltV& NormC2) const {
 template <class TXMatType, class TYMatType>
 void TCosDist::GetDist2VV(const TXMatType& X, const TYMatType& Y, TFltVV& D) const {
     GetDistVV(X, Y, D);
+    TLinAlgTransform::Sqr(D);
+}
+
+template <class TXMatType, class TYMatType>
+void TCosDist::GetDist2VV(const TXMatType& X, const TYMatType& Y, const TFltV& NormX2, const TFltV& NormY2, TFltVV& D) const {
+    TCosDist::GetDistVV(X, Y, NormX2, NormY2, D);
     TLinAlgTransform::Sqr(D);
 }
 
@@ -970,10 +979,11 @@ void TDnsKMeans<TCentroidType>::Apply(const TDataType& FtrVV, const int& NInst, 
 
         // get the distance of each of the points to each of the centroids
         // and assign the instances
-        TAbsKMeans<TCentroidType>::Dist->UpdateNormC2(TAbsKMeans<TCentroidType>::CentroidVV, NormC2);
+        TAbsKMeans<TCentroidType>::Dist->UpdateNormC2(CentroidVV, NormC2);
         TAbsKMeans<TCentroidType>::Dist->GetDist2VV(TAbsKMeans<TCentroidType>::CentroidVV, FtrVV, NormC2, NormX2, ClustDistVV);
-        TLinAlgSearch::GetColMinIdxV(ClustDistVV, *AssignIdxVPtr);
 
+        TLinAlgSearch::GetColMinIdxV(ClustDistVV, *AssignIdxVPtr);
+        
         // if the assignment hasn't changed then terminate the loop
         if (*AssignIdxVPtr == *OldAssignIdxVPtr) {
             Notify->OnNotifyFmt(TNotifyType::ntInfo, "Converged at iteration: %d", IterN);

--- a/src/glib/mine/clustering.h
+++ b/src/glib/mine/clustering.h
@@ -979,7 +979,7 @@ void TDnsKMeans<TCentroidType>::Apply(const TDataType& FtrVV, const int& NInst, 
 
         // get the distance of each of the points to each of the centroids
         // and assign the instances
-        TAbsKMeans<TCentroidType>::Dist->UpdateNormC2(CentroidVV, NormC2);
+        TAbsKMeans<TCentroidType>::Dist->UpdateNormC2(TAbsKMeans<TCentroidType>::CentroidVV, NormC2);
         TAbsKMeans<TCentroidType>::Dist->GetDist2VV(TAbsKMeans<TCentroidType>::CentroidVV, FtrVV, NormC2, NormX2, ClustDistVV);
 
         TLinAlgSearch::GetColMinIdxV(ClustDistVV, *AssignIdxVPtr);

--- a/src/nodejs/analytics/analytics.cpp
+++ b/src/nodejs/analytics/analytics.cpp
@@ -2291,16 +2291,17 @@ void TNodeJsKMeans::UpdateParams(const PJsonVal& ParamVal) {
             throw TExcept::New("Update KMeans Exception: centroidType must be Dense or Sparse!");
         }
     }
+    if (ParamVal->IsObjKey("verbose")) { Verbose = ParamVal->GetObjBool("verbose"); }
 
     if (DistType == TDistanceType::dtEuclid) {
         Dist = new TClustering::TEuclDist;
-    } else if (DistType == TDistanceType::dtCos) {
+    }
+    else if (DistType == TDistanceType::dtCos) {
         Dist = new TClustering::TCosDist;
-    } else {
+    }
+    else {
         throw TExcept::New("Update KMeans Exception: distance type is not valid " + TInt::GetStr((int)DistType));
     }
-
-    if (ParamVal->IsObjKey("verbose")) { Verbose = ParamVal->GetObjBool("verbose"); }
 
     Notify = Verbose ? TNotify::StdNotify : TNotify::NullNotify;
 }
@@ -2593,14 +2594,11 @@ void TNodeJsKMeans::TFitTask::Run() {
                else {
                    KMeans->Apply(JsFltVV->Mat, JsKMeans->AllowEmptyP, JsKMeans->Iter, JsKMeans->Notify);
                }
-
                KMeans->Assign(JsFltVV->Mat, JsKMeans->AssignV);
-
                TFltVV D;
                JsKMeans->Dist->GetDist2VV(JsFltVV->Mat, KMeans->GetCentroidVV(), D);
                TLinAlg::MultiplyScalar(-1, D, D);
                TLinAlgSearch::GetColMaxIdxV(D, JsKMeans->Medoids);
-
                if (JsIntV != nullptr) {
                    EAssertR(JsIntV->Vec.Len() == JsFltVV->Mat.GetCols(), "KMeans.fit: IntVector RecordIds.length must be equal to number of columns of X!");
                    
@@ -2648,11 +2646,11 @@ void TNodeJsKMeans::TFitTask::Run() {
                else {
                    KMeans->Apply(JsSpVV->Mat, JsKMeans->AllowEmptyP, JsKMeans->Iter, JsKMeans->Notify);
                }
-
                KMeans->Assign(JsSpVV->Mat, JsKMeans->AssignV);
-               
+
                TFltVV D;
                JsKMeans->Dist->GetDist2VV(JsSpVV->Mat, KMeans->GetCentroidVV(), D);
+
                TLinAlg::MultiplyScalar(-1, D, D);
                TLinAlgSearch::GetColMaxIdxV(D, JsKMeans->Medoids);
 

--- a/test/nodejs/Kmeanstest.js
+++ b/test/nodejs/Kmeanstest.js
@@ -379,6 +379,296 @@ describe("Kmeans test", function () {
                 KMeans.fit(X);
             });
         });
+
+        // distanceType: "Cos"
+
+        it("should create the model for dense centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos" });
+            var matrix = new la.Matrix([[-1, 1], [0, 0]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for dense centroids with fitIdx, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", fitIdx: [0, 1] });
+            var matrix = new la.Matrix([[-1, 1], [0, 0]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for dense centroids with dense fitStart, dense matrix, distanceType Cos", function () {
+            var centroids = new la.Matrix({ rows: 2, cols: 2, random: true });
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", fitStart: { C: centroids } });
+            var matrix = new la.Matrix([[-1, 1], [0, 1]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for dense centroids with sparse fitStart, dense matrix, distanceType Cos", function () {
+            var centroids = new la.SparseMatrix([[[1, 0]], [[0, -1]]]);
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", fitStart: { C: centroids } });
+            var matrix = new la.Matrix([[-1, 1], [0, 0]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for dense centroids, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos" });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for dense centroids with fitIdx, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", fitIdx: [0, 1] });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for dense centroids with dense fitStart, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", fitStart: { C: new la.Matrix({ rows: 11, cols: 2, random: true }) } });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for dense centroids with sparse fitStart, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", fitStart: { C: new la.SparseMatrix([[[0, 1]], [[11, 3]]]) } });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        })
+        it("should return the correct model for dense centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", distanceType: "Cos", k: 2 });
+            var matrix = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, 2);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the correct model for dense centroids with fitIdx, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2, fitIdx: [0, 1] });
+            var matrix = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, 2);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the correct model for dense centroids with dense fitStart, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2, fitStart: { C: new la.Matrix({ rows: 2, cols: 2, random: true }) } });
+            var matrix = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, 2);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the correct model for dense centroids with sparse fitStart, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2, fitStart: { C: new la.SparseMatrix([[[0, 1]], [[1, 3]]]) } });
+            var matrix = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, 2);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the correct model for dense centroids, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2 });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]], [[4, -1]]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, 11);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the correct model for dense centroids with fitIdx, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2, fitIdx: [0, 1] });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]], [[4, -1]]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, 11);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the correct model for dense centroids with dense fitStart, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2, fitStart: { C: new la.Matrix({ rows: 2, cols: 2, random: true }) } });
+            var matrix = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, 2);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the correct model for dense centroids with sparse fitStart, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2, fitStart: { C: new la.SparseMatrix([[[0, 1]], [[11, 3]]]) } });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]], [[4, -1]]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, 12);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the correct model for dense centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2 });
+            var matrix = new la.Matrix([[1, 2, 3, -10, -10, 4, 2, -10], [7, 6, 5, 5, -5, -1, -3, 0]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 8);
+            assert.equal(model.C.rows, 2);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the correct model for dense centroids with fitIdx, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2, fitIdx: [0, 1] });
+            var matrix = new la.Matrix([[1, 2, 3, -10, -10, 4, 2, -10], [7, 6, 5, 5, -5, -1, -3, 0]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 8);
+            assert.equal(model.C.rows, 2);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the same model even after changing parameter values, dense centroids, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 3 });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var model = KMeans.getModel();
+            assert.deepEqual(model.C, X);
+
+            KMeans.setParams({ iter: 102 });
+            var model2 = KMeans.getModel();
+            assert.deepEqual(model2.C, X);
+        });
+
+        it("should create the model for sparse centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", centroidType: "Sparse" });
+            var matrix = new la.Matrix([[-1, 1], [0, 0]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for sparse centroids with fitIdx, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", centroidType: "Sparse", fitIdx: [0, 1] });
+            var matrix = new la.Matrix([[-1, 1], [0, 0]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for sparse centroids with dense fitStart, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", iter: 100, k: 2, centroidType: "Sparse", fitStart: { C: new la.Matrix([[0, 1], [2, 3]]) } });
+            var matrix = new la.Matrix([[-1, 1], [0, 0]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for sparse centroids with sparse fitStart, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", iter: 100, k: 2, centroidType: "Sparse", fitStart: { C: new la.SparseMatrix([[[0, 1]], [[1, 3]]]) } });
+            var matrix = new la.Matrix([[-1, 1], [0, 0]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for sparse centroids, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", centroidType: "Sparse" });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for sparse centroids with fitIdx, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", centroidType: "Sparse", fitIdx: [0, 1] });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for sparse centroids with dense fitStart, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", iter: 100, k: 2, centroidType: "Sparse", fitStart: { C: new la.Matrix([[0, 1], [3, 3]]) } });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should create the model for sparse centroids with sparse fitStart, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", iter: 100, k: 2, centroidType: "Sparse", fitStart: { C: new la.SparseMatrix([[[0, 1]], [[1, 3]]]) } });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]]]);
+            assert.doesNotThrow(function () {
+                KMeans.fit(matrix);
+            });
+        });
+        it("should return the correct model for sparse centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 3, centroidType: "Sparse" });
+            var matrix = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, -1);
+            assert.equal(model.C.cols, 3);
+        });
+        it("should return the correct model for sparse centroids with fitIdx, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 3, centroidType: "Sparse", fitIdx: [0, 1, 2] });
+            var matrix = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, -1);
+            assert.equal(model.C.cols, 3);
+        });
+        it("should return the correct model for sparse centroids, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2, centroidType: "Sparse" });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]], [[4, -1]]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, -1);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the correct model for sparse centroids with fitIdx, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2, centroidType: "Sparse", fitIdx: [0, 1] });
+            var matrix = new la.SparseMatrix([[[0, 1], [10, 2]], [[2, 3]], [[4, -1]]]);
+            KMeans.fit(matrix);
+            var model = KMeans.getModel();
+            assert.equal(model.idxv.length, 3);
+            assert.equal(model.C.rows, -1);
+            assert.equal(model.C.cols, 2);
+        });
+        it("should return the same model even after changing parameter values, sparse centroids, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 3, centroidType: "Sparse" });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var model = KMeans.getModel();
+            assert.deepEqual(model.C.rows, -1);
+            assert.deepEqual(model.C.cols, 3);
+
+            KMeans.setParams({ iter: 102 });
+            var model2 = KMeans.getModel();
+            assert.deepEqual(model2.C.rows, -1);
+            assert.deepEqual(model2.C.cols, 3);
+        });
+        it("should throw an exception if k and length of fitIdx are not equal, dense centroids, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 3, fitIdx: [0, 1] });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            assert.throws(function () {
+                KMeans.fit(X);
+            });
+        });
+        it("should throw an exception if maximum value of fitIdx is greater that number of columns of matrix, dense centroids, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2, fitIdx: [0, 5] });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            assert.throws(function () {
+                KMeans.fit(X);
+            });
+        });
+        it("should throw an exception if maximum value of fitIdx is greater that number of columns of matrix, sparse centroids, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ distanceType: "Cos", k: 2, centroidType: "Sparse", fitIdx: [0, 5] });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            assert.throws(function () {
+                KMeans.fit(X);
+            });
+        });
+
     });
     describe("Predict Tests", function () {
         it("should not throw an exception dense centroids, dense matrix", function () {
@@ -486,6 +776,115 @@ describe("Kmeans test", function () {
                 KMeans.predict(matrix);
             });
         });
+
+        // distanceType: 'Cos'
+
+        it("should not throw an exception dense centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.Matrix([[1, 1], [0, -1]]);
+            assert.doesNotThrow(function () {
+                KMeans.predict(matrix);
+            });
+        });
+        it("should not throw an exception dense centroids, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.SparseMatrix([[[1, 1]], [[0, -1]]]);
+            assert.doesNotThrow(function () {
+                KMeans.predict(matrix);
+            });
+        });
+        it("should return the predictions of the matrix dense centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.Matrix([[-1, 2, 1], [0, 1, -3]]);
+            var prediction = KMeans.predict(matrix);
+            assert.equal(prediction.length, 3);
+        });
+        it("should return the predictions of the matrix dense centroids, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.SparseMatrix([[[0, 1]], [[1, 1]], [[0, 2], [1, 4]]]);
+            var prediction = KMeans.predict(matrix);
+            assert.equal(prediction.length, 3);
+        });
+        it("should throw an exception if the matrix has less rows dense centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.Matrix([[1, 1]]);
+            assert.throws(function () {
+                KMeans.predict(matrix);
+            });
+        });
+        it("should throw an exception if the matrix has too many rows dense centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.Matrix([[1, 1], [0, -1], [0, 0]]);
+            assert.throws(function () {
+                KMeans.predict(matrix);
+            });
+        });
+        it("should throw an exception if the matrix has too many rows dense centroids, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.SparseMatrix([[[4, 1]]]);
+            assert.throws(function () {
+                KMeans.predict(matrix);
+            });
+        });
+
+        it("should not throw an exception sparse centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, centroidType: "Sparse", distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.Matrix([[1, 1], [0, -1]]);
+            assert.doesNotThrow(function () {
+                KMeans.predict(matrix);
+            });
+        });
+        it("should not throw an exception sparse centroids, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, centroidType: "Sparse", distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.SparseMatrix([[[1, 1]], [[0, -1]]]);
+            assert.doesNotThrow(function () {
+                KMeans.predict(matrix);
+            });
+        });
+        it("should return the predictions of the matrix sparse centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, centroidType: "Sparse", distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.Matrix([[-1, 2, 1], [0, 1, -3]]);
+            var prediction = KMeans.predict(matrix);
+            assert.equal(prediction.length, 3);
+        });
+        it("should return the predictions of the matrix sparse centroids, sparse matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, centroidType: "Sparse", distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.SparseMatrix([[[0, 1]], [[1, 1]], [[0, 2], [1, 4]]]);
+            var prediction = KMeans.predict(matrix);
+            assert.equal(prediction.length, 3);
+        });
+        it("should throw an exception if the matrix has less rows sparse centroids, dense matrix, distanceType Cos", function () {
+            var KMeans = new analytics.KMeans({ k: 3, centroidType: "Sparse", distanceType: 'Cos' });
+            var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+            KMeans.fit(X);
+            var matrix = new la.Matrix([[1, 1]]);
+            assert.throws(function () {
+                KMeans.predict(matrix);
+            });
+        });
+
     });
 
 


### PR DESCRIPTION
Issue #449: Not all methods used for KMeans.fit were implemented when using distanceType: "Cos". Added unit tests for the fit and predict methods in the case of distanceType: "Cos".