### PR TITLE
Documentation update and tokenizer default value at constructor

### DIFF
--- a/src/nodejs/analytics/analytics.cpp
+++ b/src/nodejs/analytics/analytics.cpp
@@ -1909,7 +1909,7 @@ TNodeJsTokenizer* TNodeJsTokenizer::NewFromArgs(const v8::FunctionCallbackInfo<v
         const TStr& TypeNm = "unicode";
         PJsonVal ParamVal = TJsonVal::NewObj();
         ParamVal->AddToObj("type", TypeNm);
-        // create
+        // create tokenizer
         PTokenizer Tokenizer = TTokenizer::New(TypeNm, ParamVal);
         return new TNodeJsTokenizer(Tokenizer);
     } else if (TNodeJsUtil::IsArgObj(Args, 0)) {
@@ -1920,7 +1920,7 @@ TNodeJsTokenizer* TNodeJsTokenizer::NewFromArgs(const v8::FunctionCallbackInfo<v
         } else {
             ParamVal->AddToObj("type", TypeNm);
         }
-        // create
+        // create tokenizer
         PTokenizer Tokenizer = TTokenizer::New(TypeNm, ParamVal);
         return new TNodeJsTokenizer(Tokenizer);
     } else {

--- a/src/nodejs/analytics/analytics.cpp
+++ b/src/nodejs/analytics/analytics.cpp
@@ -1906,7 +1906,7 @@ void TNodeJsTokenizer::Init(v8::Handle<v8::Object> exports) {
 TNodeJsTokenizer* TNodeJsTokenizer::NewFromArgs(const v8::FunctionCallbackInfo<v8::Value>& Args) {
 	// parse arguments
     if (Args.Length() == 0) {
-        const TStr& TypeNm = "unicode";
+        const TStr TypeNm = "unicode";
         PJsonVal ParamVal = TJsonVal::NewObj();
         ParamVal->AddToObj("type", TypeNm);
         // create tokenizer
@@ -1914,12 +1914,8 @@ TNodeJsTokenizer* TNodeJsTokenizer::NewFromArgs(const v8::FunctionCallbackInfo<v
         return new TNodeJsTokenizer(Tokenizer);
     } else if (TNodeJsUtil::IsArgObj(Args, 0)) {
         PJsonVal ParamVal = TNodeJsUtil::GetArgJson(Args, 0);
-        TStr& TypeNm = TStr("unicode");
-        if (ParamVal->IsObjKey("type")) {
-            TypeNm = ParamVal->GetObjStr("type");
-        } else {
-            ParamVal->AddToObj("type", TypeNm);
-        }
+        const TStr TypeNm = ParamVal->GetObjStr("type", "unicode");
+        ParamVal->AddToObj("type", TypeNm.CStr());
         // create tokenizer
         PTokenizer Tokenizer = TTokenizer::New(TypeNm, ParamVal);
         return new TNodeJsTokenizer(Tokenizer);

--- a/src/nodejs/analytics/analytics.cpp
+++ b/src/nodejs/analytics/analytics.cpp
@@ -1905,13 +1905,27 @@ void TNodeJsTokenizer::Init(v8::Handle<v8::Object> exports) {
 
 TNodeJsTokenizer* TNodeJsTokenizer::NewFromArgs(const v8::FunctionCallbackInfo<v8::Value>& Args) {
 	// parse arguments
-	PJsonVal ParamVal = TNodeJsUtil::GetArgJson(Args, 0);
-	EAssertR(ParamVal->IsObjKey("type"),
-		"Missing tokenizer type " + ParamVal->SaveStr());
-	const TStr& TypeNm = ParamVal->GetObjStr("type");
-	// create
-	PTokenizer Tokenizer = TTokenizer::New(TypeNm, ParamVal);
-	return new TNodeJsTokenizer(Tokenizer);
+    if (Args.Length() == 0) {
+        const TStr& TypeNm = "unicode";
+        PJsonVal ParamVal = TJsonVal::NewObj();
+        ParamVal->AddToObj("type", TypeNm);
+        // create
+        PTokenizer Tokenizer = TTokenizer::New(TypeNm, ParamVal);
+        return new TNodeJsTokenizer(Tokenizer);
+    } else if (TNodeJsUtil::IsArgObj(Args, 0)) {
+        PJsonVal ParamVal = TNodeJsUtil::GetArgJson(Args, 0);
+        TStr& TypeNm = TStr("unicode");
+        if (ParamVal->IsObjKey("type")) {
+            TypeNm = ParamVal->GetObjStr("type");
+        } else {
+            ParamVal->AddToObj("type", TypeNm);
+        }
+        // create
+        PTokenizer Tokenizer = TTokenizer::New(TypeNm, ParamVal);
+        return new TNodeJsTokenizer(Tokenizer);
+    } else {
+        throw TExcept::New("Tokenizer construction: supported only objects!");
+    }
 }
 
 void TNodeJsTokenizer::getTokens(const v8::FunctionCallbackInfo<v8::Value>& Args) {

--- a/src/nodejs/analytics/analytics.h
+++ b/src/nodejs/analytics/analytics.h
@@ -158,7 +158,7 @@ private:
 * see: {@link http://ttic.uchicago.edu/~nati/Publications/PegasosMPB.pdf Pegasos: Primal Estimated sub-GrAdient SOlver for SVM}.
 * @class
 * @param {module:analytics~SVMParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
-* <br>1. Using the parameter object {@link  module:analytics~SVMParam},
+* <br>1. Using the {@link  module:analytics~SVMParam} object,
 * <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import modules
@@ -338,7 +338,7 @@ public:
 * @classdesc Support Vector Machine Regression. Implements a soft margin linear support vector regression using the PEGASOS algorithm with epsilon insensitive loss, see: {@link http://ttic.uchicago.edu/~nati/Publications/PegasosMPB.pdf Pegasos: Primal Estimated sub-GrAdient SOlver for SVM}.
 * @class
 * @param {module:analytics~SVMParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
-* <br>1. Using the parameter object {@link  module:analytics~SVMParam},
+* <br>1. Using the {@link  module:analytics~SVMParam} object,
 * <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import module
@@ -518,7 +518,7 @@ public:
  * @classdesc Ridge regression minimizes the value `||A' x - b||^2 + ||gamma x||^2`. 
  * Uses {@link http://en.wikipedia.org/wiki/Tikhonov_regularization Tikhonov regularization}.
  * @param {module:analytics~ridgeRegParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
- * <br>1. Using the parameter object {@link  module:analytics~ridgeRegParam},
+ * <br>1. Using the {@link  module:analytics~ridgeRegParam} object,
  * <br>2. using the file input stream {@link module:fs.FIn}.
  * @example
  * // import modules
@@ -904,7 +904,7 @@ public:
  * @classdesc Anomaly detector that checks if the test point is too far from the nearest known point.
  * @class
  * @param {module:analytics~detectorParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
-* <br>1. Using the parameter object {@link  module:analytics~detectorParam},
+* <br>1. Using the {@link  module:analytics~detectorParam} object,
 * <br>2. using the file input stream {@link module:fs.FIn}.
  * @example
  * // import modules
@@ -1182,7 +1182,7 @@ public:
 * @classdesc Holds the Recursive Linear Regression model.
 * @class
 * @param {module:analytics~recLinRegParam | module:fs.FIn} arg - Construction arguments. There are two ways of constructing:
-* <br>1. Using the parameter object {@link  module:analytics~detectorParam},
+* <br>1. Using the {@link  module:analytics~detectorParam} object,
 * <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import analytics module
@@ -1372,7 +1372,7 @@ private:
  * @class
  * @classdesc  Uses Newtons method to compute the weights. <b>Before use: QMiner must be built with the OpenBLAS library.</b>
  * @param { module:analytics~logisticRegParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
-* <br>1. Using the parameter object {@link  module:analytics~logisticRegParam},
+* <br>1. Using the {@link  module:analytics~logisticRegParam} object,
 * <br>2. using the file input stream {@link module:fs.FIn}.
  * @example
  * // import analytics module
@@ -1534,7 +1534,7 @@ public:
  * @classdesc Proportional Hazards Model  with a constant hazard function. Uses Newtons method to compute the weights.
  * <b>Before use: QMiner must be built with the OpenBLAS library.</b>
  * @param {module:analytics~hazardModelParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
-* <br>1. Using the parameter object {@link module:analytics~hazardModelParam},
+* <br>1. Using the {@link module:analytics~hazardModelParam} object,
 * <br>2. using the file input stream {@link module:fs.FIn}.
  * @example
  * // import analytics module
@@ -1701,7 +1701,7 @@ public:
 * @class
 * @classdesc Holds online/offline neural network model.
 * @param {module:analytics~nnetParams | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
-* <br>1. Using the parameter object {@link module:analytics~nnetParams},
+* <br>1. Using the {@link module:analytics~nnetParams} object,
 * <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import module
@@ -1950,7 +1950,7 @@ public:
 * @class
 * @classdesc Scales a higher level vectors into a 2D vector space such that the distances between vectors are preserved as well as possible.
 * @param {module:analytics~MDSParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
-* <br>1. Using the parameter object {@link module:analytics~MDSParam},
+* <br>1. Using the {@link module:analytics~MDSParam} object,
 * <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import analytics module
@@ -2110,7 +2110,7 @@ private:
 * @classdesc KMeans Clustering is an iterative, data-partitioning algorithm that assigns observations into K clusters.
 * @class
 * @param {module:analytics~KMeansParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
-* <br>1. Using the parameter object {@link module:analytics~KMeansParam},
+* <br>1. Using the {@link module:analytics~KMeansParam} object,
 * <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import analytics and la modules
@@ -2401,7 +2401,7 @@ private:
 * unknown values. If `A` is a matrix with unknown values it calculates the matrices `U` and `V` such that `U*V` approximates `A`.
 * @class
 * @param {module:analytics~RecSysParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
-* <br>1. Using the parameter object {@link module:analytics~RecSysParam},
+* <br>1. Using the {@link module:analytics~RecSysParam} object,
 * <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import analytics and la modules

--- a/src/nodejs/analytics/analytics.h
+++ b/src/nodejs/analytics/analytics.h
@@ -43,7 +43,7 @@ private:
 	};
 public:
 	/**
-	* Computes the non-negative matrix factorization, see: {@link https://en.wikipedia.org/wiki/Non-negative_matrix_factorization}.
+	* Calculates the non-negative matrix factorization, see: {@link https://en.wikipedia.org/wiki/Non-negative_matrix_factorization}.
 	* @param {(module:la.Matrix | module:la.SparseMatrix)} mat - The non-negative matrix.
 	* @param {number} k - The reduced rank, e.g. number of columns in matrix U and number of rows in matrix V. Must be between 0 and `min(mat.rows, mat.cols)`.
 	* @param {Object} [json] - Algorithm options.
@@ -154,11 +154,12 @@ private:
 
 /**
 * SVC
-* @classdesc Support Vector Machine Classifier. Implements a soft margin linear support vector classifier using the PEGASOS algorithm, see: {@link http://ttic.uchicago.edu/~nati/Publications/PegasosMPB.pdf Pegasos: Primal Estimated sub-GrAdient SOlver for SVM}.
+* @classdesc Support Vector Machine Classifier. Implements a soft margin linear support vector classifier using the PEGASOS algorithm, 
+* see: {@link http://ttic.uchicago.edu/~nati/Publications/PegasosMPB.pdf Pegasos: Primal Estimated sub-GrAdient SOlver for SVM}.
 * @class
-* @param {module:fs.FIn | module:analytics~SVMParam} [arg] - Construction arguments. There are two ways of constructing:
+* @param {module:analytics~SVMParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
 * <br>1. Using the parameter object {@link  module:analytics~SVMParam},
-* <br>2. using the file input stream {@link module:fs.FIn} (loads the model from disk).
+* <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import modules
 * var la = require('qminer').la;
@@ -337,9 +338,9 @@ public:
 * SVR
 * @classdesc Support Vector Machine Regression. Implements a soft margin linear support vector regression using the PEGASOS algorithm with epsilon insensitive loss, see: {@link http://ttic.uchicago.edu/~nati/Publications/PegasosMPB.pdf Pegasos: Primal Estimated sub-GrAdient SOlver for SVM}.
 * @class
-* @param {module:fs.FIn | module:analytics~SVMParam} [arg] - Construction arguments. There are two ways of constructing:
+* @param {module:analytics~SVMParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
 * <br>1. Using the parameter object {@link  module:analytics~SVMParam},
-* <br>2. using the file input stream {@link module:fs.FIn} (loads the model from disk).
+* <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import module
 * var analytics = require('qminer').analytics;
@@ -517,9 +518,9 @@ public:
  * Ridge regression. Minimizes: `||A' x - b||^2 + ||gamma x||^2`. 
  * Uses {@link http://en.wikipedia.org/wiki/Tikhonov_regularization Tikhonov regularization}.
  * @class
- * @param {(module:analytics~ridgeRegParam|module:fs.FIn)} [arg] - Construction arguments. There are two ways of constructing:
+ * @param {module:analytics~ridgeRegParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
  * <br>1. Using the parameter object {@link  module:analytics~ridgeRegParam},
- * <br>2. using the file input stream {@link module:fs.FIn} (loads the model from disk).
+ * <br>2. using the file input stream {@link module:fs.FIn}.
  * @example
  * // import modules
  * analytics = require('qminer').analytics;
@@ -713,7 +714,7 @@ public:
  * @class
  * @param {module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
 * <br>1. construction by default value (not giving an argument),
-* <br>2. using the file input stream {@link module:fs.FIn} (loads the model from disk).
+* <br>2. using the file input stream {@link module:fs.FIn}.
  * @example
  * // import modules
  * la = require('qminer').la;
@@ -730,7 +731,7 @@ public:
  * var pred1 = sigmoid.predict(1.2);
  * var pred2 = sigmoid.predict(-1.2);
  */
-//# exports.Sigmoid = function(arg) {};
+//# exports.Sigmoid = function(arg) { return Object.create(require('qminer').analytics.Sigmoid.prototype); };
 class TNodeJsSigmoid : public node::ObjectWrap {
     friend class TNodeJsUtil;
 public:
@@ -820,6 +821,8 @@ public:
      * Returns the expected response for the provided feature vector.
      * @param {number | module:la.Vector} x - Prediction score.
      * @returns {number | module:la.Vector}
+     * <br> 1. If `x` is a number, returns a normalized prediction score,
+     * <br> 2. if `x` is a {@link module:la.Vector}, returns a vector of normalized prediction scores.
 	 * @example
 	 * // import modules
 	 * var analytics = require('qminer').analytics;
@@ -839,8 +842,7 @@ public:
 
     /**
      * Returns the expected response for the provided feature vector.
-     *
-     * @param {number | module:la.Vector} x - Prediction score (or vector of them).
+     * @param {number | module:la.Vector} x - Prediction score.
      * @returns {number | module:la.Vector} 
      * <br> 1. If `x` is a number, returns a normalized prediction score,
      * <br> 2. if `x` is a {@link module:la.Vector}, returns a vector of normalized prediction scores.
@@ -904,9 +906,9 @@ public:
  * Nearest Neighbour Anomaly Detection 
  * @classdesc Anomaly detector that checks if the test point is too far from the nearest known point.
  * @class
- * @param {(module:analytics~detectorParam|module:fs.FIn)} [detectorParam] - Construction arguments. There are two ways of constructing:
+ * @param {module:analytics~detectorParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
 * <br>1. Using the parameter object {@link  module:analytics~detectorParam},
-* <br>2. using the file input stream {@link module:fs.FIn} (loads the model from disk).
+* <br>2. using the file input stream {@link module:fs.FIn}.
  * @example
  * // import modules
  * var analytics = require('qminer').analytics;
@@ -978,7 +980,7 @@ public:
     JsDeclareFunction(getParams);
     
     /**
-     * Save model to provided output stream.
+     * Saves model to provided output stream.
      * @param {module:fs.FOut} fout - The output stream.
      * @returns {module:fs.FOut} The output stream `fout`.
 	 * @example
@@ -1021,7 +1023,7 @@ public:
     JsDeclareFunction(getModel);
 
 	/**
-	* Adds a new point to the known points and recomputes the threshold.
+	* Adds a new point to the known points and recalculates the threshold.
 	* @param {module:la.SparseVector} X - Test example.
 	* @param {number} recId - Integer record ID, used in {@link module:analytics.NearestNeighborAD.prototype.explain}.
 	* @returns {module:analytics.NearestNeighborAD} Self. The model is updated.
@@ -1044,7 +1046,7 @@ public:
     JsDeclareFunction(partialFit);
     
 	/**
-	* Analyzes the nearest neighbor distances and computes the detector threshold based on the rate parameter.
+	* Analyzes the nearest neighbor distances and calculates the detector threshold based on the rate parameter.
 	* @param {module:la.SparseMatrix} A - Matrix whose columns correspond to known examples. Gets saved as it is part of the model.
 	* @param {module:la.IntVector} [idVec] - An integer vector of IDs.
 	* @returns {module:analytics.NearestNeighborAD} Self. The model is set by the matrix `A`.
@@ -1087,7 +1089,7 @@ public:
 	/**
 	* Compares the point to the known points and returns 1 if it's too far away (based on the precalculated threshold).
 	* @param {module:la.SparseVector} x - Test vector.
-	* @returns {number} Returns 1.0 if the vector x is an anomaly and 0.0 otherwise.
+	* @returns {number} Returns 1.0 if the vector `x` is an anomaly and 0.0 otherwise.
 	* @example
 	* // import modules
 	* var analytics = require('qminer').analytics;
@@ -1108,7 +1110,7 @@ public:
 
 	/**
 	* @typedef {Object} NearestNeighborADExplain
-	* A Json object used for interpreting the predictions of {@link module:analytics.NearestNeighborAD}.
+	* An object used for interpreting the predictions of {@link module:analytics.NearestNeighborAD}.
 	* @property {number} nearestID - The ID of the nearest neighbor.
 	* @property {number} distance - The distance to the nearest neighbor.
 	* @property {Array.<module:analytics~NearestNeighborADFeatureContribution>} features - An array with feature contributions.
@@ -1118,7 +1120,7 @@ public:
 
 	/**
 	* @typedef {Object} NearestNeighborADFeatureContribution
-	* A JSON object explaining the prediction of {@link module:analytics.NearestNeighborAD} in terms of a single feature.
+	* An object explaining the prediction of {@link module:analytics.NearestNeighborAD} in terms of a single feature.
 	* @property {number} id - The ID of the feature.
 	* @property {number} val - The value of the feature for the vector we are explaining.
 	* @property {number} nearVal - The the value of the feature for the nearest neighbor.
@@ -1126,7 +1128,7 @@ public:
 	*/
 	
 	/**
-	* Returns a JSON object that encodes the ID of the nearest neighbor and the features that contributed to the distance.
+	* Returns an object that encodes the ID of the nearest neighbor and the features that contributed to the distance.
 	* @param {module:la.SparseVector} x - Test vector.
 	* @returns {module:analytics~NearestNeighborADExplain} The explanation object.
 	* @example
@@ -1181,14 +1183,16 @@ public:
 * Recursive Linear Regression
 * @classdesc Holds the Recursive Linear Regression model.
 * @class
-* @param {(module:analytics~recLinearRegParam|module:fs.FIn)} param - The constructor parameter json object.
+* @param {module:analytics~recLinearRegParam | module:fs.FIn} arg - Construction arguments. There are two ways of constructing:
+* <br>1. Using the parameter object {@link  module:analytics~detectorParam},
+* <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import analytics module
 * var analytics = require('qminer').analytics;
 * // create the recursive linear regression model holder
 * var linreg = new analytics.RecLinReg({ dim: 10, regFact: 1.0, forgetFact: 1.0 });
 */
-//# exports.RecLinReg = function(param) { return Object.create(require('qminer').analytics.RecLinReg.prototype); }
+//# exports.RecLinReg = function(arg) { return Object.create(require('qminer').analytics.RecLinReg.prototype); }
 class TNodeJsRecLinReg : public node::ObjectWrap {
 	friend class TNodeJsUtil;
 private:
@@ -1202,7 +1206,7 @@ private:
 	static TNodeJsRecLinReg* NewFromArgs(const v8::FunctionCallbackInfo<v8::Value>& Args);
 	
 	/**
-	* Creates a partial fit of the input.
+	* Updates the internal model.
 	* @param {module:la.Vector} vec - The input vector.
 	* @param {number} num - The target number for the vector.
 	* @returns {module:analytics.RecLinReg} Self. The internal model is updated.
@@ -1221,9 +1225,9 @@ private:
 	JsDeclareFunction(partialFit);
 
 	/**
-	* Creates a fit of the input.
+	* Creates/updates the internal model.
 	* @param {module:la.Matrix} mat - The input matrix.
-	* @param {module:la.Vector} vec - The target numbers, where the i-th number in vector is the target number for the i-th column of the matrix.
+	* @param {module:la.Vector} vec - The target numbers, where the i-th number in vector is the target number for the i-th column of the `mat`.
 	* @returns {module:analytics.RecLinReg} Self. The internal model is updated.
 	* @example
 	* // import modules
@@ -1242,7 +1246,7 @@ private:
 
 	/**
 	* Puts the vector through the model and returns the prediction as a real number.
-	* @param {module:la.Vector} vec - The vector needed to be predicted.
+	* @param {module:la.Vector} vec - The prediction vector.
 	* @returns {number} The prediction.
 	* @example
 	* // import modules
@@ -1265,7 +1269,7 @@ private:
 
 	/**
 	* Sets the parameters of the model.
-	* @param {module:analytics~recLinearRegParam} param - The new parameters of the model.
+	* @param {module:analytics~recLinearRegParam} params - The new parameters of the model.
 	* @returns {module:analytics.RecLinReg} Self. The parameters are updated. Any previous model is set to default.
 	* @example
 	* // import analytics module
@@ -1275,7 +1279,7 @@ private:
 	* // set the parameters of the model
 	* linreg.setParams({ dim: 3, recFact: 1e2, forgetFact: 0.5 });
 	*/
-	//# exports.RecLinReg.prototype.setParams = function (param) { return Object.create(require('qminer').analytics.RecLinReg.prototype); }
+	//# exports.RecLinReg.prototype.setParams = function (params) { return Object.create(require('qminer').analytics.RecLinReg.prototype); }
 	JsDeclareFunction(setParams);
 
 	/**
@@ -1289,17 +1293,37 @@ private:
 	* // get the parameters of the model
 	* var params = linreg.getParams(); // returns { dim: 10, recFact: 1.0, forgetFact: 1.0 }
 	*/
-	//# exports.RecLinReg.prototype.getParams = function () { return { dim: 0, regFact: 1.0, forgetFact: 1.0 }}
+	//# exports.RecLinReg.prototype.getParams = function () { return { dim: 0, regFact: 1.0, forgetFact: 1.0 }; }
 	JsDeclareFunction(getParams);
 
 	/**
 	* Gives the weights of the model.
+    * @example
+    * // import analytics module
+    * var analytics = require('qminer').analytics;
+    * var la = require('qminer').la;
+	* // create a new Recursive Linear Regression model
+	* var linreg = new analytics.RecLinReg({ dim: 2 });
+    * // create a new dense matrix and target vector
+	* var mat = new la.Matrix([[1, 2], [1, -1]]);
+	* var vec = new la.Vector([3, 3]);
+	* // fit the model with the matrix
+	* linreg.fit(mat, vec);
+    * // get the weights of the model
+    * var weights = linreg.weights;
 	*/
-	//# exports.RecLinReg.prototype.weights = Object.create(require('qminer').la.Vector);
+	//# exports.RecLinReg.prototype.weights = Object.create(require('qminer').la.Vector.prototype);
 	JsDeclareProperty(weights);
 
 	/**
 	* Gets the dimensionality of the model.
+    * @example
+    * // import analytics module
+    * var analytics = require('qminer').analytics;
+    * // create a new Recursive Linear Regression model
+    * var linreg = new analytics.RecLinReg({ dim: 10 });
+    * // get the dimensionality of the model
+    * var dim = linreg.dim;
 	*/
 	//# exports.RecLinReg.prototype.dim = 0;
 	JsDeclareProperty(dim);
@@ -1307,7 +1331,7 @@ private:
 	/**
 	* Save model to provided output stream.
 	* @param {module:fs.FOut} fout - The output stream.
-	* @returns {module:fs.FOut} Provided output stream fout.
+	* @returns {module:fs.FOut} The output stream `fout`.
 	* @example
 	* // import modules
 	* var analytics = require('qminer').analytics;
@@ -1340,23 +1364,25 @@ private:
 
 /**
 * @typedef {Object} logisticRegParam
-* The Json constructor parameters for {@link module:analytics.LogReg}.
+* An object used for the construction of {@link module:analytics.LogReg}.
 * @property {number} [lambda=1] - The regularization parameter.
-* @property {boolean} [intercept=false] - Indicates wether to automatically include the intercept.
+* @property {boolean} [intercept=false] - Indicates whether to automatically include the intercept.
 */
 
 /**
- * Logistic regression model. Uses Newtons method to compute the weights.
- * <b>Before use: include BLAS library.</b>
- * @constructor
- * @param {(module:analytics~logisticRegParam|module:fs.FIn)} [opts] - The options used for initialization or the input stream from which the model is loaded. If this parameter is an input stream than no other parameters are required.
+ * Logistic regression model.
+ * @class
+ * @classdesc  Uses Newtons method to compute the weights. <b>Before use: QMiner must be built with the OpenBLAS library.</b>
+ * @param { module:analytics~logisticRegParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
+* <br>1. Using the parameter object {@link  module:analytics~logisticRegParam},
+* <br>2. using the file input stream {@link module:fs.FIn}.
  * @example
  * // import analytics module
  * var analytics = require('qminer').analytics;
  * // create the Logistic Regression model
  * var logreg = new analytics.LogReg({ lambda: 2 });
  */
-//# exports.LogReg = function (opts) { return Object.create(require('qminer').analytics.LogReg.prototype); }
+//# exports.LogReg = function (arg) { return Object.create(require('qminer').analytics.LogReg.prototype); }
 class TNodeJsLogReg : public node::ObjectWrap {
 	friend class TNodeJsUtil;
 public:
@@ -1398,15 +1424,15 @@ public:
 	* // set the parameters of the model
 	* logreg.setParams({ lambda: 1 });
 	*/
-	//# exports.LogReg.prototype.setParams = function () { return Object.create(require('qminer').analytics.LogReg.prototype); }
+	//# exports.LogReg.prototype.setParams = function (param) { return Object.create(require('qminer').analytics.LogReg.prototype); }
 	JsDeclareFunction(setParams);
 
 	/**
-	 * Fits a column matrix of feature vectors X onto the response variable y.
+	 * Fits a column matrix of feature vectors `X` onto the response variable `y`.
 	 * @param {module:la.Matrix} X - the column matrix which stores the feature vectors.
 	 * @param {module:la.Vector} y - the response variable.
 	 * @param {number} [eps] - the epsilon used for convergence.
-	 * @returns {module:analytics.LogReg} Self.
+	 * @returns {module:analytics.LogReg} Self. The model has been updated.
 	 * @example
 	 * // import modules
 	 * var analytics = require('qminer').analytics;
@@ -1416,7 +1442,7 @@ public:
 	 * // create the input matrix and vector for fitting the model
 	 * var mat = new la.Matrix([[1, 0, -1, 0], [0, 1, 0, -1]]);
 	 * var vec = new la.Vector([1, 0, -1, -2]);
-	 * // if openblas is used, fit the model
+	 * // if OpenBLAS is used, fit the model
 	 * if (require('qminer').flags.blas) {
 	 *     logreg.fit(mat, vec);
 	 * }
@@ -1437,7 +1463,7 @@ public:
 	 * // create the input matrix and vector for fitting the model
 	 * var mat = new la.Matrix([[1, 0, -1, 0], [0, 1, 0, -1]]);
 	 * var vec = new la.Vector([1, 0, -1, -2]);
-	 * // if openblas is used
+	 * // if openblas is used, fit the model and predict the value
 	 * if (require('qminer').flags.blas) {
 	 *     // fit the model
 	 *     logreg.fit(mat, vec);
@@ -1452,6 +1478,14 @@ public:
 
 	/**
 	 * Gives the weights of the model.
+     * @example 
+     * // import modules
+     * var analytics = require('qminer').analytics;
+     * var la = require('qminer').la;
+     * // create the logistic regression model
+     * var logreg = new analytics.LogReg();
+     * // get the weights of the model
+     * var weights = logreg.weights;
 	 */
 	//# exports.LogReg.prototype.weights = Object.create(require('qminer').la.vector.prototype);
 	JsDeclareProperty(weights);
@@ -1459,7 +1493,7 @@ public:
 	/**
 	 * Saves the model into the output stream.
 	 * @param {module:fs.FOut} fout - the output stream.
-	 * @returns {module:fs.FOut} The output stream fout.
+	 * @returns {module:fs.FOut} The output stream `fout`.
 	 * @example
 	 * // import modules
 	 * var analytics = require('qminer').analytics;
@@ -1492,24 +1526,25 @@ public:
 
 /**
 * @typedef {Object} hazardModelParam
-* The constructor parameters for the Proportional Hazards Model.
+* An object used for the construction of {@link module:analytics.PropHazards}.
 * @property {number} [lambda = 0] - The regularization parameter.
 */
 
 /**
- * Proportional Hazards Model with a constant hazard function.
- * Uses Newtons method to compute the weights.
- * <b>Before use: include BLAS library.</b>
- *
- * @constructor
- * @property {module:analytics~hazardModelParam|module:fs.FIn} [opts] - The options used for initialization or the input stream from which the model is loaded. If this parameter is an input stream than no other parameters are required.
+ * Proportional Hazards Model
+ * @class
+ * @classdesc Proportional Hazards Model  with a constant hazard function. Uses Newtons method to compute the weights.
+ * <b>Before use: QMiner must be built with the OpenBLAS library.</b>
+ * @param {module:analytics~hazardModelParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
+* <br>1. Using the parameter object {@link module:analytics~hazardModelParam},
+* <br>2. using the file input stream {@link module:fs.FIn}.
  * @example
  * // import analytics module
  * var analytics = require('qminer').analytics;
  * // create a Proportional Hazard model
  * var hazard = new analytics.PropHazards();
  */
-//# exports.PropHazards = function (opts) { return Object.create(require('qminer').analytics.PropHazards.prototype); }
+//# exports.PropHazards = function (arg) { return Object.create(require('qminer').analytics.PropHazards.prototype); }
 
 class TNodeJsPropHaz : public node::ObjectWrap {
 	friend class TNodeJsUtil;
@@ -1543,7 +1578,7 @@ public:
 	/**
 	* Sets the parameters of the model.
 	* @param {module:analytics~hazardModelParam} params - The parameters given to the model.
-	* @returns {module:analytics.PropHazards} Self.
+	* @returns {module:analytics.PropHazards} Self. The model parameters have been updated.
 	* @example 
 	* // import analytics module
 	* var analytics = require('qminer').analytics;
@@ -1556,12 +1591,11 @@ public:
 	JsDeclareFunction(setParams);
 
 	/**
-	 * Fits a column matrix of feature vectors X onto the response variable y.
-	 *
+	 * Fits a column matrix of feature vectors `X` onto the response variable `y`.
 	 * @param {module:la.Matrix} X - The column matrix which stores the feature vectors.
 	 * @param {module:la.Vector} y - The response variable.
 	 * @param {number} [eps] - The epsilon used for convergence.
-	 * @returns {module:analytics.PropHazards} Self.
+	 * @returns {module:analytics.PropHazards} Self. The model has been updated.
 	 * @example
 	 * // import modules
 	 * var analytics = require('qminer').analytics;
@@ -1581,7 +1615,6 @@ public:
 
 	/**
 	 * Returns the expected response for the provided feature vector.
-	 *
 	 * @param {module:la.Vector} x - The feature vector.
 	 * @returns {number} The expected response.
 	 * @example
@@ -1593,7 +1626,7 @@ public:
 	 * // create the input matrix and vector for fitting the model
 	 * var mat = new la.Matrix([[1, 1], [1, -1]]);
      * var vec = new la.Vector([3, 3]);
-	 * // if openblas used
+	 * // if openblas used, fit the model and get the prediction
 	 * if (require('qminer').flags.blas) {
 	 *     // fit the model
 	 *     hazards.fit(mat, vec);       
@@ -1608,14 +1641,22 @@ public:
 
 	/**
 	 * The models weights.
+     * @example
+     * // import modules
+	 * var analytics = require('qminer').analytics;
+	 * var la = require('qminer').la;
+	 * // create the Proportional Hazards model
+	 * var hazards = new analytics.PropHazards();
+     * // get the weights
+     * var weights = hazards.weights;
 	 */
 	//# exports.PropHazards.prototype.weights = Object.create(require('qminer').la.Vector.prototype);
 	JsDeclareProperty(weights);
 
 	/**
 	 * Saves the model into the output stream.
-	 * @param {module:fs.FOut} sout - The output stream.
-	 * @returns {module:fs.FOut} The output stream sout.
+	 * @param {module:fs.FOut} fout - The output stream.
+	 * @returns {module:fs.FOut} The output stream `fout`.
 	 * @example
 	 * // import modules
 	 * var analytics = require('qminer').analytics;
@@ -1639,7 +1680,7 @@ public:
 	 * // create a Proportional Hazards object that loads the model and parameters from input stream
 	 * var hazards2 = new analytics.PropHazards(fin);	
 	 */
-	//# exports.PropHazards.prototype.save = function(sout) { return Object.create(require('qminer').fs.FOut.prototype); }
+	//# exports.PropHazards.prototype.save = function(fout) { return Object.create(require('qminer').fs.FOut.prototype); }
 	JsDeclareFunction(save);
 };
 
@@ -1649,20 +1690,28 @@ public:
 
 /**
 * @typedef {Object} nnetParams
-* @property {module:la.IntVector} [layout] - The integer vector with the corresponding values of the number of neutrons. Default is the integer vector [1, 2 ,1].
+* An object used for the construction of {@link module:analytics.NNet}.
+* @property {Array.<number>} [layout = [1, 2, 1]] - The array representing the network schema.
 * @property {number} [learnRate = 0.1] - The learning rate.
 * @property {number} [momentum = 0.5] - The momentum of optimization.
-* @property {string} [tFuncHidden = 'tanHyper'] - The function.
-* @property {string} [tFuncOut = 'tanHyper'] - The function.
+* @property {string} [tFuncHidden = 'tanHyper'] - Type of activation function used on hidden nevrons. Possible options are: `'tanHyper'`, `'sigmoid'`, `'fastTanh'`, `'softPlus'`, `'fastSigmoid'` and `'linear'`.
+* @property {string} [tFuncOut = 'tanHyper'] - Type of activation function used on output nevrons. Possible options are: `'tanHyper'`, `'sigmoid'`, `'fastTanh'`, `'softPlus'`, `'fastSigmoid'` and `'linear'`.
 */
 
 /**
-* Neural Network Model
-* @classdesc Holds online/offline neural network model.
+* Neural Network Model.
 * @class
-* @param {module:analytics~nnetParams|module:fs.FIn} [params] - The parameters for the construction of the model.
+* @classdesc Holds online/offline neural network model.
+* @param {module:analytics~nnetParams | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
+* <br>1. Using the parameter object {@link module:analytics~nnetParams},
+* <br>2. using the file input stream {@link module:fs.FIn}.
+* @example
+* // import module
+* var analytics = require('qminer').analytics;
+* // create a new Neural Networks model
+* var nnet = new analytics.NNet({ layout: [3, 5, 2], learnRate: 0.2, momentum: 0.6 });
 */
-//# exports.NNet = function (params) { return Object.create(require('qminer').analytics.NNet.prototype); }
+//# exports.NNet = function (arg) { return Object.create(require('qminer').analytics.NNet.prototype); }
 class TNodeJsNNet : public node::ObjectWrap {
 	friend class TNodeJsUtil;
 private:
@@ -1693,7 +1742,7 @@ public:
 	/**
 	* Sets the parameters of the model.
 	* @params {module:analytics~nnetParams} params - The given parameters.
-	* @returns {module:analytics.NNet} Self.
+	* @returns {module:analytics.NNet} Self. The model parameters have been updated.
 	* @example
 	* // import analytics module
 	* var analytics = require('qminer').analytics;
@@ -1707,11 +1756,11 @@ public:
 
 	/**
 	* Fits the model.
-	* @param {(module:la.Vector|module:la.Matrix)} input1 - The input vector or matrix.
-	* @param {(module:la.Vector|module:la.Matrix)} input2 - The input vector or matrix.
-	* <br> If input1 and input2 are both {@link module:la.Vector}, then the fitting is in online mode.
-	* <br> If input1 and input2 are both {@link module:la.Matrix}, then the fitting is in batch mode.
-	* @returns {module:analytics.NNet} Self.
+	* @param {module:la.Vector | module:la.Matrix} X - The input data.
+	* @param {module:la.Vector | module:la.Matrix} Y - The output data.
+	* <br> If `X` and `Y` are both {@link module:la.Vector}, then the fitting is in online mode.
+	* <br> If `X` and `Y` are both {@link module:la.Matrix}, then the fitting is in batch mode.
+	* @returns {module:analytics.NNet} Self. The model has been updated.
 	* @example
 	* // import modules
 	* var analytics = require('qminer').analytics;
@@ -1724,13 +1773,13 @@ public:
 	* // fit the model
 	* nnet.fit(matIn, matOut);
 	*/
-	//# exports.NNet.prototype.fit = function (input1, input2) { return Object.create(require('qminer').analytics.NNet.prototype); }
+	//# exports.NNet.prototype.fit = function (input, output) { return Object.create(require('qminer').analytics.NNet.prototype); }
 	JsDeclareFunction(fit);
 	
 	/**
-	* Sends the vector through the model and get the prediction.
-	* @param {module:la.Vector} vec - The sent vector.
-	* @returns {number} The prediction of the vector vec.
+	* Gets the prediction of the vector.
+	* @param {module:la.Vector} vec - The prediction vector.
+	* @returns {module:la.Vector} The prediction of vector `vec`.
 	* @example
 	* // import modules
 	* var analytics = require('qminer').analytics;
@@ -1744,16 +1793,16 @@ public:
 	* nnet.fit(matIn, matOut);
 	* // create the vector for the prediction
 	* var test = new la.Vector([1, 1]);
-	* // predict the value
+	* // predict the value of the vector
 	* var prediction = nnet.predict(test);
 	*/
-	//# exports.NNet.prototype.predict = function (vec) { return 0.0; }
+	//# exports.NNet.prototype.predict = function (vec) { return Object.create(require('qminer').la.Vector.prototype); }
 	JsDeclareFunction(predict);
 
 	/**
 	* Saves the model.
 	* @param {module:fs.FOut} fout - The output stream.
-	* @returns {module:fs.FOut} The output stream fout.
+	* @returns {module:fs.FOut} The output stream `fout`.
 	* @example
 	* // import modules
 	* var analytics = require('qminer').analytics;
@@ -1785,24 +1834,25 @@ public:
 
 /**
 * @typedef {Object} tokenizerParam
-* @property {string} type - The type of the tokenizer. The different types are: 
-*<br>"simple" -
-*<br>"html" -
-*<br>"unicode" -
+* An object used for the construction of {@link module:analytics.Tokenizer}.
+* @property {string} [type='unicode'] - The type of the tokenizer. The different types are: 
+*<br>1. 'simple' - Creates break on white spaces.
+*<br>2. 'html' - Creates break on white spaces and ignores html tags.
+*<br>3. 'unicode' - Creates break on white spaces and normalizes unicode letters, e.g. èšðž changes to csðz.
 */
 
 /**
  * Tokenizer
  * @class 
  * @classdesc Breaks text into tokens (i.e. words).
- * @param {module:analytics.tokenizerParam} param - The constructor parameters.
+ * @param {module:analytics~tokenizerParam} [arg] - Construction arguments. If arg is not given it uses the `'unicode'` tokenizer type.
  * @example
  * // import analytics module
  * var analytics = require('qminer').analytics;
- * // construct model
- * var tokenizer = new analytics.Tokenizer({ type: "simple" })
+ * // construct Tokenizer object
+ * var tokenizer = new analytics.Tokenizer({ type: "simple" });
  */
-//# exports.Tokenizer = function (param) { return Object.create(require("qminer").analytics.Tokenizer.prototype); }
+//# exports.Tokenizer = function (arg) { return Object.create(require("qminer").analytics.Tokenizer.prototype); }
 class TNodeJsTokenizer : public node::ObjectWrap {
 	friend class TNodeJsUtil;
 public:
@@ -1819,17 +1869,17 @@ public:
 
 	// Functions:
 	/**
-	* This function tokenizes given strings and returns it as an array of strings.
-	* @param {String} str - String of text you want to tokenize.
-	* @returns {Array.<String>} Returns array of strings. The number of strings in this array is equal to number of words in input string parameter.
+	* Tokenizes given string.
+	* @param {String} str - String given to tokenize.
+	* @returns {Array.<String>} Array of tokens. The number of tokens is equal to number of words in input `str`.
 	* Only keeps words, skips all punctuation.
-	* Tokenizing contractions (i.e. don't) depends on which type you use. Type 'html' breaks contractions into 2 tokens.
+	* Tokenizing contractions (i.e. don't) depends on which type you use. Example: type `'html'` breaks contractions into 2 tokens.
 	* @example
 	* // import modules
 	* var analytics = require('qminer').analytics;
 	* var la = require('qminer').la;
 	* // construct model
-	* var tokenizer = new analytics.Tokenizer({ type: "simple" });
+	* var tokenizer = new analytics.Tokenizer();
 	* // string you wish to tokenize
 	* var string = "What a beautiful day!";
 	* // tokenize string using getTokens
@@ -1841,18 +1891,17 @@ public:
 	JsDeclareFunction(getTokens);
 
 	/**
-	* This function breaks text into sentences and returns them as an array of strings.
-	* @param {String} str - String of text you want to break into sentences.
-	* @returns {Array.<String>} Returns array of strings. The number of strings in this array is equal to number of sentences in input string parameter.
+	* Breaks string into sentences.
+	* @param {String} str - String given to break into sentences.
+	* @returns {Array.<String>} Array of sentences. The number of sentences is equal to number of sentences in input `str`.
 	* How function breaks sentences depends on where you use a full-stop, exclamation mark, question mark or the new line command.
 	* Careful: the space between the lines is not ignored. 
-	* With all 3 types this function returns sentences as they are.
 	* @example
 	* // import modules
 	* var analytics = require('qminer').analytics;
 	* var la = require('qminer').la;
 	* // construct model
-	* var tokenizer = new analytics.Tokenizer({ type: "simple" });
+	* var tokenizer = new analytics.Tokenizer();
 	* // string you wish to tokenize
 	* var string = "C++? Alright. Let's do this!";
 	* // tokenize text using getSentences
@@ -1864,17 +1913,16 @@ public:
 	JsDeclareFunction(getSentences);
 	
 	/**
-	* This function breaks text into paragraphs and returns them as an array of strings.
-	* @param {String} str - String of text you want to break into paragraphs.
-	* @returns {Array.<String>} Returns array of strings. The number of strings in this array is equal to number of paragraphs in input string parameter.
-	* When function detects commands '\n', '\r' or '\t' it breaks text as new paragraph.
-	* With all 3 types this function returns paragraphs as they are.
+	* Breaks string into paragraphs.
+	* @param {String} str - String given to break into paragraphs.
+	* @returns {Array.<String>} Array of paragraphs. The number of paragraphs is equal to number of paragraphs in input `str`.
+	* When function detects escape sequences `'\n'`, `'\r'` or `'\t'` it breaks text as new paragraph.
 	* @example
 	* // import modules
 	* var analytics = require('qminer').analytics;
 	* var la = require('qminer').la;
 	* // construct model
-	* var tokenizer = new analytics.Tokenizer({ type: "simple" });
+	* var tokenizer = new analytics.Tokenizer();
 	* // string you wish to tokenize
 	* var string = "Yes!\t No?\n Maybe...";
 	* // tokenize text using getParagraphs
@@ -1892,23 +1940,27 @@ public:
 
 /**
 * @typedef {Object} MDSParam
-* @property {number} [maxSecs=500] - The maximum time period to compute MDS of a matrix.
+* An object used for the construction of {@link module:analytics.MDS}.
+* @property {number} [maxSecs=500] - The maximum time period to compute Multidimensional Scaling of a matrix.
 * @property {number} [maxStep=5000] - The maximum number of iterations.
 * @property {number} [minDiff=1e-4] - The minimum difference criteria in MDS.
 * @property {string} [distType="Euclid"] - The type of distance used. Available types: "Euclid", "Cos", "SqrtCos".
 */
 
 /**
+* Multidimensional Scaling
 * @class
-* @classdesc Multidimensional scaling
-* @param {(module:analytics~MDSParam | module:fs.FIn)} [params] - The parameters for the construction.
+* @classdesc Scales a higher level vectors into a 2D vector space such that the distances between vectors are preserved as well as possible.
+* @param {module:analytics~MDSParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
+* <br>1. Using the parameter object {@link module:analytics~MDSParam},
+* <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import analytics module
 * var analytics = require('qminer').analytics;
 * // construct a MDS instance
 * var mds = new analytics.MDS({ maxStep: 300, distType: 'Cos' });
 */
-//# exports.MDS = function (params) { return Object.create(require('qminer').analytics.MDS.prototype); }
+//# exports.MDS = function (arg) { return Object.create(require('qminer').analytics.MDS.prototype); }
 class TNodeJsMDS : public node::ObjectWrap {
 	friend class TNodeJsUtil;
 public:
@@ -1945,7 +1997,7 @@ private:
 public:
 	/**
 	* Get the parameters.
-	* @returns {module:analytics~MDSParam} The json object containing the parameters of the instance.
+	* @returns {module:analytics~MDSParam} The constructor parameters.
 	* @example
 	* // import analytics module
 	* var analytics = require('qminer').analytics;
@@ -1960,7 +2012,8 @@ public:
 
 	/**
 	* Set the parameters.
-	* @param {module:analytics~MDSParam} params - The json object containing the parameters for the instance.
+	* @param {module:analytics~MDSParam} params - The constructor parameters.
+    * @returns {module:analytics.MDS} Self. The model parameters have been updated.
 	* @example
 	* // import analytics module
 	* var analytics = require('qminer').analytics;
@@ -1970,16 +2023,16 @@ public:
 	* // returns { maxStep: 5000, maxSecs: 300, minDiff: 1e-4, distType: "Euclid" }
 	* var params = mds.getParams();
 	*/
-	//# exports.MDS.prototype.setParams = function (params) { return { maxStep: 0, maxSecs: 0, minDiff: 0, distType: "" }; }
+	//# exports.MDS.prototype.setParams = function (params) { return Object.create(require('qminer').analytics.MDS.prototype); }
 	JsDeclareFunction(setParams);
 
 	/**
 	* Get the MDS of the given matrix.
-	* @param {(module:la.Matrix | module:la.SparseMatrix)} mat - The multidimensional matrix.
-	* @param {function} [callback] - The callback function receiving the error parameter (err) and the result parameter (result).
+	* @param {module:la.Matrix | module:la.SparseMatrix} mat - The multidimensional matrix.
+	* @param {function} [callback] - The callback function receiving the error parameter (`err`) and the result parameter (`res`).
 	* <i>Only for the asynchronous function.</i>
-	* @returns {module:la.Matrix} The matrix of dimensions mat.cols x 2, where the i-th row of the matrix is the 2d representation 
-	* of the i-th column of mat.
+	* @returns {module:la.Matrix} The matrix of dimensions `mat.cols` x 2, where the i-th row of the matrix is the 2D representation 
+	* of the i-th column of `mat`.
 	* @example <caption>Asynchronous function</caption>
 	* // import the modules
 	* var analytics = require('qminer').analytics;
@@ -1990,7 +2043,7 @@ public:
 	* var mat = new la.Matrix({ rows: 50, cols: 10, random: true });
 	* // get the 2d representation of mat 
 	* mds.fitTransformAsync(mat, function (err, res) {
-	*    if (err) { console.log(err); return }
+	*    if (err) throw err;
 	*    // successful calculation
 	*    var mat2d = res;
 	* }); 
@@ -2005,13 +2058,13 @@ public:
 	* // get the 2d representation of mat 
 	* var mat2d = mds.fitTransform(mat); 
 	*/
-	//# exports.MDS.prototype.fitTransform = function (mat) { return Object.create(require('qminer').la.Matrix.prototype); }
+	//# exports.MDS.prototype.fitTransform = function (mat, callback) { return Object.create(require('qminer').la.Matrix.prototype); }
 	JsDeclareSyncAsync(fitTransform, fitTransformAsync, TFitTransformTask);
 
 	/**
-	* Save the MDS.
+	* Save the MDS model.
 	* @param {module:fs.FOut} fout - The output stream.
-	* @returns {module:fs.FOut} The output stram fout.
+	* @returns {module:fs.FOut} The output stram `fout`.
 	* @example
 	* // import modules
 	* var analytics = require('qminer').analytics;
@@ -2041,34 +2094,38 @@ private:
 // QMiner-JavaScript-KMeans
 
 /**
-* @typedef {Object} KMeansParameters
+* @typedef {Object} KMeansParam
+* An object used for the construction of {@link module:analytics.KMeans}.
 * @property {number} [iter=10000] - The maximum number of iterations.
 * @property {number} [k=2] - The number of centroids.
-* @property {boolean} [allowEmpty=true] - wether to allow empty clusters to be generated
-* @property {string} [centroidType="Dense"] - The type of centroids. Options: "Dense" or "Sparse".
-* @property {string} [distanceType="Euclid"] - The distance type used at the calculations. Options: "Euclid" or "Cos".
-* @property {boolean} [verbose=false] - If false, the console output is supressed.
+* @property {boolean} [allowEmpty=true] - Whether to allow empty clusters to be generated.
+* @property {string} [centroidType="Dense"] - The type of centroids. Possible options are `'Dense'` and `'Sparse'`.
+* @property {string} [distanceType="Euclid"] - The distance type used at the calculations. Possible options are `'Euclid'` and `'Cos'`.
+* @property {boolean} [verbose=false] - If `false`, the console output is supressed.
 * @property {Array.<number>} [fitIdx] - The index array used for the construction of the initial centroids.
 * @property {Object} [fitStart] - The KMeans model returned by {@link module:analytics.KMeans.prototype.getModel} used for centroid initialization.
 * @property {(module:la.Matrix | module:la.SparseMatrix)} fitStart.C - The centroid matrix.
 */
 
 /** 
- * @classdesc KMeans clustering
- * @class
- * @param {(module:analytics~KMeansParameters |  module:fs.FIn)} [params] - The parameters for the construction.
- * @example
- * // import analytics and la modules
- * var analytics = require('qminer').analytics;
- * var la = require('qminer').la;
- * // create a KMeans object
- * var KMeans = new analytics.KMeans();
- * // create the matrix to be fitted
- * var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
- * // create the model
- * KMeans.fit(X);
- */
-//# exports.KMeans = function (params) { return Object.create(require('qminer').analytics.KMeans.prototype); }
+* KMeans Clustering 
+* @classdesc KMeans Clustering is an iterative, data-partitioning algorithm that assigns observations into K clusters.
+* @class
+* @param {module:analytics~KMeansParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
+* <br>1. Using the parameter object {@link module:analytics~KMeansParam},
+* <br>2. using the file input stream {@link module:fs.FIn}.
+* @example
+* // import analytics and la modules
+* var analytics = require('qminer').analytics;
+* var la = require('qminer').la;
+* // create a KMeans object
+* var KMeans = new analytics.KMeans();
+* // create the matrix to be fitted
+* var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+* // create the model
+* KMeans.fit(X);
+*/
+//# exports.KMeans = function (arg) { return Object.create(require('qminer').analytics.KMeans.prototype); }
 class TNodeJsKMeans : public node::ObjectWrap {
     friend class TNodeJsUtil;
 public:
@@ -2128,7 +2185,7 @@ public:
 
     /**
     * Returns the parameters.
-    * @returns {module:analytics~KMeansParameters} The construction parameters.
+    * @returns {module:analytics~KMeansParam} The construction parameters.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
@@ -2142,8 +2199,8 @@ public:
     
     /**
      * Sets the parameters.
-     * @param {module:analytics~KMeansParameters} params - The construction parameters.
-     * @returns {module:analytics.KMeans} Self.
+     * @param {module:analytics~KMeansParam} params - The construction parameters.
+     * @returns {module:analytics.KMeans} Self. The model parameters have been updated.
      * @example
      * // import analytics module
      * var analytics = require('qminer').analytics;
@@ -2156,9 +2213,9 @@ public:
     JsDeclareFunction(setParams);
 
     /**
-     * Computes the centroids.
-     * @param {(module:la.Matrix | module:la.SparseMatrix)} X - Matrix whose columns correspond to examples.
-     * @returns {module:analytics.KMeans} Self. It stores the info about the new model.
+     * Calculates the centroids.
+     * @param {module:la.Matrix | module:la.SparseMatrix} X - Matrix whose columns correspond to examples.
+     * @returns {module:analytics.KMeans} Self. The model has been updated.
      * @example <caption> Asynchronous function </caption>
      * // import analytics module
      * var analytics = require('qminer').analytics;
@@ -2168,9 +2225,7 @@ public:
      * var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
      * // create the model with the matrix X
      * KMeans.fitAsync(X, function (err) {
-     *     if (err) {
-     *         console.log(err);
-     *     }
+     *     if (err) throw err;
      *     // successful calculation
      * });
      *
@@ -2188,7 +2243,7 @@ public:
 
     /**
      * Returns an vector of cluster id assignments.
-     * @param {(module:la.Matrix | module:la.SparseMatrix)} A - Matrix whose columns correspond to examples.
+     * @param {module:la.Matrix | module:la.SparseMatrix} A - Matrix whose columns correspond to examples.
      * @returns {module:la.IntVector} Vector of cluster assignments.
      * @example
      * // import analytics module
@@ -2209,7 +2264,7 @@ public:
 
     /**
      * Transforms the points to vectors of squared distances to centroids.
-     * @param {(module:la.Matrix | module:la.SparseMatrix)} A - Matrix whose columns correspond to examples.
+     * @param {module:la.Matrix | module:la.SparseMatrix} A - Matrix whose columns correspond to examples.
      * @returns {module:la.Matrix} Matrix where each column represents the squared distances to the centroid vectors.
      * @example
      * // import modules
@@ -2235,8 +2290,8 @@ public:
 
     /**
      * Permutates the clusters, and with it {@link module:analytics.KMeans#centroids}, {@link module:analytics.KMeans#medoids} and {@link module:analytics.KMeans#idxv}.
-     * @param {module:la.IntVector} mapping - The mapping, where mapping[4] = 2 means "map cluster 4 into cluster 2".
-     * @returns {module:analytics.KMeans} Self with permutated clusters.
+     * @param {module:la.IntVector} mapping - The mapping, where `mapping[4] = 2` means "map cluster 4 into cluster 2".
+     * @returns {module:analytics.KMeans} Self. The clusters has been permutated.
      * @example 
      * // import the modules
      * var analytics = require('qminer').analytics;
@@ -2257,26 +2312,69 @@ public:
 
     /**
      * Saves KMeans internal state into (binary) file.
-     * @param {module:fs.FOut} Out - The output stream.
-     * @returns {module:fs.FOut} The output stream fout.
+     * @param {module:fs.FOut} fout - The output stream.
+     * @returns {module:fs.FOut} The output stream `fout`.
+     * @example
+     * // import the modules
+     * var analytics = require('qminer').analytics;
+     * var la = require('qminer').la;
+     * var fs = require('qminer').fs;
+     * // create a new KMeans object
+     * var KMeans = new analytics.KMeans({ iter: 1000, k: 3 });
+     * // create a matrix to be fitted
+     * var X = new la.Matrix([[1, -2, -1], [1, 1, -3]]);
+     * // create the model with the matrix X
+     * KMeans.fit(X); 
+     * // create the file output stream
+     * var fout = new fs.openWrite('KMeans.bin');
+     * // save the KMeans instance
+     * KMeans.save(fout);
+     * fout.close();
+     * // load the KMeans instance
+     * var fin = fs.openRead('KMeans.bin');
+     * var KMeans2 = new analytics.KMeans(fin);
      */
-    //# exports.KMeans.prototype.save = function (Out) { return Object.create(require('qminer').fs.FOut.prototype); }
+    //# exports.KMeans.prototype.save = function (fout) { return Object.create(require('qminer').fs.FOut.prototype); }
     JsDeclareFunction(save);
 
     /**
      * The centroids created with the fit method.
+     * @example
+     * // import the modules
+     * var analytics = require('qminer').analytics;
+     * var la = require('qminer').la;
+     * // create a new KMeans object
+     * var KMeans = new analytics.KMeans({ iter: 1000, k: 3 });
+     * // get the centroids
+     * var centroids = KMeans.centroids;
      */
     //# exports.KMeans.prototype.centroids = Object.create(require('qminer').la.Matrix.prototype);
     JsDeclareProperty(centroids);
 
     /**
     * The medoids created with the fit method.
+    * @example
+    * // import the modules
+    * var analytics = require('qminer').analytics;
+    * var la = require('qminer').la;
+    * // create a new KMeans object
+    * var KMeans = new analytics.KMeans({ iter: 1000, k: 3 });
+    * // get the centroids
+    * var medoids = KMeans.medoids;
     */
     //# exports.KMeans.prototype.medoids = Object.create(require('qminer').la.IntVector.prototype);
     JsDeclareProperty(medoids);
 
     /**
     * The integer vector containing the cluster ids of the training set created with the fit method.
+    * @example
+    * // import the modules
+    * var analytics = require('qminer').analytics;
+    * var la = require('qminer').la;
+    * // create a new KMeans object
+    * var KMeans = new analytics.KMeans({ iter: 1000, k: 3 });
+    * // get the idxv
+    * var idxv = KMeans.idxv;
     */
     //# exports.KMeans.prototype.idxv = Object.create(require('qminer').la.IntVector.prototype);
     JsDeclareProperty(idxv);
@@ -2291,7 +2389,8 @@ private:
 // QMiner-JavaScript-Recommender System
 
 /**
-* @typedef {Object} RecSysParams
+* @typedef {Object} RecSysParam
+* An object used for the construction of {@link module:analytics.RecommenderSys}.
 * @property {number} [iter=10000] - The maximum number of iterations.
 * @property {number} [k=2] - The number of centroids.
 * @property {number} [tol=1e-3] - The tolerance.
@@ -2299,9 +2398,13 @@ private:
 */
 
 /**
-* @classdesc Recommender System
+* Recommender System
+* @classdesc The recommender system algorithm using Weighted Non-negative Matrix Factorization to predict the 
+* unknown values. If `A` is a matrix with unknown values it calculates the matrices `U` and `V` such that `U*V` approximates `A`.
 * @class
-* @param {(module:analytics~RecSysParams |  module:fs.FIn)} [params] - The parameters for the construction.
+* @param {module:analytics~RecSysParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
+* <br>1. Using the parameter object {@link module:analytics~RecSysParam},
+* <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
 * // import analytics and la modules
 * var analytics = require('qminer').analytics;
@@ -2313,7 +2416,7 @@ private:
 * // create the model
 * recSys.fit(X);
 */
-//# exports.RecommenderSys = function (params) { return Object.create(require('qminer').analytics.RecommenderSys.prototype); }
+//# exports.RecommenderSys = function (arg) { return Object.create(require('qminer').analytics.RecommenderSys.prototype); }
 class TNodeJsRecommenderSys : public node::ObjectWrap {
 	friend class TNodeJsUtil;
 public:
@@ -2352,7 +2455,7 @@ public:
 
 	/**
 	* Returns the parameters.
-	* @returns {module:analytics~RecSysParams} The construction parameters.
+	* @returns {module:analytics~RecSysParam} The construction parameters.
 	* @example
 	* // import analytics module
 	* var analytics = require('qminer').analytics;
@@ -2366,8 +2469,8 @@ public:
 
 	/**
 	* Sets the parameters.
-	* @param {module:analytics~RecSysParams} params - The construction parameters.
-	* @returns {module:analytics.RecommenderSys} Self.
+	* @param {module:analytics~RecSysParam} params - The construction parameters.
+	* @returns {module:analytics.RecommenderSys} Self. The parameters has been updated.
 	* @example
 	* // import analytics module
 	* var analytics = require('qminer').analytics;
@@ -2381,8 +2484,9 @@ public:
 
 	/**
 	 * Gets the model.
-	 * @returns {Object} An object <b>json</b> containing the matrices json.U and json.V, for which the product gives the approximation of the fitted 
-	 * matrix.
+	 * @returns {Object} An object `recRes` containing the properties:
+     * <br>1. `recRes.U` - The matrix `U` from the weighted NMF. Type {@link module:la.Matrix}.
+     * <br>2. `recRes.V` - The matrix `V` from the weighted NMF. Type {@link module:la.Matrix}.
 	 * @example
 	 * // import modules
 	 * //var analytics = require('qminer').analytics;
@@ -2396,47 +2500,63 @@ public:
 	 * // get the model
 	 * //var model = recSys.getModel();
 	 */
-	//# exports.RecommenderSys.prototype.getModel = function (params) { return Object.create(require('qminer').analytics.RecommenderSys.prototype); }
+	//# exports.RecommenderSys.prototype.getModel = function () { return { U: Object.create(require('qminer').la.Matrix.prototype), V: Object.create(require('qminer').la.Matrix.prototype) }; }
 	JsDeclareFunction(getModel);
 
 	/**
 	* Fits the input matrix to the recommender model.
-	* @param {(module:la.Matrix | module:la.SparseMatrix)} A - Matrix with the ratings, where it A_ij element is the rating that the i-th person
+	* @param {module:la.Matrix | module:la.SparseMatrix} A - Matrix with the ratings, where it A_ij element is the rating that the i-th person
 	* gave to the j-th item. If A_ij = 0, the data doesn't exist.
 	* @returns {module:analytics.RecommenderSys} Self.
 	* @example <caption> Asynhronous function </caption>
 	* // import modules
-	* //var analytics = require('qminer').analytics;
-	* //var la = require('qminer').la;
+	* var analytics = require('qminer').analytics;
+	* var la = require('qminer').la;
 	* // create a new Recommender System object
-	* //var recSys = new analytics.RecommenderSys({ iter: 1000, k: 3 });
+	* var recSys = new analytics.RecommenderSys({ iter: 1000, k: 2 });
 	* // create a matrix to be fitted
-	* //var X = new la.Matrix([[1, 5, 0], [1, 0, 3]]);
+	* var X = new la.Matrix([[1, 5, 0], [1, 0, 3]]);
 	* // create the model with the matrix X
-	* //recSys.fitAsync(X, function (err) {
-	* //   if (err) { console.log(err); }
-	* //   // successful calculation
-	* //});
+	* recSys.fitAsync(X, function (err) {
+	*    if (err) { console.log(err); }
+	*    // successful calculation
+	* });
 	* @example <caption> Synhronous function </caption>
 	* // import modules
-	* //var analytics = require('qminer').analytics;
-	* //var la = require('qminer').la;
+	* var analytics = require('qminer').analytics;
+	* var la = require('qminer').la;
 	* // create a new Recommender System object
-	* //var recSys = new analytics.RecommenderSys({ iter: 1000, k: 3 });
+	* var recSys = new analytics.RecommenderSys({ iter: 1000, k: 2 });
 	* // create a matrix to be fitted
-	* //var X = new la.Matrix([[1, 5, 0], [1, 0, 3]]);
+	* var X = new la.Matrix([[1, 5, 0], [1, 0, 3]]);
 	* // create the model with the matrix X
-	* //recSys.fit(X);
+	* recSys.fit(X);
 	*/
 	//# exports.RecommenderSys.prototype.fit = function (A) { return Object.create(require('qminer').analytics.RecommenderSys.prototype); }
 	JsDeclareSyncAsync(fit, fitAsync, TFitTask);
 
 	/**
 	* Saves RecommenderSys internal state into (binary) file.
-	* @param {module:fs.FOut} Out - The output stream.
-	* @returns {module:fs.FOut} The output stream fout.
+	* @param {module:fs.FOut} fout - The output stream.
+	* @returns {module:fs.FOut} The output stream `fout`.
+    * @example
+    * // import modules
+	* var analytics = require('qminer').analytics;
+    * var fs = require('qminer').fs;
+	* // create a new Recommender System object
+	* var recSys = new analytics.RecommenderSys();
+	* // change the parameters of the Recommender System object
+	* recSys.setParams({ iter: 1000, k: 5 });
+    * // create the file output stream
+    * var fout = new fs.openWrite('recsys.bin');
+    * // save the RecommenderSys instance
+    * recSys.save(fout);
+    * fout.close();
+    * // load the RecommenderSys instance
+    * var fin = fs.openRead('recsys.bin');
+    * var recSys2 = new analytics.RecommenderSys(fin);
 	*/
-	//# exports.RecommenderSys.prototype.save = function (Out) { return Object.create(require('qminer').fs.FOut.prototype); }
+	//# exports.RecommenderSys.prototype.save = function (fout) { return Object.create(require('qminer').fs.FOut.prototype); }
 	JsDeclareFunction(save);
 
 private:

--- a/src/nodejs/analytics/analytics.h
+++ b/src/nodejs/analytics/analytics.h
@@ -139,8 +139,8 @@ private:
 // QMiner-JavaScript-Support-Vector-Classification
 
 /**
-* SVM constructor parameters. Used for the construction of {@link module:analytics.SVC} and {@link module:analytics.SVR}.
 * @typedef {Object} SVMParam
+* SVM constructor parameters. Used for the construction of {@link module:analytics.SVC} and {@link module:analytics.SVR}.
 * @property  {string} [algorithm='SGD'] - The algorithm procedure. Possible options are `'SGD'`, `'PR_LOQO'` and `'LIBSVM'`.
 * @property  {number} [c=1.0] - Cost parameter. Increasing the parameter forces the model to fit the training data more accurately (setting it too large may lead to overfitting) .
 * @property  {number} [j=1.0] - Unbalance parameter. Increasing it gives more weight to the positive examples (getting a better fit on the positive training examples gets a higher priority). Setting c=n is like adding n-1 copies of the positive training examples to the data set.
@@ -214,8 +214,7 @@ public:
 	//# exports.SVC.prototype.setParams = function(param) { return Object.create(require('qminer').analytics.SVC.prototype); };
 
 	/**	
-	* Gets the vector of coefficients of the linear model.
-	* @property {module:la.Vector} weights - Vector of coefficients of the linear model.
+	* Gets the vector of coefficients of the linear model. Type {@link module:la.Vector}.
 	* @example 
 	* // import the analytics and la modules
 	* var analytics = require('qminer').analytics;
@@ -394,8 +393,7 @@ public:
 	//# exports.SVR.prototype.setParams = function(param) { return Object.create(require('qminer').analytics.SVR.prototype); };
 
 	/**
-	* The vector of coefficients of the linear model.
-	* @returns {module:la.Vector} weights - Vector of coefficients of the linear model.
+	* The vector of coefficients of the linear model. Type {@link module:la.Vector}.
     * @example
     * // import the modules
 	* var analytics = require('qminer').analytics;
@@ -515,9 +513,10 @@ public:
 */
 
 /**
- * Ridge regression. Minimizes: `||A' x - b||^2 + ||gamma x||^2`. 
- * Uses {@link http://en.wikipedia.org/wiki/Tikhonov_regularization Tikhonov regularization}.
+ * Ridge Regression
  * @class
+ * @classdesc Ridge regression minimizes the value `||A' x - b||^2 + ||gamma x||^2`. 
+ * Uses {@link http://en.wikipedia.org/wiki/Tikhonov_regularization Tikhonov regularization}.
  * @param {module:analytics~ridgeRegParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
  * <br>1. Using the parameter object {@link  module:analytics~ridgeRegParam},
  * <br>2. using the file input stream {@link module:fs.FIn}.
@@ -661,7 +660,7 @@ public:
     JsDeclareFunction(predict);
     
     /**
-     * @property {module:la.Vector} weights - Vector of coefficients for linear regression.
+     * Vector of coefficients for linear regression. Type {@link module:la.Vector}.
      * @example
      * // import modules
 	 * var analytics = require('qminer').analytics;
@@ -712,9 +711,7 @@ public:
 /**
  * Sigmoid function (`y = 1/[1 + exp[-A*x + B]]`) fitted on decision function to mimic.
  * @class
- * @param {module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
-* <br>1. construction by default value (not giving an argument),
-* <br>2. using the file input stream {@link module:fs.FIn}.
+ * @param {module:fs.FIn} [arg] - Construction arguments.
  * @example
  * // import modules
  * la = require('qminer').la;
@@ -781,9 +778,9 @@ public:
 
 	/**
 	* Gets the model.
-	* @returns {Object} The object `sigRes` containing the properties:
-    * <br> `sigRes.A` - First value of the Sigmoid model,
-    * <br> `sigRes.B` - Second value of the Sigmoid model.
+	* @returns {Object} The object `sigModel` containing the properties:
+    * <br> `sigModel.A` - First value of the Sigmoid model,
+    * <br> `sigModel.B` - Second value of the Sigmoid model.
 	* @example
 	* // import analytics module
 	* var analytics = require('qminer').analytics;
@@ -1007,9 +1004,9 @@ public:
     
 	/**
 	* Returns the model.
-	* @returns {Object} The object `nnRes` containing the properties:
-	* <br> 1. `nnRes.rate` - The expected fraction of emmited anomalies.
-	* <br> 2. `nnRes.thresh` - Maximal squared distance to the nearest neighbor that is not anomalous.
+	* @returns {Object} The object `neighbourModel` containing the properties:
+	* <br> 1. `neighbourModel.rate` - The expected fraction of emmited anomalies.
+	* <br> 2. `neighbourModel.thresh` - Maximal squared distance to the nearest neighbor that is not anomalous.
 	* @example
 	* // import analytics module
 	* var analytics = require('qminer').analytics;
@@ -1110,7 +1107,7 @@ public:
 
 	/**
 	* @typedef {Object} NearestNeighborADExplain
-	* An object used for interpreting the predictions of {@link module:analytics.NearestNeighborAD}.
+	* An object used for interpreting the predictions of {@link module:analytics.NearestNeighborAD#explain}.
 	* @property {number} nearestID - The ID of the nearest neighbor.
 	* @property {number} distance - The distance to the nearest neighbor.
 	* @property {Array.<module:analytics~NearestNeighborADFeatureContribution>} features - An array with feature contributions.
@@ -1120,7 +1117,8 @@ public:
 
 	/**
 	* @typedef {Object} NearestNeighborADFeatureContribution
-	* An object explaining the prediction of {@link module:analytics.NearestNeighborAD} in terms of a single feature.
+	* An object explaining the prediction of {@link module:analytics.NearestNeighborAD#explain} in terms of a single feature.
+    * Contained in the object {@link module:analytics~NearestNeighborADExplain}.
 	* @property {number} id - The ID of the feature.
 	* @property {number} val - The value of the feature for the vector we are explaining.
 	* @property {number} nearVal - The the value of the feature for the nearest neighbor.
@@ -1150,7 +1148,7 @@ public:
 	JsDeclareFunction(explain);
 
 	/**
-	* Returns true when the model has enough data to initialize.
+	* Returns true when the model has enough data to initialize. Type `boolean`.
     * @example
     * // import modules
 	* var analytics = require('qminer').analytics;
@@ -1172,7 +1170,7 @@ public:
 // QMiner-JavaScript-Recursive-Linear-Regression
 
 /**
-* @typedef {Object} recLinearRegParam
+* @typedef {Object} recLinRegParam
 * An object used for the construction of {@link module:analytics.RecLinReg}.
 * @param {number} dim - The dimension of the model.
 * @param {number} [regFact=1.0] - The regularization factor.
@@ -1183,7 +1181,7 @@ public:
 * Recursive Linear Regression
 * @classdesc Holds the Recursive Linear Regression model.
 * @class
-* @param {module:analytics~recLinearRegParam | module:fs.FIn} arg - Construction arguments. There are two ways of constructing:
+* @param {module:analytics~recLinRegParam | module:fs.FIn} arg - Construction arguments. There are two ways of constructing:
 * <br>1. Using the parameter object {@link  module:analytics~detectorParam},
 * <br>2. using the file input stream {@link module:fs.FIn}.
 * @example
@@ -1269,7 +1267,7 @@ private:
 
 	/**
 	* Sets the parameters of the model.
-	* @param {module:analytics~recLinearRegParam} params - The new parameters of the model.
+	* @param {module:analytics~recLinRegParam} params - The new parameters of the model.
 	* @returns {module:analytics.RecLinReg} Self. The parameters are updated. Any previous model is set to default.
 	* @example
 	* // import analytics module
@@ -1284,7 +1282,7 @@ private:
 
 	/**
 	* Returns the parameters.
-	* @returns {module:analytics~recLinearRegParam} The parameters of the model.
+	* @returns {module:analytics~recLinRegParam} The parameters of the model.
 	* @example
 	* // import analytics module
 	* var analytics = require('qminer').analytics;
@@ -1297,7 +1295,7 @@ private:
 	JsDeclareFunction(getParams);
 
 	/**
-	* Gives the weights of the model.
+	* Gives the weights of the model. Type {@link module:la.Vector}.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
@@ -1316,7 +1314,7 @@ private:
 	JsDeclareProperty(weights);
 
 	/**
-	* Gets the dimensionality of the model.
+	* Gets the dimensionality of the model. Type `number`.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
@@ -1477,7 +1475,7 @@ public:
 	JsDeclareFunction(predict);
 
 	/**
-	 * Gives the weights of the model.
+	 * Gives the weights of the model. Type {@link module:la.Vector}.
      * @example 
      * // import modules
      * var analytics = require('qminer').analytics;
@@ -1640,7 +1638,7 @@ public:
 	JsDeclareFunction(predict);
 
 	/**
-	 * The models weights.
+	 * The models weights. Type {@link module:la.Vector}.
      * @example
      * // import modules
 	 * var analytics = require('qminer').analytics;
@@ -1689,13 +1687,13 @@ public:
 // QMiner-JavaScript-Neural-Networks
 
 /**
-* @typedef {Object} nnetParams
+* @typedef {Object} nnetParam
 * An object used for the construction of {@link module:analytics.NNet}.
 * @property {Array.<number>} [layout = [1, 2, 1]] - The array representing the network schema.
 * @property {number} [learnRate = 0.1] - The learning rate.
 * @property {number} [momentum = 0.5] - The momentum of optimization.
-* @property {string} [tFuncHidden = 'tanHyper'] - Type of activation function used on hidden nevrons. Possible options are: `'tanHyper'`, `'sigmoid'`, `'fastTanh'`, `'softPlus'`, `'fastSigmoid'` and `'linear'`.
-* @property {string} [tFuncOut = 'tanHyper'] - Type of activation function used on output nevrons. Possible options are: `'tanHyper'`, `'sigmoid'`, `'fastTanh'`, `'softPlus'`, `'fastSigmoid'` and `'linear'`.
+* @property {string} [tFuncHidden = 'tanHyper'] - Type of activation function used on hidden nevrons. Possible options are `'tanHyper'`, `'sigmoid'`, `'fastTanh'`, `'softPlus'`, `'fastSigmoid'` and `'linear'`.
+* @property {string} [tFuncOut = 'tanHyper'] - Type of activation function used on output nevrons. Possible options are `'tanHyper'`, `'sigmoid'`, `'fastTanh'`, `'softPlus'`, `'fastSigmoid'` and `'linear'`.
 */
 
 /**
@@ -2338,7 +2336,7 @@ public:
     JsDeclareFunction(save);
 
     /**
-     * The centroids created with the fit method.
+     * The centroids created with the fit method. Type {@link module:la.Matrix}.
      * @example
      * // import the modules
      * var analytics = require('qminer').analytics;
@@ -2352,7 +2350,7 @@ public:
     JsDeclareProperty(centroids);
 
     /**
-    * The medoids created with the fit method.
+    * The medoids created with the fit method. Type {@link module:la.IntVector}.
     * @example
     * // import the modules
     * var analytics = require('qminer').analytics;
@@ -2366,7 +2364,7 @@ public:
     JsDeclareProperty(medoids);
 
     /**
-    * The integer vector containing the cluster ids of the training set created with the fit method.
+    * The integer vector containing the cluster ids of the training set created with the fit method. Type {@link module:la.IntVector}.
     * @example
     * // import the modules
     * var analytics = require('qminer').analytics;
@@ -2484,9 +2482,9 @@ public:
 
 	/**
 	 * Gets the model.
-	 * @returns {Object} An object `recRes` containing the properties:
-     * <br>1. `recRes.U` - The matrix `U` from the weighted NMF. Type {@link module:la.Matrix}.
-     * <br>2. `recRes.V` - The matrix `V` from the weighted NMF. Type {@link module:la.Matrix}.
+	 * @returns {Object} An object `recSysModel` containing the properties:
+     * <br>1. `recSysModel.U` - The matrix `U` from the weighted NMF. Type {@link module:la.Matrix}.
+     * <br>2. `recSysModel.V` - The matrix `V` from the weighted NMF. Type {@link module:la.Matrix}.
 	 * @example
 	 * // import modules
 	 * //var analytics = require('qminer').analytics;
@@ -2507,7 +2505,7 @@ public:
 	* Fits the input matrix to the recommender model.
 	* @param {module:la.Matrix | module:la.SparseMatrix} A - Matrix with the ratings, where it A_ij element is the rating that the i-th person
 	* gave to the j-th item. If A_ij = 0, the data doesn't exist.
-	* @returns {module:analytics.RecommenderSys} Self.
+	* @returns {module:analytics.RecommenderSys} Self. The model has been fitted.
 	* @example <caption> Asynhronous function </caption>
 	* // import modules
 	* var analytics = require('qminer').analytics;

--- a/src/nodejs/fs/fs_nodejs.h
+++ b/src/nodejs/fs/fs_nodejs.h
@@ -99,119 +99,241 @@ private:
 public:
 
 	/**
-	* open file in read mode and return file input stream
+	* Open file in read mode and return file input stream.
 	* @param {string} fileName - File name.
 	* @returns {module:fs.FIn} Input stream.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // open file to write
+    * var fout = fs.openWrite('read_text.txt');
+    * // write to file
+    * fout.write('This is awesome!');
+    * // close the stream 
+    * fout.close();
+    * // open file to read
+    * var fin = fs.openWrite('read_text.txt');
 	*/
 	//# exports.openRead = function(fileName) { return Object.create(require('qminer').fs.FIn.prototype); }
     JsDeclareFunction(openRead);
     
 	/**
-	* open file in write mode and return file output stream
+	* Open file in write mode and return file output stream.
 	* @param {string} fileName - File name.
 	* @returns {module:fs.FOut} Output stream.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // open file to write
+    * var fout = fs.openWrite('write_text.txt');
+    * // close the stream 
+    * fout.close();
 	*/
 	//# exports.openWrite = function(fileName) { return Object.create(require('qminer').fs.FOut.prototype); }
     JsDeclareFunction(openWrite);
 	
 	/**
-	* open file in append mode and return file output stream
+	* Open file in append mode and return file output stream.
 	* @param {string} fileName - File name.
 	* @returns {module:fs.FOut} Output stream.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // open file to write
+    * var fout = fs.openWrite('append_text.txt');
+    * // close the stream
+    * fout.close();
+    * // open file in append mode
+    * var foutAppend = fs.openAppend('append_text.txt');
+    * // close the stream
+    * foutAppend.close();
 	*/
 	//# exports.openAppend = function(fileName) { return Object.create(require('qminer').fs.FOut.prototype); }	
 	JsDeclareFunction(openAppend);
 	
 	/**
-	* checks if the file exists
+	* Checks if the file exists.
 	* @param {string} fileName - File name.
 	* @returns {boolean} True if file exists.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // check if a file exists
+    * fs.exists('text.txt');
 	*/
 	//# exports.exists = function(fileName) { return false; }	
     JsDeclareFunction(exists);
 	
 	/**
-	* copies a file
+	* Copies a file.
 	* @param {string} source - Source file name.
 	* @param {string} dest - Destination file name.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // open file to write
+    * var fout = fs.openWrite('text.txt');
+    * // close the stream
+    * fout.close();
+    * // copy the file
+    * var destination = fs.copy('text.txt', 'copy.txt');
 	*/
-	//# exports.copy = function(source, dest) {}	
+	//# exports.copy = function(source, dest) { return ""; }	
     JsDeclareFunction(copy);
 	
 	/**
-	* moves a file
+	* Moves a file.
 	* @param {string} source - Source file name.
 	* @param {string} dest - Destination file name.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // open file to write
+    * var fout = fs.openWrite('text.txt');
+    * // close the stream
+    * fout.close();
+    * // move the file
+    * var destination = fs.move('text.txt', 'move.txt');
 	*/
-	//# exports.move = function(source, dest) {}
+	//# exports.move = function(source, dest) { return ""; }
 	JsDeclareFunction(move);
 	
 	/**
-	* deletes a file
+	* Deletes a file.
 	* @param {string} fileName - File name.
 	* @returns {boolean} True if delete succeeded.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // open file to write
+    * var fout = fs.openWrite('delete.txt');
+    * // close the stream
+    * fout.close();
+    * // delete the file
+    * var destination = fs.del('delete.txt');
 	*/
 	//# exports.del = function(fileName) { return false; }	
     JsDeclareFunction(del);
 	
 	/**
-	* renames a file
+	* Renames a file.
 	* @param {string} source - Source file name.
 	* @param {string} dest - Destination file name.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // open file to write
+    * var fout = fs.openWrite('text.txt');
+    * // close the stream
+    * fout.close();
+    * // rename the file
+    * if (fs.exists('rename.txt')) {
+    *    fs.del('rename.txt');
+    * }
+    * var destination = fs.rename('text.txt', 'rename.txt');
 	*/
-	//# exports.rename = function(source, dest) {}
+	//# exports.rename = function(source, dest) { return ""; }
     JsDeclareFunction(rename);
 
 	/**
-	* Information about the file
 	* @typedef {Object} FileInfo 	
-	* @property  {string} FileInfo.createTime - Create time.
-	* @property  {string} FileInfo.lastAccessTime - Last access time.
-	* @property  {string} FileInfo.lastWriteTime - Last write time.
-	* @property  {number} FileInfo.size - File size in bytes.	
+    * Information about the file.
+	* @property  {string} createTime - Create time.
+	* @property  {string} lastAccessTime - Last access time.
+	* @property  {string} lastWriteTime - Last write time.
+	* @property  {number} size - File size in bytes.	
 	*/	
 	
 	/**
-	* returns the file info
+	* Returns the file info.
 	* @param {string} fileName - File name.
 	* @returns {module:fs~FileInfo} File info object.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // open file to write
+    * var fout = fs.openWrite('text.txt');
+    * // close the stream
+    * fout.close();
+    * // get the file info
+    * var info = fs.fileInfo('text.txt');
 	*/
 	//# exports.fileInfo = function(fileName) { return { createTime : "",  lastAccessTime: "", lastWriteTime: "", size: 0 }}	
     JsDeclareFunction(fileInfo);
 	
 	/**
-	* Creates a folder
+	* Creates a folder.
 	* @param {string} dirName - Folder name.
 	* @returns {boolean} True if succeeded.
+    * @example
+    // import fs module
+    * var fs = require('qminer').fs;
+    * // create a folder
+    * var makeFolder = fs.mkdir('folder');
 	*/
 	//# exports.mkdir = function(dirName) { return false; }	
     JsDeclareFunction(mkdir);
 	
 	/**
-	* Removes a folder
+	* Removes a folder.
 	* @param {string} dirName - Folder name.
 	* @returns {boolean} True if succeeded.
+    * @example
+    // import fs module
+    * var fs = require('qminer').fs;
+    * // create a folder
+    * var makeFolder = fs.mkdir('folder');
+    * // delete folder
+    * if (makeFolder) {
+    *    fs.rmdir('folder');
+    * }
 	*/
 	//# exports.rmdir = function(dirName) { return false; }
     JsDeclareFunction(rmdir);
 	
 	/**
-	* Returns a list fo files in the folder
+	* Returns a list fo files in the folder.
 	* @param {string} dirName - Folder name.
 	* @param {string} [fileExtension] - Results are filtered by file extension.
 	* @param {boolean} [recursive=false] - Recursively searches for file names if true.
-	* @returns {string[]} Array of file names.
+	* @returns {Array.<string>} Array of file names.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // get the names of all files
+    * var fileNames = fs.listFile('./');
 	*/
 	//# exports.listFile = function(dirName, fileExtension, recursive) { return ['']; }
     JsDeclareFunction(listFile);
 
     /**
      * Reads a buffer line by line and calls a callback for each line.
-     *
-     * @param {String|FIn|Buffer} buffer - name of the file, input stream of a Node.js buffer
-     * @param {function} onLine - a callback that gets called on each line (for example: function (line) {})
-     * @param {function} onEnd - a callback that gets returned after all the lines have been read
-     * @param {function} onError - a callback that gets called if an error occurs
+     * @param {String | module:fs.FIn | Buffer} buffer - Name of the file, input stream of a Node.js buffer.
+     * @param {function} onLine - A callback that gets called on each line (for example: `function (line) {}`).
+     * @param {function} onEnd - A callback that gets returned after all the lines have been read.
+     * @param {function} onError - A callback that gets called if an error occurs.
+     * @example
+     * // import fs module
+     * var fs = require('qminer').fs;
+     * // create a file and write some lines
+     * var fout = fs.openWrite('poem.txt');
+     * fout.write('I dig,\nYou dig,\nHe digs,\nShe digs,\nWe dig,\nThey dig.\n It\'s not a beautiful poem, but it\'s deep.');
+     * fout.close();
+     * // open the file in read mode
+     * var fin = fs.openRead('poem.txt');
+     * // read the file line by line and call functions
+     * //var numberOfLines = 0;
+     * //function onLine(line) {
+     * //    console.log(line);
+     * //    numberOfLines += 1;
+     * //}
+     * //function onEnd(line) {
+     * //    console.log("Number of lines", numberOfLines);
+     * //}
+     * //function onError(err) {
+     * //    console.log(err);
+     * //}
+     * //fs.readLines(fin, onLine, onEnd, onError);
      */
     //# exports.readLines = function (buffer, onLine, onEnd, onError) {}
     JsDeclareFunction(readLines);
@@ -252,76 +374,181 @@ private:
 	* Input file stream.
 	* @classdesc Used for reading files.
 	* @class
-	* @param {string} fileName - File name
+	* @param {string} fileName - File name.
 	* @example
 	* // import module
 	* var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = fs.openWrite('file.txt');
+    * // write sync and close
+    * fout.writeLine('example text');
+    * fout.close();
 	* // open file in read mode
 	* var fin = new fs.FIn('file.txt');
 	* // read a line
 	* var str = fin.readLine();
 	*/
-	//# exports.FIn = function(fnm) {}	
+	//# exports.FIn = function(fileName) { return Object.create(require('qminer').fs.FIn.prototype); }	
 	// parses arguments, called by javascript constructor 
 	static TNodeJsFIn* NewFromArgs(const v8::FunctionCallbackInfo<v8::Value>& Args);
 public:
 	/**
-	* Peeks a character
+	* Peeks a character.
 	* @returns {string} Character string.
+    * @example
+    * // import module
+    * var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = fs.openWrite('file.txt');
+    * // write sync and close
+    * fout.writeLine('example text');
+    * fout.close();
+    * // open file in read mode
+    * var fin = new fs.FIn('file.txt');
+    * // peek the next character
+    * var char = fin.peekCh();
 	*/
 	//# exports.FIn.prototype.peekCh= function() { return ''; }
 	JsDeclareFunction(peekCh);	
 	
 	/**
-	* Reads a character
+	* Reads a character.
 	* @returns {string} Character string.
+    * @example
+    * // import module
+    * var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = fs.openWrite('file.txt');
+    * // write sync and close
+    * fout.writeLine('example text');
+    * fout.close();
+    * // open file in read mode
+    * var fin = new fs.FIn('file.txt');
+    * // get the next character
+    * var char = fin.getCh();
 	*/
 	//# exports.FIn.prototype.getCh= function() { return ''; }
 	JsDeclareFunction(getCh);
 	
 	/**
-	* Reads a line	
+	* Reads a line.
 	* @returns {string} Line string.
+    * @example
+    * // import module
+    * var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = fs.openWrite('file.txt');
+    * // write sync and close
+    * fout.writeLine('example text');
+    * fout.close();
+    * // open file in read mode
+    * var fin = new fs.FIn('file.txt');
+    * // get/read a new line
+    * var line = fin.readLine();
 	*/
 	//# exports.FIn.prototype.readLine = function() { return ''; }
 	JsDeclareFunction(readLine);
     
 	/**
 	* Reads a string that was serialized using `fs.FOut.writeBinary`.
-	* @returns {string} String
+	* @returns {string} String.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // read a string that was serialized using fs.FOut.writeBinary
 	*/
     //# exports.FIn.prototype.readString = function() { return ''; }
     JsDeclareFunction(readString);
 	
 	/**
-	* @property {boolean} eof - True if end of file is detected.
+	* True if end of file is detected. Otherwise, false. Type `boolean`.
+    * @example
+    * // import module
+    * var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = fs.openWrite('file.txt');
+    * // write sync and close
+    * fout.writeLine('example text');
+    * fout.close();
+    * // open file in read mode
+    * var fin = new fs.FIn('file.txt');
+    * // check if it's end of the file
+    * var eof = fin.eof;
 	*/
 	//# exports.FIn.prototype.eof = false;
 	JsDeclareProperty(eof);
 
 	/**
-	* @property {number} length - Length of input stream.
+	* Length of input stream. Type `number`.
+    * @example
+    * // import module
+    * var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = fs.openWrite('file.txt');
+    * // write sync and close
+    * fout.writeLine('example text');
+    * fout.close();
+    * // open file in read mode
+    * var fin = new fs.FIn('file.txt');
+    * // get the length of the document
+    * var len = fin.length;
 	*/
 	//# exports.FIn.prototype.length = 0;
 	JsDeclareProperty(length);
 
 	/**
-	* Reads the whole stream
+	* Reads the whole stream.
 	* @returns {string} Content of the file.
+    * @example
+    * // import module
+    * var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = fs.openWrite('file.txt');
+    * // write sync and close
+    * fout.writeLine('example text');
+    * fout.close();
+    * // open file in read mode
+    * var fin = new fs.FIn('file.txt');
+    * // get/read a the whole string
+    * var all = fin.readAll();
 	*/
 	//# exports.FIn.prototype.readAll = function() { return ''; }
 	JsDeclareFunction(readAll);
 
 	/**
 	* Closes the input stream.
+    * @example
+    * // import module
+    * var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = fs.openWrite('file.txt');
+    * // write sync and close
+    * fout.writeLine('example text');
+    * fout.close();
+    * // open file in read mode
+    * var fin = new fs.FIn('file.txt');
+    * // close the stream
+    * fin.close();
 	*/
-	//# exports.FIn.prototype.close = function() { return ''; }
+	//# exports.FIn.prototype.close = function() { }
 	JsDeclareFunction(close);
 
 	/**
 	* Checks if the input stream is closed.
+    * @example
+    * // import module
+    * var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = fs.openWrite('file.txt');
+    * // write sync and close
+    * fout.writeLine('example text');
+    * fout.close();
+    * // open file in read mode
+    * var fin = new fs.FIn('file.txt');
+    * // check if the stream is closed
+    * var check = fin.isClosed();
 	*/
-	//# exports.FIn.prototype.isClosed = function() { return ''; }
+	//# exports.FIn.prototype.isClosed = function() { return false; }
 	JsDeclareFunction(isClosed);
 };
 
@@ -348,8 +575,8 @@ public:
 	* Output file stream.
 	* @classdesc Used for writing files.
 	* @class
-	* @param {String} fileName - File name
-	* @param {boolean} [append=false] - Append flag
+	* @param {String} fileName - File name.
+	* @param {boolean} [append=false] - Append flag.
 	* @example
 	* // import module
 	* var fs = require('qminer').fs;
@@ -364,38 +591,80 @@ public:
 	static TNodeJsFOut* NewFromArgs(const v8::FunctionCallbackInfo<v8::Value>& Args);
 public:
 	/**
-	* Writes a string or number or a JSON object in human readable form
-	* @param {(String | Number | Object)} arg - Argument to write
+	* Writes a string or number or a JSON object in human readable form.
+	* @param {(String | Number | Object)} arg - Argument to write.
 	* @returns {module:fs.FOut} Self.
+    * @example
+	* // import module
+	* var fs = require('qminer').fs;
+	* // open file in write mode
+	* var fout = new fs.FOut('file.txt');
+	* // write a string
+	* fout.write('example text');
+    * // close
+    * fout.close();
 	*/
 	//# exports.FOut.prototype.write = function(arg) { return this; }
 	JsDeclareFunction(write);
 
 	/**
-	* Writes a string or number or a JSON object in binary form
-	* @param {(String | Number | Object)} str - Argument to write
+	* Writes a string or number or a JSON object in binary form.
+	* @param {(String | Number | Object)} str - Argument to write.
 	* @returns {module:fs.FOut} Self.
+    * @example
+    * // import fs module
+    * var fs = require('qminer').fs;
+    * // save a string in binary form
 	*/
 	//# exports.FOut.prototype.writeBinary = function(arg) { return this; }
 	JsDeclareFunction(writeBinary);
 
 	/**
-	* Writes a string and adds a new line
-	* @param {String} str - String to write
+	* Writes a string and adds a new line.
+	* @param {String} str - String to write.
 	* @returns {module:fs.FOut} Self.
+    * @example
+    * // import module
+    * var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = new fs.FOut('file.txt');
+    * // write a line
+    * fout.writeLine('example text');
+    * // close
+    * fout.close();
 	*/
 	//# exports.FOut.prototype.writeLine = function(str) { return this; }
     JsDeclareFunction(writeLine);
     
 	/**
-	* Flushes the output stream
+	* Flushes the output stream.
 	* @returns {module:fs.FOut} Self.
+    * @example
+    * // import module
+    * var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = new fs.FOut('file.txt');
+    * // write a line
+    * fout.writeLine('example text');
+    * // flush the stream
+    * fout.flush();
+    * // close
+    * fout.close();
 	*/
 	//# exports.FOut.prototype.flush = function() { return this; }
     JsDeclareFunction(flush);
 
 	/**
-	* Closes the output stream
+	* Closes the output stream.
+    * @example
+    * // import module
+    * var fs = require('qminer').fs;
+    * // open file in write mode
+    * var fout = new fs.FOut('file.txt');
+    * // write a line
+    * fout.writeLine('example text');
+    * // close
+    * fout.close();
 	*/
 	//# exports.FOut.prototype.close = function() {}
     JsDeclareFunction(close);

--- a/src/nodejs/ht/IntFltDocData.js
+++ b/src/nodejs/ht/IntFltDocData.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 exports.view = {
-	"title" : "Integer-Float hashmap",
+	"title" : "Integer-Float hashmap.",
 	"className" : "IntFltMap",
 	"key1" : "5",
 	"val1" : "10.5",

--- a/src/nodejs/ht/IntIntDocData.js
+++ b/src/nodejs/ht/IntIntDocData.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 exports.view = {
-	"title" : "Integer-Integer hashmap",
+	"title" : "Integer-Integer hashmap.",
 	"className" : "IntIntMap",
 	"key1" : "5",
 	"val1" : "10",

--- a/src/nodejs/ht/IntStrDocData.js
+++ b/src/nodejs/ht/IntStrDocData.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 exports.view = {
-	"title" : "Int-string hashmap",
+	"title" : "Int-string hashmap.",
 	"className" : "IntStrMap",
 	"key1" : "10",
 	"val1" : "'foo'",

--- a/src/nodejs/ht/StrFltDocData.js
+++ b/src/nodejs/ht/StrFltDocData.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 exports.view = {
-	"title" : "String-Float hashmap",
+	"title" : "String-Float hashmap.",
 	"className" : "StrFltMap",
 	"key1" : "'foo'",
 	"val1" : "10.5",

--- a/src/nodejs/ht/StrIntDocData.js
+++ b/src/nodejs/ht/StrIntDocData.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 exports.view = {
-	"title" : "String-Integer hashmap",
+	"title" : "String-Integer hashmap.",
 	"className" : "StrIntMap",
 	"key1" : "'foo'",
 	"val1" : "10",

--- a/src/nodejs/ht/StrStrDocData.js
+++ b/src/nodejs/ht/StrStrDocData.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 exports.view = {
-	"title" : "String-string hashmap",
+	"title" : "String-string hashmap.",
 	"className" : "StrStrMap",
 	"key1" : "'foo'",
 	"val1" : "'bar'",

--- a/src/nodejs/ht/htDocHead.js
+++ b/src/nodejs/ht/htDocHead.js
@@ -5,6 +5,7 @@
  * This source code is licensed under the FreeBSD license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /**
 * Hashtable module.
 * @module ht

--- a/src/nodejs/ht/ht_nodejs.h
+++ b/src/nodejs/ht/ht_nodejs.h
@@ -311,6 +311,7 @@ public:
     * fout = fs.openWrite('map.dat'); // open write stream
     * h.save(fout).close(); // save and close write stream
     * var fin = fs.openRead('map.dat'); // open read stream
+    * var h2 = new ht.<% className %>();
     * h2.load(fin); // load
 	*/
     //# exports.<% className %>.prototype.load = function(fin) { return this; }

--- a/src/nodejs/ht/ht_nodejs.h
+++ b/src/nodejs/ht/ht_nodejs.h
@@ -256,7 +256,15 @@ public:
     JsDeclareFunction(hasKey);
 	
 	/**
-    * @property {number} length - Number of key/dat pairs.
+    * Number of key/dat pairs. Type `number`.
+    * @example
+    * // create a new hashtable
+	* ht = require('qminer').ht;
+	* var h = new ht.<% className %>();
+	* // Adding two key/dat pairs
+	* h.put(<% key1 %>, <% val1 %>);
+    * // get the number of key/dat pairs
+    * var length = h.length; // returns 1
 	*/
 	//# exports.<% className %>.prototype.length = 0;
 	JsDeclareProperty(length);

--- a/src/nodejs/ht/ht_nodejs.h
+++ b/src/nodejs/ht/ht_nodejs.h
@@ -203,80 +203,168 @@ public:
 	JsDeclareFunction(New);	
 	
 	/**
-	* Returns dat given key
+	* Returns dat given key.
 	* @param {<% keyType %>} key - Hashmap key.
 	* @returns {<% datType %>} Hashmap data.
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var ht = qm.ht;
+    * // create a new hashtable
+    * var h = new ht.<% className %>();
+    * // add a key/dat pair
+    * h.put(<% key1 %>, <% val1 %>);
+    * // get the newly added data
+    * var val = h.get(<% key1 %>); // returns <% val1 %>
 	*/
     //# exports.<% className %>.prototype.get = function(key) { return <% defaultVal %>; }
     JsDeclareFunction(get);
 	
 	/**
-	* add/update key-value pair
+	* add/update key-value pair.
 	* @param {<% keyType %>} key - Hashmap key.
 	* @param {<% datType %>} data - Hashmap data.
 	* @returns {module:ht.<% className %>} Self.
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var ht = qm.ht;
+    * // create a new hashtable
+    * var h = new ht.<% className %>();
+    * // add a key/dat pair
+    * h.put(<% key1 %>, <% val1 %>);
 	*/
     //# exports.<% className %>.prototype.put = function(key, data) { return this; }
     JsDeclareFunction(put);    
 	
 	/**
-	* returns true if the map has a given key 
+	* Returns true if the map has a given key.
 	* @param {<% keyType %>} key - Hashmap key.	
-	* @returns {boolean} True if the map contains key.
+	* @returns {boolean} True if the map contains key. Otherwise, false.
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var ht = qm.ht;
+    * // create a new hashtable
+    * var h = new ht.<% className %>();
+    * // add a key/dat pair
+    * h.put(<% key1 %>, <% val1 %>);
+    * // check if the hashtable has the key
+    * h.hasKey(<% key1 %>); // returns true
 	*/
     //# exports.<% className %>.prototype.hasKey = function(key) { return false; }
     JsDeclareFunction(hasKey);
 	
 	/**
-    * @property {number} length - Number of key/dat pairs
+    * @property {number} length - Number of key/dat pairs.
 	*/
 	//# exports.<% className %>.prototype.length = 0;
 	JsDeclareProperty(length);
     
 	/**
-	* returns n-th key
-	* @param {number} n - Hashmap key number. Should be between 0 and length-1.	
-	* @returns {<% keyType %>} n-th key.
+	* Returns n-th key.
+	* @param {number} n - Hashmap key index number. Should be between 0 and length-1.	
+	* @returns {<% keyType %>} The n-th key.
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var ht = qm.ht;
+    * // create a new hashtable
+    * var h = new ht.<% className %>();
+    * // add a key/dat pair
+    * h.put(<% key1 %>, <% val1 %>);
+    * // get the first key
+    * var key = h.key(0); // returns <% key1 %>
 	*/
     //# exports.<% className %>.prototype.key = function(n) { return <% defaultKey %>; }	
     JsDeclareFunction(key);
 
 	/**
-	* returns n-th dat
-	* @param {number} n - Hashmap dat number. Should be between 0 and length-1
-	* @returns {<% datType %>} n-th data value.
+	* Returns n-th dat.
+	* @param {number} n - Hashmap dat index number. Should be between 0 and length-1.
+	* @returns {<% datType %>} The n-th data value.
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var ht = qm.ht;
+    * // create a new hashtable
+    * var h = new ht.<% className %>();
+    * // add a key/dat pair
+    * h.put(<% key1 %>, <% val1 %>);
+    * // get the first dat
+    * var key = h.key(0); // returns <% val1 %>
 	*/
     //# exports.<% className %>.prototype.dat = function(n) { return <% defaultVal %>; }
     JsDeclareFunction(dat);
     
 	/**
-	* loads the hashtable from input stream
+	* Loads the hashtable from input stream.
 	* @param {module:fs.FIn} fin - Input stream.	
 	* @returns {module:ht.<% className %>} Self.
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var ht = qm.ht;
+    * var fs = qm.fs;
+    * // create a new hashtable
+    * var h = new ht.<% className %>();
+    * fout = fs.openWrite('map.dat'); // open write stream
+    * h.save(fout).close(); // save and close write stream
+    * var fin = fs.openRead('map.dat'); // open read stream
+    * h2.load(fin); // load
 	*/
     //# exports.<% className %>.prototype.load = function(fin) { return this; }
     JsDeclareFunction(load);
 
 	/**
-	* saves the hashtable to output stream
+	* Saves the hashtable to output stream.
 	* @param {module:fs.FOut} fout - Output stream.	
 	* @returns {module:fs.FOut} fout.
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var ht = qm.ht;
+    * var fs = qm.fs;
+    * // create a new hashtable
+    * var h = new ht.<% className %>();
+    * fout = fs.openWrite('map.dat'); // open write stream
+    * h.save(fout).close(); // save and close write stream
 	*/
     //# exports.<% className %>.prototype.save = function(fout) { return Object.create(require('qminer').fs.FOut.prototype); }
     JsDeclareFunction(save);
 
 	/**
-	* sorts by keys
-	* @param {boolean} [asc=true] - Sort in ascending order?
+	* Sorts by keys.
+	* @param {boolean} [asc=true] - If true, sorts in ascending order.
 	* @returns {module:ht.<% className %>} Self.
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var ht = qm.ht;
+    * // create a new hashtable
+    * var h = new ht.<% className %>();
+    * h.put(<% key1 %>, <% val1 %>);
+    * h.put(<% key2 %>, <% val2 %>);
+    * // sort the hashtable by keys
+    * h.sortKey();
 	*/
 	//# exports.<% className %>.prototype.sortKey = function(asc) { return this; }
 	JsDeclareFunction(sortKey);
 
 	/**
-	* sorts by values
-	* @param {boolean} [asc=true] - Sort in ascending order?
+	* Sorts by dat.
+	* @param {boolean} [asc=true] - If true, sorts in ascending order.
 	* @returns {module:ht.<% className %>} Self.
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var ht = qm.ht;
+    * // create a new hashtable
+    * var h = new ht.<% className %>();
+    * h.put(<% key1 %>, <% val1 %>);
+    * h.put(<% key2 %>, <% val2 %>);
+    * // sort the hashtable by dat
+    * h.sortDat();
 	*/
 	//# exports.<% className %>.prototype.sortDat = function(asc) { return this; }
 	JsDeclareFunction(sortDat);

--- a/src/nodejs/ht/ht_nodejs.h
+++ b/src/nodejs/ht/ht_nodejs.h
@@ -176,7 +176,7 @@ public:
 
 	/**
 	* <% title %> 
-	* @classdesc Used for storing key/data pairs, wrapps an efficient C++ implementation.
+	* @classdesc Used for storing key/data pairs, wraps an efficient C++ implementation.
 	* @class
 	* @example
 	* // create a new hashtable
@@ -221,7 +221,7 @@ public:
     JsDeclareFunction(get);
 	
 	/**
-	* add/update key-value pair.
+	* Add/update key-value pair.
 	* @param {<% keyType %>} key - Hashmap key.
 	* @param {<% datType %>} data - Hashmap data.
 	* @returns {module:ht.<% className %>} Self.

--- a/src/nodejs/la/BoolVectorDocData.js
+++ b/src/nodejs/la/BoolVectorDocData.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 exports.view = {
-    "title": "Vector - array of boolean",
+    "title": "Vector - array of boolean.",
     "className": "BoolVector",
     "elementType": "boolean",
 
@@ -16,12 +16,15 @@ exports.view = {
     "output2": "[true, false, true]",
     "output3": "[true]",
 
+	"val1": "false",
+	
     "sortCallback": "boolVectorCompareCb",
     "exampleSort": "[true, false, false]",
     "inputSort": "function(arg1, arg2) { return arg2; }",
     "outputSort": "[false, true, true]",
     "outputSortAsc": "[false, true, true]",
     
+	"skipSubVec": "skip.",
     "skipInner": "skip.",
     "skipSum": "skip.",
     "skipGetMaxIdx": "skip.",

--- a/src/nodejs/la/IntVectorDocData.js
+++ b/src/nodejs/la/IntVectorDocData.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 exports.view = {
-    "title": "Vector - array of integers",
+    "title": "Vector - array of integers.",
     "className": "IntVector",
     "elementType": "number",
 
@@ -16,12 +16,15 @@ exports.view = {
     "output2": "[1, 4, 5]",
     "output3": "[1]",
 
+	"val1": "10",
+	
     "sortCallback": "intVectorCompareCb",
     "exampleSort": "[-2, 1, 3]",
     "inputSort": "function(arg1, arg2) { return Math.abs(arg1) - Math.abs(arg2); }",
     "outputSort": "[1, -2, 3]",
     "outputSortAsc": "[-2, 1, 3]",
 
+	"skipSubVec": "",
     "skipInner": "skip.",
     "skipSum": "",
     "skipGetMaxIdx": "",

--- a/src/nodejs/la/StrVectorDocData.js
+++ b/src/nodejs/la/StrVectorDocData.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 exports.view = {
-	"title" : "Vector - array of strings",
+	"title" : "Vector - array of strings.",
 	"className" : "StrVector",
 	"elementType": "string",
 
@@ -16,12 +16,15 @@ exports.view = {
     "output2": "['a', 'd', 'e']",
     "output3": "['a']",
 	
+	"val1": "'xyz'",
+	
 	"sortCallback": "strVectorCompareCb",
     "exampleSort": "['asd', 'z', 'kkkk']",
     "inputSort": "function(arg1, arg2) { return arg1.length - arg2.length; }",
     "outputSort": "['z', 'asd', 'kkkk']",
     "outputSortAsc": "['asd', 'kkkk', 'z']",
 
+	"skipSubVec": "",
 	"skipInner": "skip.",
 	"skipSum": "skip.",
 	"skipGetMaxIdx": "skip.",

--- a/src/nodejs/la/VectorDocData.js
+++ b/src/nodejs/la/VectorDocData.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 exports.view = {
-	"title" : "Vector - array of doubles",
+	"title" : "Vector - array of doubles.",
 	"className" : "Vector",
 	"elementType": "number",
 
@@ -16,12 +16,15 @@ exports.view = {
 	"output2": "[1, 4, 5]",
     "output3": "[1]",
 
+	"val1": "10",
+	
 	"sortCallback": "vectorCompareCb",
     "exampleSort": "[-2.0, 1.0, 3.0]",
     "inputSort": "function(arg1, arg2) { return Math.abs(arg1) - Math.abs(arg2); }",
     "outputSort": "[1.0, -2.0, 3.0]",
     "outputSortAsc": "[-2.0, 1.0, 3.0]",
 
+	"skipSubVec": "",
 	"skipInner": "",
 	"skipSum": "",
 	"skipGetMaxIdx": "",

--- a/src/nodejs/la/la_nodejs.h
+++ b/src/nodejs/la/la_nodejs.h
@@ -106,6 +106,13 @@ public:
 	* @returns {Object} A JSON object `qrRes` which contains the decomposition matrices:
 	* <br>`qrRes.Q` - The orthogonal matrix Q of the QR decomposition. Type {@link module:la.Matrix}.
 	* <br>`qrRes.R` - The upper triangular matrix R of the QR decomposition. Type {@link module:la.Matrix}.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a random matrix
+    * var mat = new la.Matrix({ rows: 10, cols: 5, random: true });
+    * // calculate the QR decomposition of mat
+    * var qrRes = la.qr(mat);
 	*/
 	//# exports.prototype.qr = function (mat, tol) { return { Q: Object.create(require('qminer').la.Matrix.prototype), R: Object.create(require('qminer').la.Matrix.prototype) } }
 	JsDeclareFunction(qr);

--- a/src/nodejs/la/la_nodejs.h
+++ b/src/nodejs/la/la_nodejs.h
@@ -14,7 +14,16 @@
 * Linear algebra module.
 * @module la
 * @example
-* // import module, create a random matrix and a vector, multiply. find svd of the matrix
+* // import la module
+* var la = require('qminer').la;
+* // create a random matrix
+* var mat = new la.Matrix({ rows: 10, cols: 5, random: true });
+* // create a vector
+* var vec = new la.Vector([1, 2, 3, 0, -1]);
+* // multiply the matrix and vector
+* var vec2 = mat.multiply(vec);
+* // calculate the svd decomposition of the matrix
+* var svd = la.svd(mat, 3);
 */
 class TNodeJsLinAlg : public node::ObjectWrap {
 	friend class TNodeJsUtil;
@@ -52,10 +61,10 @@ public:
 	* @param {number} [json.tol = 1e-6] - The tolerance number.
 	* @param {function} [callback] - The callback function, that takes the error parameters (err) and the result parameter (res). 
 	* <i>Only for the asynchronous function.</i>
-	* @returns {Object} The JSON object svdRes which contains the SVD decomposition U*S*V^T matrices:
-	* <br>svdRes.U - The dense matrix of the decomposition. Type {@link module:la.Matrix}.
-	* <br>svdRes.V - The dense matrix of the decomposition. Type {@link module:la.Matrix}.
-	* <br>svdRes.s - The vector containing the singular values of the decomposition. Type {@link module:la.Vector}.
+	* @returns {Object} The JSON object `svdRes` which contains the SVD decomposition U*S*V^T matrices:
+	* <br>`svdRes.U` - The dense matrix of the decomposition. Type {@link module:la.Matrix}.
+	* <br>`svdRes.V` - The dense matrix of the decomposition. Type {@link module:la.Matrix}.
+	* <br>`svdRes.s` - The vector containing the singular values of the decomposition. Type {@link module:la.Vector}.
 	* @example <caption>Asynchronous function</caption>
 	* // import the modules
 	* var la = require('qminer').la;
@@ -88,16 +97,15 @@ public:
 	* var s = result.s;
 	*/
 	//# exports.prototype.svd = function (mat, k, json) { return { U: Object.create(require('qminer').la.Matrix.prototype), V: Object.create(require('qminer').la.Matrix.prototype), s: Object.create(require('qminer').la.Vector.prototype) } }
-	//JsDeclareFunction(svd);
 	JsDeclareSyncAsync(svd, svdAsync, TSVDTask);
 
 	/**
 	* Computes the QR decomposition.
 	* @param {module:la.Matrix} mat - The matrix.
 	* @param {number} [tol = 1e-6] - The tolerance number.
-	* @returns {Object} A JSON object qrRes which contains the decomposition matrices:
-	* <br>qrRes.Q - The orthogonal dense matrix Q of the QR decomposition. Type {@link module:la.Matrix}.
-	* <br>qrRes.R - The upper triangular dense matrix R of the QR decomposition. Type {@link module:la.Matrix}.
+	* @returns {Object} A JSON object `qrRes` which contains the decomposition matrices:
+	* <br>`qrRes.Q` - The orthogonal matrix Q of the QR decomposition. Type {@link module:la.Matrix}.
+	* <br>`qrRes.R` - The upper triangular matrix R of the QR decomposition. Type {@link module:la.Matrix}.
 	*/
 	//# exports.prototype.qr = function (mat, tol) { return { Q: Object.create(require('qminer').la.Matrix.prototype), R: Object.create(require('qminer').la.Matrix.prototype) } }
 	JsDeclareFunction(qr);

--- a/src/nodejs/la/la_structures_nodejs.h
+++ b/src/nodejs/la/la_structures_nodejs.h
@@ -1009,7 +1009,7 @@ public:
     * // create a new sparse matrix
     * var mat = new la.SparseMatrix([[[0, 2], [2, -3]], [[1, 1], [3, -2]]]);
     * // get the submatrix containing the 1, 2 and 4 column
-    * var submat = mat.getColSubmatrix(new la.IntVector([0, 1, 3]));
+    * var submat = mat.getColSubmatrix(new la.IntVector([1]));
     */
 	//# exports.SparseMatrix.prototype.getColSubmatrix = function (columnIdVec) { return Object.create(require('qminer').la.SparseMatrix.prototype); }
     JsDeclareFunction(getColSubmatrix);

--- a/src/nodejs/la/la_structures_nodejs.h
+++ b/src/nodejs/la/la_structures_nodejs.h
@@ -289,8 +289,7 @@ private:
 	JsDeclareFunction(frob);
 
 	/**
-	* Gives the number of rows of matrix.
-	* @returns {number} Number of rows of matrix.
+	* Gives the number of rows of matrix. Type `number`.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -303,8 +302,7 @@ private:
 	JsDeclareProperty(rows);
 
 	/**
-	* Gives the number of columns of matrix.
-	* @returns {number} Number of columns of matrix.
+	* Gives the number of columns of matrix. Type `number`.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -655,8 +653,7 @@ public:
 	JsDeclareFunction(normalize);
 
 	/**
-	* Returns the number of non-zero values.
-	* @returns {number} Number of non-zero values.
+	* Returns the number of non-zero values. Type `number`.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -670,8 +667,7 @@ public:
 	JsDeclareProperty(nnz);
 
 	/**
-	* Returns the dimension of sparse vector.
-	* @returns {number} Dimension of sparse vector.
+	* Returns the dimension of sparse vector. Type `number`.
     * @example
     * // import la module
     * var la = require('qminer').la;
@@ -1093,8 +1089,7 @@ public:
 	JsDeclareFunction(frob);
 
 	/**
-	* Gives the number of rows of sparse matrix.
-	* @returns {number} Number of rows of sparse matrix.
+	* Gives the number of rows of sparse matrix. Type `number`.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -1107,8 +1102,7 @@ public:
 	JsDeclareProperty(rows);
 
 	/**
-	* Gives the number of columns of sparse matrix.
-	* @returns {number} Number of columns of sparse matrix.
+	* Gives the number of columns of sparse matrix. Type `number`.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;

--- a/src/nodejs/la/la_structures_nodejs.h
+++ b/src/nodejs/la/la_structures_nodejs.h
@@ -14,19 +14,19 @@
 /**
 * Matrix constructor parameter object.
 * @typedef {Object} matrixArg
-* @property  {number} matrixArg.rows - Number of rows.
-* @property  {number} matrixArg.cols - Number of columns.
-* @property  {boolean} [matrixArg.random=false] - Generate a random matrix with entries sampled from a uniform [0,1] distribution. If set to false, a zero matrix is created.
+* @property {number} rows - Number of rows.
+* @property {number} cols - Number of columns.
+* @property {boolean} [random=false] - Generate a random matrix with entries sampled from a uniform [0,1] distribution. If set to false, a zero matrix is created.
 */
 
 /**
-* Matrix class
+* Matrix class.
 * @classdesc Represents a dense matrix (2d array), wraps a C++ object implemented in glib/base/ds.h.
 * @class
 * @param {(module:la~matrixArg | Array<Array<number>> | module:la.Matrix)} [arg] - Constructor arguments. There are three ways of constructing:
-* <br>1. Parameter object {@link module:la~matrixArg}.
-* <br>2. Nested array of matrix elements (row major). Example: [[1,2],[3,4]] has two rows, the first row is [1,2].
-* <br>3. A dense matrix (copy constructor).
+* <br>1. Using the parameter object {@link module:la~matrixArg},
+* <br>2. using a nested array of matrix elements (row major). Example: [[1,2],[3,4]] has two rows, the first row is [1,2],
+* <br>3. using a dense matrix (copy constructor).
 * @example
 * // import la module
 * var la = require('qminer').la;
@@ -74,8 +74,8 @@ private:
 	* Sets an element or a block of matrix.
 	* @param {number} rowIdx - Row index (zero based). 
 	* @param {number} colIdx - Column index (zero based).
-	* @param {(number | module:la.Matrix)} arg - A number or a matrix. If the arg is a matrix, then it gets copied, where the argument's upper left corner, arg.at(0,0), gets copied to (rowIdx, colIdx).
-	* @returns {module:la.Matrix} Self. The (rowIdx, colIdx) value/block is changed.
+	* @param {(number | module:la.Matrix)} arg - A number or a matrix. If arg is of type {@link module:la.Matrix}, it gets copied, where the argument's upper left corner, <code>arg.at(0,0)</code>, gets copied to position (<code>rowIdx</code>, <code>colIdx</code>).
+	* @returns {module:la.Matrix} Self. The (<code>rowIdx</code>, <code>colIdx</code>) value/block is changed.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -95,8 +95,8 @@ private:
 	* Right-hand side multiplication of matrix with parameter.
 	* @param {(number | module:la.Vector | module:la.SparseVector | module:la.Matrix | module:la.SparseMatrix)} arg - Multiplication input. Supports scalar, vector and matrix input.
 	* @returns {(module:la.Matrix | module:la.Vector)}
-	* <br>1. {@link module:la.Matrix}, if arg is a number, {@link module:la.Matrix} or {@link module:la.SparseMatrix}.
-	* <br>2. {@link module:la.Vector}, if arg is a {@link module:la.Vector} or {@link module:la.SparseVector}.
+	* <br>1. {@link module:la.Matrix}, if <code>arg</code> is a number, {@link module:la.Matrix} or {@link module:la.SparseMatrix}.
+	* <br>2. {@link module:la.Vector}, if <code>arg</code> is a {@link module:la.Vector} or {@link module:la.SparseVector}.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -114,8 +114,8 @@ private:
 	* Matrix transpose and right-hand side multiplication of matrix with parameter.
 	* @param {(number | module:la.Vector | module:la.SparseVector | module:la.Matrix | module:la.SparseMatrix)} arg - Multiplication input. Supports scalar, vector and matrix input.
 	* @returns {(module:la.Matrix | module:la.Vector)}
-	* <br>1. {@link module:la.Matrix}, if arg is a number, {@link module:la.Matrix} or a {@link module:la.SparseMatrix}.
-	* <br>2. {@link module:la.Vector}, if arg is a {@link module:la.Vector} or a {@link module:la.SparseVector}.
+	* <br>1. {@link module:la.Matrix}, if <code>arg</code> is a number, {@link module:la.Matrix} or a {@link module:la.SparseMatrix}.
+	* <br>2. {@link module:la.Vector}, if <code>arg</code> is a {@link module:la.Vector} or a {@link module:la.SparseVector}.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -130,7 +130,7 @@ private:
 	JsDeclareFunction(multiplyT);
 
 	/**
-	* Addition of two matrices.
+	* Adds two matrices.
 	* @param {module:la.Matrix} mat - The second matrix.
 	* @returns {module:la.Matrix} The sum of the matrices.
 	* @example
@@ -149,7 +149,7 @@ private:
 	JsDeclareFunction(plus);
 
 	/**
-	* Substraction of two matrices.
+	* Substracts two matrices.
 	* @param {module:la.Matrix} mat - The second matrix.
 	* @returns {module:la.Matrix} The difference of the matrices.
 	* @example
@@ -168,7 +168,7 @@ private:
 	JsDeclareFunction(minus);
 
 	/**
-	* Transposes matrix.
+	* Transposes the matrix.
 	* @returns {module:la.Matrix} Transposed matrix.
 	* @example
 	* // import la module
@@ -202,7 +202,7 @@ private:
 	JsDeclareFunction(solve);
 
 	/**
-	* Returns a vector of row norms.
+	* Calculates the matrix row norms.
 	* @returns {module:la.Vector} Vector, where the value at i-th index is the norm of the i-th row of matrix.
 	* @example
 	* // import la module
@@ -216,7 +216,7 @@ private:
 	JsDeclareFunction(rowNorms);
 
 	/**
-	* Returns a vector of column norms.
+	* Calculates the matrix column norms.
 	* @returns {module:la.Vector} Vector, where the value at i-th index is the norm of the i-th column of matrix.
 	* @example
 	* // import la module
@@ -231,7 +231,7 @@ private:
 
 	/**
 	* Normalizes each column of matrix.
-	* @returns {module:la.Matrix} Self. The columns of the matrix are normalized. 
+	* @returns {module:la.Matrix} Self. The columns of matrix are normalized. 
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -290,7 +290,7 @@ private:
 
 	/**
 	* Gives the number of rows of matrix.
-	* @returns {number} Number of rows in matrix.
+	* @returns {number} Number of rows of matrix.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -304,7 +304,7 @@ private:
 
 	/**
 	* Gives the number of columns of matrix.
-	* @returns {number} Number of columns in matrix.
+	* @returns {number} Number of columns of matrix.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -319,7 +319,7 @@ private:
 	/**
 	* Gives the index of the maximum element in the given row.
 	* @param {number} rowIdx - Row index (zero based).
-	* @returns {number} Column index (zero based) of the maximum value in the rowIdx-th row of matrix.
+	* @returns {number} Column index (zero based) of the maximum value in the <code>rowIdx</code>-th row of matrix.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -334,7 +334,7 @@ private:
 	/**
 	* Gives the index of the maximum element in the given column.
 	* @param {number} colIdx - Column index (zero based).
-	* @returns {number} Row index (zero based) of the maximum value in colIdx-th column of matrix.
+	* @returns {number} Row index (zero based) of the maximum value in <code>colIdx</code>-th column of matrix.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -349,7 +349,7 @@ private:
 	/**
 	* Returns the corresponding column of matrix as vector.
 	* @param {number} colIdx - Column index (zero based).
-	* @returns {module:la.Vector} The colIdx-th column of matrix.
+	* @returns {module:la.Vector} The <code>colIdx</code>-th column of matrix.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -365,7 +365,7 @@ private:
 	* Sets the column of the matrix.
 	* @param {number} colIdx - Column index (zero based).
 	* @param {module:la.Vector} vec - The new column of matrix.
-	* @returns {module:la.Matrix} Self. The colIdx-th column is changed.
+	* @returns {module:la.Matrix} Self. The <code>colIdx</code>-th column is changed.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -387,6 +387,13 @@ private:
 	* Gets the submatrix from the column ids.
 	* @param {module:la.IntVector} intVec - The vector containing the column ids.
 	* @returns {module:la.Matrix} The submatrix containing the the columns of the original matrix.
+    * @example 
+    * //import la module
+    * var la = require('qminer').la;
+    * // create a random matrix
+    * var mat = new la.Matrix({ rows: 10, cols: 10, random: true });
+    * // get the submatrix containing the 1, 2 and 4 column
+    * var submat = mat.getColSubmatrix(new la.IntVector([0, 1, 3]));
 	*/
 	//# exports.Matrix.prototype.getColSubmatrix = function (intVec) { return Object.create(require('qminer').la.Matrix.prototype); }
 	JsDeclareFunction(getColSubmatrix);
@@ -398,6 +405,13 @@ private:
 	* @param {number} minCol - The minimum column index.
 	* @param {number} maxCol - The maximum column index.
 	* @returns {module:la.Matrix} The submatrix of the original matrix.
+    * @example
+    * //import la module
+    * var la = require('qminer').la;
+    * // create a random matrix
+    * var mat = new la.Matrix({ rows: 10, cols: 10, random: true });
+    * // get the submatrix containing from the position (1, 2) to (7, 4)
+    * var submat = mat.getSubmatrix(1, 7, 2, 4);
 	*/
 	//# exports.Matrix.prototype.getSubmatrix = function (minRow, maxRow, minCol, maxCol) { return Object.create(require('qminer').la.Matrix.prototype); }
 	JsDeclareFunction(getSubmatrix);
@@ -405,7 +419,7 @@ private:
 	/**
 	* Returns the corresponding row of matrix as vector.
 	* @param {number} rowIdx - Row index (zero based).
-	* @returns {module:la.Vector} The rowIdx-th row of matrix.
+	* @returns {module:la.Vector} The <code>rowIdx</code>-th row of matrix.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -421,7 +435,7 @@ private:
 	* Sets the row of matrix.
 	* @param {number} rowIdx - Row index (zero based).
 	* @param {module:la.Vector} vec - The new row of matrix.
-	* @returns {module:la.Matrix} Self. The rowIdx-th row is changed.
+	* @returns {module:la.Matrix} Self. The <code>rowIdx</code>-th row is changed.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -456,7 +470,7 @@ private:
 	/**
 	* Saves the matrix as output stream.
 	* @param {module:fs.FOut} fout - Output stream.
-	* @returns {module:fs.FOut} The output stream fout.
+	* @returns {module:fs.FOut} The output stream <code>fout</code>.
 	* @example
 	* // import the modules
 	* var fs = require('qminer').fs;
@@ -474,7 +488,7 @@ private:
 	/**
 	* Loads the matrix from input stream.
 	* @param {module:fs.FIn} fin - Input stream.
-	* @returns {module:la.Matrix} Self. It is made out of the input stream fin.
+	* @returns {module:la.Matrix} Self. It is made out of the input stream <code>fin</code>.
 	* @example
 	* // import the modules
 	* var fs = require('qminer').fs;

--- a/src/nodejs/la/la_structures_nodejs.h
+++ b/src/nodejs/la/la_structures_nodejs.h
@@ -527,13 +527,13 @@ public:
 //! 
 
 /**
-* Sparse Vector
-* @classdesc Represents a sparse vector.
+* Sparse Vector.
+* @classdesc Sparse vector is an array of (int,double) pairs that represent column indices and values.
 * @class
 * @param {(Array<Array<number>> | module:la.SparseVector)} [arg] - Constructor arguments. There are two ways of constructing:
-* <br>1. Nested array of vector elements. Example: [[0, 2],[2, 3]] has two nonzero values, first value is 2 at position 0, second value is 3 at position 2.
-* <br>2. A sparse vector (copy constructor).
-* @param {number} [dim] - Maximal length of sparse vector. It is only in combinantion with nested array of vector elements.
+* <br>1. Using a nested array of vector elements. Example: `[[0, 2],[2, 3]]` has two nonzero values, first value is 2 at position 0, second value is 3 at position 2,
+* <br>2. using a sparse vector (copy constructor).
+* @param {number} [dim] - Maximum length of sparse vector. <i>It is only in combinantion with nested array of vector elements.</i>
 * @example
 * // import la module
 * var la = require('qminer').la;
@@ -583,7 +583,7 @@ public:
 	* Puts a new element in sparse vector.
 	* @param {number} idx - Index (zero based).
 	* @param {number} num - Input value.
-	* @returns {module:la.SparseVector} Self. It puts/changes the values with the index idx to the value num.
+	* @returns {module:la.SparseVector} Self. It puts/changes the values with the index `idx` to the value `num`.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -628,7 +628,7 @@ public:
 	/**
 	* Multiplies the sparse vector with a scalar.
 	* @param {number} num - The scalar.
-	* @returns {module:la.SparseVector} The product of num and sparse vector.
+	* @returns {module:la.SparseVector} The product of `num` and sparse vector.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -643,21 +643,28 @@ public:
 	/**
 	* Normalizes the sparse vector.
 	* @returns {module:la.SparseVector} Self. The vector is normalized.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new sparse vector
+    * var spVec = new la.SparseVector([[0, 1], [2, 3], [3, 6]]);
+    * // normalize the sparse vector
+    * spVec.normalize();
 	*/
 	//# exports.SparseVector.prototype.normalize = function () { return Object.create(require('qminer').la.SparseVector.prototype); }
 	JsDeclareFunction(normalize);
 
 	/**
-	* Returns the number of nonzero values.
-	* @returns {number} Number of nonzero values.
+	* Returns the number of non-zero values.
+	* @returns {number} Number of non-zero values.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
 	* // create a new sparse vector
-	* var vec = new la.SparseVector([[0,2], [3,1], [7, 5], [11,4]]);
+	* var vec = new la.SparseVector([[0, 2], [3, 1], [7, 5], [11, 4]]);
 	* // check the number of nonzero values in sparse vector
+    * // returns 4
 	* var nonz = vec.nnz;
-	* // returns 4
 	*/
 	//# exports.SparseVector.prototype.nnz = 0;
 	JsDeclareProperty(nnz);
@@ -665,6 +672,14 @@ public:
 	/**
 	* Returns the dimension of sparse vector.
 	* @returns {number} Dimension of sparse vector.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new sparse vector and designate the dimension of the vector
+    * var vec = new la.SparseVector([[0, 2], [3, 1], [7, 5], [11, 4]], 15);
+    * // get the dimension of the sparse vector
+    * // returns 15
+    * var dim = vec.dim; 
 	*/
 	//# exports.SparseVector.prototype.dim = 0;
 	JsDeclareProperty(dim);
@@ -672,6 +687,13 @@ public:
 	/**
 	* Returns the norm of sparse vector.
 	* @returns {number} Norm of sparse vector.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new sparse vector
+    * var vec = new la.SparseVector([[0, 2], [3, 1], [7, 5], [11, 4]]); 
+    * // get the norm of the vector
+    * var norm = vec.norm();
 	*/
 	//# exports.SparseVector.prototype.norm = function () { return 0.0; }
 	JsDeclareFunction(norm);
@@ -679,20 +701,41 @@ public:
 	/**
 	* Returns the dense vector representation of the sparse vector.
 	* @returns {module:la.Vector} The dense vector representation.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new sparse vector
+    * var vec = new la.SparseVector([[0, 2], [3, 1], [7, 5], [11, 4]]); 
+    * // create a dense representation of the vector
+    * var dense = vec.full();
 	*/
 	//# exports.SparseVector.prototype.full = function () { return Object.create(require('qminer').la.Vector.prototype); }
 	JsDeclareFunction(full);
 
 	/**
-	* Returns a dense vector of values of nonzero elements of sparse vector.
+	* Returns a dense vector of values of non-zero elements of sparse vector.
 	* @returns {module:la.Vector} A dense vector of values.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new sparse vector
+    * var vec = new la.SparseVector([[0, 2], [3, 1], [7, 5], [11, 4]]);
+    * // get the non-zero values of the sparse vector
+    * var valVec = vec.valVec();
 	*/
 	//# exports.SparseVector.prototype.valVec = function () { return Object.create(require('qminer').la.Vector.prototype); }
 	JsDeclareFunction(valVec);
 
 	/**
-	* Returns a dense vector of indices (zero based) of nonzero elements of sparse vector.
+	* Returns a dense vector of indices (zero based) of non-zero elements of sparse vector.
 	* @returns {module:la.Vector} A dense vector of indeces.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new sprase vector
+    * var vec = new la.SparseVector([[0, 2], [3, 1], [7, 5], [11, 4]]);
+    * // get the non-zero indeces of the sparse vector
+    * var idxVec = vec.idxVec();
 	*/
 	//# exports.SparseVector.prototype.idxVec = function () { return Object.create(require('qminer').la.Vector.prototype); }
 	JsDeclareFunction(idxVec);
@@ -728,13 +771,13 @@ public:
 
 /**
 * Sparse Matrix
-* @classdesc Represents a sparse matrix.
+* @classdesc Sparse Matrix is represented as a dense vector of sparse vectors which correspond to matrix columns.
 * @class
 * @param {(Array<Array<Array<number>>> | module:la.SparseMatrix)} [arg] - Constructor arguments. There are two ways of constructing:
-* <br>1. A nested array of sparse vectors (columns). A sparse vector is a nested array of pairs, first value is index, second is value.. Example: [[[0,2]], [[0, 1], [2,3]]] has 2 columns.
-* The second nonzero element in second column has a value 3 at index 2.
-* <br>2. A sparse matrix (copy constructor).
-* @param {number} [rows] - Maximal number of rows in sparse vector. It is only in combinantion with nested array of vector elements.
+* <br>1. using a nested array of sparse vectors (columns). A sparse vector is a nested array of pairs, first value is index, second is value. Example: [[[0, 2]], [[0, 1], [2, 3]]] has 2 columns.
+* The second non-zero element in second column has a value 3 at index 2,
+* <br>2. using a sparse matrix (copy constructor).
+* @param {number} [rows] - Maximal number of rows in sparse vector. <i>It is only in combinantion with nested array of vector elements.</i>
 * @example
 * // import la module
 * var la = require('qminer').la;
@@ -787,7 +830,7 @@ public:
 	* @param {number} rowIdx - Row index (zero based).
 	* @param {number} colIdx - Column index (zero based).
 	* @param {number} num - Element value.
-	* @returns {module:la.SparseMatrix} Self. The value at position (rowIdx, colIdx) is changed.
+	* @returns {module:la.SparseMatrix} Self. The value at position (`rowIdx`, `colIdx`) is changed.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -807,7 +850,7 @@ public:
 	/**
 	* Returns the column of the sparse matrix.
 	* @param {number} colIdx - The column index (zero based).
-	* @returns {module:la.SparseVector} Sparse vector corresponding to the colIdx-th column of sparse matrix.
+	* @returns {module:la.SparseVector} Sparse vector corresponding to the `colIdx`-th column of sparse matrix.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -823,7 +866,7 @@ public:
 	* Sets a column in sparse matrix.
 	* @param {number} colIdx - Column index (zero based).
 	* @param {module:la.SparseVector} spVec - The new column sparse vector.
-	* @returns {module:la.SparseMatrix} Self.
+	* @returns {module:la.SparseMatrix} Self. The `colIdx`-th column has been replaced with `spVec`.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -839,7 +882,7 @@ public:
 	/**
 	* Attaches a column to the sparse matrix.
 	* @param {module:la.SparseVector} spVec - Attached column as sparse vector.
-	* @returns {module:la.SparseMatrix} Self. The last column is now the added sparse vector and the number of columns is now bigger by one.
+	* @returns {module:la.SparseMatrix} Self. The last column is now the added `spVec` and the number of columns is now bigger by one.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
@@ -859,11 +902,20 @@ public:
 	JsDeclareFunction(push);
 
 	/**
-	* Multiplies argument with sparse vector.
+	* Multiplies argument with sparse maatrix.
 	* @param {(number | module:la.Vector | module:la.SparseVector | module:la.Matrix | module:la.SparseMatrix)} arg - Multiplication input.
 	* @returns {(module:la.Vector | module:la.Matrix)}
-	* <br>1. {@link module:la.Matrix}, if arg is number, {@link module:la.Matrix} or {@link module:la.SparseMatrix}.
-	* <br>2. {@link module:la.Vector}, if arg is {@link module:la.Vector} or {@link module:la.SparseVector}.
+	* <br>1. {@link module:la.Matrix}, if `arg` is number, {@link module:la.Matrix} or {@link module:la.SparseMatrix}.
+	* <br>2. {@link module:la.Vector}, if `arg` is {@link module:la.Vector} or {@link module:la.SparseVector}.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create new sparse matrix
+    * var mat = new la.SparseMatrix([[[0, 2], [3, 5]], [[1, -3]]]);
+    * // create a vector
+    * var vec = new la.Vector([3, -2]);
+    * // multiply the matrix and vector
+    * var vec2 = mat.multiply(vec);
 	*/
 	//# exports.SparseMatrix.prototype.multiply = function (arg) { return (arg instanceof require('qminer').la.Vector | arg instanceof require('qminer').la.SparseVector) ? Object.create(require('qminer').la.Vector.prototype) : Object.create(require('qminer').la.Matrix.prototype); }
 	JsDeclareFunction(multiply);
@@ -872,14 +924,23 @@ public:
 	* Sparse matrix transpose and multiplies with argument.
 	* @param {(number | module:la.Vector | module:la.SparseVector | module:la.Matrix | module:la.SparseMatrix)} arg - Multiplication input.
 	* @returns {(module:la.Vector | module:la.Matrix)}
-	* <br>1. {@link module:la.Matrix}, if arg is number, {@link module:la.Matrix} or {@link module:la.SparseMatrix}.
-	* <br>2. {@link module:la.Vector}, if arg is {@link module:la.Vector} or {@link module:la.SparseVector}.
+	* <br>1. {@link module:la.Matrix}, if `arg` is number, {@link module:la.Matrix} or {@link module:la.SparseMatrix}.
+	* <br>2. {@link module:la.Vector}, if `arg` is {@link module:la.Vector} or {@link module:la.SparseVector}.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create new sparse matrix
+    * var mat = new la.SparseMatrix([[[0, 2], [3, 5]], [[1, -3]]]);
+    * // create a dense matrix
+    * var mat2 = new la.Matrix([[0, 1], [2, 3], [4, 5], [-1, 3]]);
+    * // transpose mat and multiply it with mat2
+    * var mat3 = mat.multiplyT(mat2);
 	*/
 	//# exports.SparseMatrix.prototype.multiplyT = function (arg) { return (arg instanceof require('qminer').la.Vector | arg instanceof require('qminer').la.SparseVector) ? Object.create(require('qminer').la.Vector.prototype) : Object.create(require('qminer').la.Matrix.prototype); }
 	JsDeclareFunction(multiplyT);
 
 	/**
-	* Returns the sum of two matrices.
+	* Addition of two matrices.
 	* @param {module:la.SparseMatrix} mat - The second sparse matrix.
 	* @returns {module:la.SparseMatrix} Sum of the two sparse matrices.
 	* @example
@@ -900,7 +961,7 @@ public:
 	JsDeclareFunction(plus);
 
 	/**
-	* Returns the difference of two matrices.
+	* Substraction of two matrices.
 	* @param {module:la.SparseMatrix} mat - The second sparse matrix.
 	* @returns {module:la.SparseMatrix} The difference of the two sparse matrices.
 	* @example
@@ -941,20 +1002,42 @@ public:
     * Returns a submatrix containing only selected columns.
     * Columns are identified by a vector of ids.
 	* @param {module:la.IntVector} columnIdVec - Integer vector containing selected column ids.
-    * @returns {module:la.SparseMatrix}
+    * @returns {module:la.SparseMatrix} The submatrix containing the the columns of the original matrix.
+    * @example
+    * //import la module
+    * var la = require('qminer').la;
+    * // create a new sparse matrix
+    * var mat = new la.SparseMatrix([[[0, 2], [2, -3]], [[1, 1], [3, -2]]]);
+    * // get the submatrix containing the 1, 2 and 4 column
+    * var submat = mat.getColSubmatrix(new la.IntVector([0, 1, 3]));
     */
 	//# exports.SparseMatrix.prototype.getColSubmatrix = function (columnIdVec) { return Object.create(require('qminer').la.SparseMatrix.prototype); }
     JsDeclareFunction(getColSubmatrix);
 
     /**
     * Clear content of the matrix and sets its row dimension to -1.
+    * @returns {module:la.SparseMatrix} Self. All the content has been cleared.
+    * @example
+    * //import la module
+    * var la = require('qminer').la;
+    * // create a new sparse matrix
+    * var mat = new la.SparseMatrix([[[0, 2], [2, -3]], [[1, 1], [3, -2]]]);
+    * // clear the matrix
+    * mat.clear();
     */
-    //# exports.SparseMatrix.prototype.clear = function () { }
+    //# exports.SparseMatrix.prototype.clear = function () { return Object.create(require('qminer').la.SparseMatrix.prototype); }
     JsDeclareFunction(clear);
 
 	/**
 	* Returns the vector of column norms of sparse matrix.
 	* @returns {module:la.Vector} Vector of column norms. Ihe i-th value of the return vector is the norm of i-th column of sparse matrix.
+    * @example
+    * //import la module
+    * var la = require('qminer').la;
+    * // create a new sparse matrix
+    * var mat = new la.SparseMatrix([[[0, 2], [2, -3]], [[1, 1], [3, -2]]]);
+    * // get the column norms
+    * var norms = mat.colNorms();
 	*/
 	//# exports.SparseMatrix.prototype.colNorms = function () { return Object.create(require('qminer').la.Vector.prototype); }
 	JsDeclareFunction(colNorms);
@@ -968,11 +1051,11 @@ public:
 	* // create a new sparse matrix
 	* var mat = new la.SparseMatrix([[[0, 2]], [[0, 1], [2, 3]]]);
 	* // normalize matrix columns
+    * // The new matrix elements are:
+    * // 1  0.316227
+    * // 0  0
+    * // 0  0.948683
 	* mat.normalizeCols();
-	* // The new matrix elements are:
-	* // 1  0.316227
-	* // 0  0
-	* // 0  0.948683
 	*/
 	//# exports.SparseMatrix.prototype.normalizeCols = function () { return Object.create(require('qminer').la.SparseMatrix.prototype); }
 	JsDeclareFunction(normalizeCols);
@@ -986,11 +1069,11 @@ public:
 	* // create a new sparse matrix
 	* var mat = new la.SparseMatrix([[[0, 2]], [[0, 1], [2, 3]]]);
 	* // create a dense representation of sparse matrix
+    * // returns the dense matrix:
+    * // 2  1
+    * // 0  0
+    * // 0  3
 	* mat.full();
-	* // returns
-	* // 2  1
-	* // 0  0
-	* // 0  3
 	*/
 	//# exports.SparseMatrix.prototype.full = function () { return Object.create(require('qminer').la.Matrix.prototype); }
 	JsDeclareFunction(full);
@@ -1006,7 +1089,7 @@ public:
 	* // get the frobenious norm of sparse matrix
 	* var norm = mat.frob(); // returns sqrt(30)
 	*/
-	//# exports.SparseMatrix.prototype.frob = function () { return 0; }
+	//# exports.SparseMatrix.prototype.frob = function () { return 0.0; }
 	JsDeclareFunction(frob);
 
 	/**
@@ -1059,7 +1142,7 @@ public:
 	* Saves the sparse matrix as output stream.
 	* @param {module:fs.FOut} fout - Output stream.
 	* @param {boolean} [saveMatlab=false] - If true, saves using matlab three column text format. Otherwise, saves using binary format.
-	* @returns {module:fs.FOut} The output stream fout.
+	* @returns {module:fs.FOut} The output stream `fout`.
 	* @example
 	* // import the modules
 	* var fs = require('qminer').fs;
@@ -1077,7 +1160,7 @@ public:
 	/**
 	* Loads the sparse matrix from input stream.
 	* @param {module:fs.FIn} fin - Input stream.
-	* @returns {module:la.Matrix} Self.
+	* @returns {module:la.Matrix} Self. The content has been loaded using `fin`.
 	* @example
 	* // import the modules
 	* var fs = require('qminer').fs;
@@ -1089,12 +1172,12 @@ public:
 	* // load the matrix
 	* mat.load(fin);
 	*/
-	//# exports.SparseMatrix.prototype.load = function (FIn) { return Object.create(require('qminer').fs.FIn.prototype); }
+	//# exports.SparseMatrix.prototype.load = function (FIn) { return Object.create(require('qminer').la.SparseMatrix.prototype); }
 	JsDeclareFunction(load);
 
 	/**
-	* Sets the row dimension
-	* @param {number} rowDim - Row dimension
+	* Sets the row dimension.
+	* @param {number} rowDim - Row dimension.
 	* @example
 	* // import the modules
 	* var la = require('qminer').la;
@@ -1103,7 +1186,7 @@ public:
 	* mat.setRowDim(2);
 	* mat.rows // prints 2
 	*/
-	//# exports.SparseMatrix.prototype.setRowDim = function (dim) { }
+	//# exports.SparseMatrix.prototype.setRowDim = function (rowDim) { }
 	JsDeclareFunction(setRowDim);
 
 	//!- `spMat2 = spMat.sign()` -- create a new sparse matrix `spMat2` whose elements are sign function applied to elements of `spMat`.

--- a/src/nodejs/la/la_vector_nodejs.h
+++ b/src/nodejs/la/la_vector_nodejs.h
@@ -131,11 +131,11 @@ public:
 
 /**
 * <% title %>
-* @classdesc Wraps a C++ array.
+* @classdesc The <% elementType %> vector representation. Wraps a C++ array.
 * @class
-* @param {(Array<<% elementType %>> | module:la.<% className %>)} [arg] - Constructor arguments. There are two ways of constructing:
-* <br>1. An array of vector elements. Example: <% example1 %> is a vector of length 3.
-* <br>2. A vector (copy constructor).
+* @param {(Array.<<% elementType %>> | module:la.<% className %>)} [arg] - Constructor arguments. There are two ways of constructing:
+* <br>1. using an array of vector elements. Example: using `<% example1 %>` creates a vector of length 3,
+* <br>2. using a vector (copy constructor).
 * @example
 * var la = require('qminer').la;
 * // create a new empty vector
@@ -175,16 +175,30 @@ private:
 	* Returns element at index.
 	* @param {number} index - Element index (zero-based).
 	* @returns {<% elementType %>} Vector element.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.<% className %>(<% example1 %>);
+    * // get the element at index 1
+    * var el = vec[1];
 	*/
 	//# exports.<% className %>.prototype.at = function(number) { return <% className %>DefaultVal; }
 	JsDeclareFunction(at);
 	
 	/**
 	* Returns a subvector.
-	* @param {(Array<number> | module:la.IntVector)} arg - Index array or vector. Indices can repeat (zero based).
-	* @returns {module:la.<% className %>} Subvector, where the i-th element is the arg[i]-th element of the instance.
+	* @param {(Array.<number> | module:la.IntVector)} arg - Index array or vector. Indices can repeat (zero based).
+	* @returns {module:la.<% className %>} Subvector, where the i-th element is the `arg[i]`-th element of the instance.
+    * @<% skipSubVec %>example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.<% className %>(<% example1 %>);
+    * // get the subvector of the first two elements
+    * var subvec = vec.subVec([0, 1]);
 	*/
-	//# exports.<% className %>.prototype.subVec = function (arg) { return Object.create(this); }
+	//# <% skipSubVec %>exports.<% className %>.prototype.subVec = function (arg) { return Object.create(this); }
 	JsDeclareFunction(subVec);
 	
 	//!- `num = vec[idx]; vec[idx] = num` -- get value `num` at index `idx`, set value at index `idx` to `num` of vector `vec`(0-based indexing)
@@ -194,7 +208,14 @@ private:
 	* Sets an element in vector.
 	* @param {number} idx - Index (zero based).
 	* @param {<% elementType %>} val - Element value.
-	* @returns {module:la.<% className %>} Self.
+	* @returns {module:la.<% className %>} Self. The values at index `idx` has been changed to `val`.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.<% className %>(<% example1 %>);
+    * // set the first element to <% val1 %>
+    * vec.put(0, <% val1 %>);
 	*/
 	//# exports.<% className %>.prototype.put = function (idx, val) { return this;}
 	JsDeclareFunction(put);
@@ -203,8 +224,15 @@ private:
 	* Adds an element to the end of the vector.
 	* @param {<% elementType %>} val - The element added to the vector.
 	* @returns {number} The new length property of the object upon which the method was called.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.<% className %>(<% example1 %>);
+    * // push an element to the vector
+    * vec.push(<% val1 %>);
 	*/
-	//# exports.<% className %>.prototype.push = function (val) { return 0;}
+	//# exports.<% className %>.prototype.push = function (val) { return 0; }
 	JsDeclareFunction(push);
 		
 	/**
@@ -212,7 +240,7 @@ private:
 	* @param {number} start - Index at which to start changing the array.
 	* @param {number} deleteCount - Number of elements to be removed.
 	* @param {...number} [itemN] - The element(s) to be add to the array. If no elements are given, splice() will only remove elements from the array.
-	* @returns {module:la.<% className %>} Self.
+	* @returns {module:la.<% className %>} Self. The selected elements are removed/replaced.
 	* @example
 	* var la = require('qminer').la;
 	* // create a new vector
@@ -220,28 +248,50 @@ private:
 	* // splice the vector by removing the last two elements and adding <% input1 %>
 	* vec.splice(1, 2, <% input1 %>)// returns vector <% output2 %>
 	*/
-	//# exports.<% className %>.prototype.splice = function (start, deleteCount, itemN) { return this;}
+	//# exports.<% className %>.prototype.splice = function (start, deleteCount, itemN) { return this; }
 	JsDeclareFunction(splice);
 
 	/**
 	* Adds elements to the beginning of the vector.
 	* @param {...<% elementType %>} args - One or more elements to be added to the vector.
 	* @returns {number} The new length of vector.
-	*/
-	//# exports.<% className %>.prototype.unshift = function (args) { return 0;}
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.<% className %>(<% example1 %>);
+    * // add two elements to the beggining of the vector
+    * var len = vec.unshift(<% input1 %>); // returns 5
+    */
+	//# exports.<% className %>.prototype.unshift = function (args) { return 0; }
 	JsDeclareFunction(unshift);
 
 	/**
 	* Appends a second vector to the first one.
 	* @param {module:la.<% className %>} vec - The appended vector.
 	* @returns {number} The new length property of the vectors.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create two new vectors
+    * var vec = new la.<% className %>(<% example1 %>);
+    * var vec2 = new la.<% className %>([<% input1 %>]);
+    * // append the two vectors
+    * vec.pushV(vec2);
 	*/
-	//# exports.<% className %>.prototype.pushV = function (vec) { return 0;}
+	//# exports.<% className %>.prototype.pushV = function (vec) { return 0; }
 	JsDeclareFunction(pushV);
 
 	/** 
 	* Sums the elements in the vector.
 	* @returns {number} The sum of all elements in the instance.
+    * @example
+    * // import la modules
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.<% className %>(<% example1 %>);
+    * // sum all the elements of the vector
+    * var sum = vec.sum();
 	*/
 	//# <% skipSum %>exports.<% className %>.prototype.sum = function () { return <% className %>DefaultVal; }
 	JsDeclareFunction(sum);
@@ -249,25 +299,32 @@ private:
 	/**
 	* Gets the index of the maximal element.
 	* @returns {number} Index of the maximal element in the vector.
+    * // import la modules
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.<% className %>(<% example1 %>);
+    * // get the index of the maximum value
+    * var idx = vec.getMaxIdx();
+    * 
 	*/
-	//# <% skipGetMaxIdx %>exports.<% className %>.prototype.getMaxIdx = function () { return 0;}
+	//# <% skipGetMaxIdx %>exports.<% className %>.prototype.getMaxIdx = function () { return 0; }
 	JsDeclareSpecializedFunction(getMaxIdx);
 
 	/**
 	* Vector sort comparator callback.
 	* @callback <% sortCallback %>
-	* @param {<% elementType %>} arg1 - First argument
-	* @param {<% elementType %>} arg2 - Second argument
-	* @returns {(number | boolean)} If <% sortCallback %>(arg1, arg2) is less than 0 or false, sort arg1 to a lower index than arg2, i.e. arg1 comes first.
+	* @param {<% elementType %>} arg1 - First argument.
+	* @param {<% elementType %>} arg2 - Second argument.
+	* @returns {(number | boolean)} If `<% sortCallback %>(arg1, arg2)` is less than 0 or false, sort `arg1` to a lower index than `arg2`, i.e. `arg1` comes first.
 	*/
 	
 	/**
 	* Sorts the vector (in place operation).
 	* @param {(module:la~<% sortCallback %> | boolean)} [arg] - Sort callback or a boolean ascend flag. Default is boolean and true.
 	* @returns {module:la.<% className %>} Self.
-	* <br>1. Vector sorted in ascending order, if arg is boolean and true.  
-	* <br>2. Vector sorted in descending order, if arg is boolean and false.
-	* <br>3. Vector sorted by using the comparator callback, if arg is a {@link module:la~<% sortCallback %>}.
+	* <br>1. Vector sorted in ascending order, if `arg` is boolean and true.  
+	* <br>2. Vector sorted in descending order, if `arg` is boolean and false.
+	* <br>3. Vector sorted by using the comparator callback, if `arg` is a {@link module:la~<% sortCallback %>}.
 	* @example
 	* var la = require('qminer').la;
 	* // create a new vector
@@ -281,23 +338,19 @@ private:
 	JsDeclareFunction(sort);
 
 	/**
-	* Sort with permutation output result
-	* @typedef {Object} SortResult
-	* @property  {module:la.<% className %>} SortResult.vec - Sorted vector.
-	* @property  {module:la.IntVector} SortResult.perm - Permutation vector, where SortResult.vec[i] = unsortedVec[SortResult.perm[i]].
-	*/
-
-	/**
-	* Sorts the vector and returns the sorted vector as well as the permutation
-	* @param {boolean} [asc] - Sort in ascending order flag. Default is boolean and true.
-	* @returns {module:la~SortResult} Self.
+	* Sorts the vector and returns the sorted vector as well as the permutation.
+	* @param {boolean} [asc = true] - Sort in ascending order flag.
+	* @returns {Object} The object `<% className %>SortResult` containing the properties:
+    * <br> `<% className %>SortResult.vec` - The sorted vector,
+    * <br> `<% className %>SortResult.perm` - Permutation vector, where `<% className %>SortResult.vec[i] = instanceVector[<% className %>SortResult.perm[i]]`.
 	* @example
 	* // import la module
 	* var la = require('qminer').la;
 	* // create a new vector
 	* var vec = new la.<% className %>(<% exampleSort %>);
 	* // sort ascending
-	* var result = vec.sortPerm(); // result.vec: <% outputSortAsc %>
+	* var result = vec.sortPerm();
+    * result.vec;  // <% outputSortAsc %>
 	* result.perm; // permutation index vector
 	*/
 	//# <% skipSort %>exports.<% className %>.prototype.sortPerm = function (asc) { return {vec: Object.create(this), perm: Object.create(require('qminer').la.IntVector.prototype) }; } 
@@ -305,7 +358,14 @@ private:
 
 	/**
 	* Randomly reorders the elements of the vector (inplace).
-	* @returns {module:la.<% className %>} Self.
+	* @returns {module:la.<% className %>} Self. The elements are randomly reordered.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.<% className %>(<% exampleSort %>); 
+    * // shuffle the elements
+    * vec.shuffle();
 	*/
 	//# exports.<% className %>.prototype.shuffle = function () { return this; }
 	JsDeclareFunction(shuffle);
@@ -321,81 +381,120 @@ private:
 	* // trunc all elements with index 1 or more
 	* vec.trunc(1); // returns vector <% output3 %>
 	*/
-	//# exports.<% className %>.prototype.trunc = function (idx) { return this;} 
+	//# exports.<% className %>.prototype.trunc = function (idx) { return this; } 
 	JsDeclareFunction(trunc);
 	
 	/**
-	* Creates a dense matrix A by multiplying two vectors x and y: A = x y^T.
+	* Creates a dense matrix A by multiplying two vectors x and y: `A = x * y^T`.
 	* @param {module:la.<% className %>} vec - Second vector.
 	* @returns {module:la.Matrix} Matrix obtained by the outer product of the instance and second vector.
 	* @example
 	* var la = require('qminer').la;
-	* // create two vectors
+	* // create two new vectors
 	* var x = new la.<% className %>([1, 2, 3]);
 	* var y = new la.<% className %>([4, 5]);
 	* // create the outer product of these vectors
 	* var A = x.outer(y); // creates the dense matrix [[4, 5], [8, 10], [12, 15]]
 	*/
-	//# <% skipOuter %>exports.<% className %>.prototype.outer = function (vec) { return Object.create(require('qminer').la.Matrix.prototype);}
+	//# <% skipOuter %>exports.<% className %>.prototype.outer = function (vec) { return Object.create(require('qminer').la.Matrix.prototype); }
 	JsDeclareSpecializedFunction(outer);
 	
 	/**
 	* Computes the inner product.
-	* @param {module:la.Vector} vec - Other vector
+	* @param {module:la.Vector} vec - Other vector.
 	* @returns {number} Inner product between the instance and the other vector.
+    * @example
+	* var la = require('qminer').la;
+	* // create two new vectors
+	* var x = new la.Vector([1, 2, 3]);
+	* var y = new la.Vector([4, 5, -1]);
+    * // get the inner product of the two vectors
+    * var prod = x.inner(y); // returns 11
 	*/
-	//# <% skipInner %>exports.<% className %>.prototype.inner = function(vec) { return 0.0; }
+	//# <% skipInner %>exports.Vector.prototype.inner = function(vec) { return 0; }
 	JsDeclareSpecializedFunction(inner);
 
 	/**
 	* Returns the cosine between the two vectors.
-	* @param {module:la.<% className %>} vec - Second vector.
+	* @param {module:la.Vector} vec - Second vector.
 	* @returns {number} The cosine between the two vectors.
 	* @example
 	* var la = require('qminer').la;
-	* // create two vectors
-	* var x = new la.<% className %>([1, 0]);
-	* var y = new la.<% className %>([0, 1]);
+	* // create two new vectors
+	* var x = new la.Vector([1, 0]);
+	* var y = new la.Vector([0, 1]);
 	* // calculate the cosine between those two vectors
 	* var num = x.cosine(y); // returns 0
 	*/
-	//# <% skipCosine %>exports.<% className %>.prototype.cosine = function (vec) { return 0.0; }
+	//# <% skipCosine %>exports.Vector.prototype.cosine = function (vec) { return 0.0; }
 	JsDeclareSpecializedFunction(cosine);
 
 	/**
-	* Sums the two vectors together.
-	* @param {module:la.<% className %>} vec - Second vector.
-	* @returns {module:la.<% className %>} Sum of the instance and the second vector.
+	* Vector addition.
+	* @param {module:la.Vector} vec - Second vector.
+	* @returns {module:la.Vector} Sum of the instance and the second vector.
+    * @example
+	* var la = require('qminer').la;
+	* // create two new vectors
+	* var x = new la.Vector([1, 2, 3]);
+	* var y = new la.Vector([4, 5, -1]);
+    * // sum the vectors
+    * var z = x.plus(y);
 	*/
-	//# <% skipPlus %>exports.<% className %>.prototype.plus = function (vec) { return Object.create(this); }
+	//# <% skipPlus %>exports.Vector.prototype.plus = function (vec) { return Object.create(this); }
 	JsDeclareSpecializedFunction(plus);
 
 	/**
-	* Subtracts one vector from the other.
-	* @param {module:la.<% className %>} vec - Second vector.
-	* @returns {module:la.<% className %>} The difference of the instance and the other vector.
+	* Vector substraction.
+	* @param {module:la.Vector} vec - Second vector.
+	* @returns {module:la.Vector} The difference of the instance and the other vector.
+    * @example
+	* var la = require('qminer').la;
+	* // create two new vectors
+	* var x = new la.Vector([1, 2, 3]);
+	* var y = new la.Vector([4, 5, -1]);
+    * // substract the vectors
+    * var z = x.minus(y);
 	*/
-	//# <% skipMinus %>exports.<% className %>.prototype.minus = function (vec) { return Object.create(this); }
+	//# <% skipMinus %>exports.Vector.prototype.minus = function (vec) { return Object.create(this); }
 	JsDeclareSpecializedFunction(minus);
 
 	/**
 	* Multiplies the vector with a scalar.
 	* @param {number} val - Scalar.
-	* @returns {module:la.<% className %>} Product of the vector and scalar.
+	* @returns {module:la.Vector} Product of the vector and scalar.
+    * @example
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var x = new la.Vector([4, 5, -1]);
+    * // multiply the vector with the scalar 3
+    * var y = x.multiply(3);
 	*/
-	//# <% skipMultiply %>exports.<% className %>.prototype.multiply = function (val) { return Object.create(this); }
+	//# <% skipMultiply %>exports.Vector.prototype.multiply = function (val) { return Object.create(this); }
 	JsDeclareSpecializedFunction(multiply);
 
 	/**
 	* Normalizes vector.
-	* @returns {module:la.<% className %>} Normalized self.
+	* @returns {module:la.Vector} Self. The vector is normalized.
+    * @example
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var x = new la.Vector([4, 5, -1]); 
+    * // normalize the vector
+    * x.normalize();
 	*/
-	//# <% skipNormalize %>exports.<% className %>.prototype.normalize = function () { return this; } 
+	//# <% skipNormalize %>exports.Vector.prototype.normalize = function () { return this; } 
 	JsDeclareSpecializedFunction(normalize);
 
 	/**
 	* Gives the length of vector.
 	* @returns {number} Length of vector.
+    * @example
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var x = new la.<% className %>(<% example1 %>);
+    * // get the length of the vector
+    * var len = x.length; // returns 3
 	*/
 	//# exports.<% className %>.prototype.length = 0;
 	JsDeclareProperty(length);
@@ -416,13 +515,25 @@ private:
 	/**
 	* Creates a dense diagonal matrix out of the vector.
 	* @returns{module:la.Matrix} Diagonal matrix, where the (i, i)-th element is the i-th element of vector.
+    * @example
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.Vector([4, 5, -1]);
+    * // create a dense matrix with the diagonal equal to vec
+    * var mat = vec.diag();
 	*/
-	//# <% skipDiag %>exports.<% className %>.prototype.diag = function () { return Object.create(require('qminer').la.Matrix.prototype); }
+	//# <% skipDiag %>exports.Vector.prototype.diag = function () { return Object.create(require('qminer').la.Matrix.prototype); }
 	JsDeclareSpecializedFunction(diag);
 
 	/**
 	* Creates a sparse diagonal matrix out of the vector.
 	* @returns {module:la.SparseMatrix} Diagonal matrix, where the (i, i)-th element is the i-th element of vector.
+    * @example
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.Vector([4, 5, -1]);
+    * // create a sparse matrix with the diagonal equal to vec
+    * var mat = vec.spDiag();
 	*/
 	//# <% skipSpDiag %>exports.<% className %>.prototype.spDiag = function () { return Object.create(require('qminer').la.SparseMatrix.prototype); }
 	JsDeclareSpecializedFunction(spDiag);
@@ -430,28 +541,46 @@ private:
 	/**
 	* Calculates the norm of the vector.
 	* @returns {number} The norm of the vector.
+    * @example
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.Vector([4, 5, -1]);
+    * // get the norm of the vector
+    * var norm = vec.norm();
 	*/
-	//# <% skipNorm %>exports.<% className %>.prototype.norm = function () { return 0.0; }
+	//# <% skipNorm %>exports.Vector.prototype.norm = function () { return 0.0; }
 	JsDeclareSpecializedFunction(norm);
 
 	/**
 	* Creates the sparse vector representation of the vector.
 	* @returns {module:la.SparseVector} The sparse vector representation.
+    * @example
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.Vector([4, 5, -1]);
+    * // create the sparse representation of the vector
+    * var spVec = vec.sparse();
 	*/
-	//# <% skipSparse %>exports.<% className %>.prototype.sparse = function () { return Object.create(require('qminer').la.SparseVector.prototype); }
+	//# <% skipSparse %>exports.Vector.prototype.sparse = function () { return Object.create(require('qminer').la.SparseVector.prototype); }
 	JsDeclareSpecializedFunction(sparse);
 
 	/**
 	* Creates a matrix with a single column that is equal to the vector.
 	* @returns {module:la.Matrix} The matrix with a single column that is equal to the instance.
+    * @example
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.Vector([4, 5, -1]);
+    * // create a matrix representation of the vector
+    * var mat = vec.toMat();
 	*/
-	//# <% skipToMat %>exports.<% className %>.prototype.toMat = function () { return Object.create(require('qminer').la.Matrix.prototype); }
+	//# <% skipToMat %>exports.Vector.prototype.toMat = function () { return Object.create(require('qminer').la.Matrix.prototype); }
 	JsDeclareSpecializedFunction(toMat);
 
 	/**
 	* Saves the vector as output stream (binary serialization).
 	* @param {module:fs.FOut} fout - Output stream.
-	* @returns {module:fs.FOut} fout.
+	* @returns {module:fs.FOut} The output stream `fout`.
 	* @example
 	* // import fs module
 	* var fs = require('qminer').fs;
@@ -469,7 +598,7 @@ private:
 	/**
 	* Loads the vector from input stream (binary deserialization).
 	* @param {module:fs.FIn} fin - Input stream.
-	* @returns {module:la.<% className %>} Self.
+	* @returns {module:la.<% className %>} Self. The vector is filled using the input stream `fin`.
 	* @example
 	* // import fs module
 	* var fs = require('qminer').fs;
@@ -487,7 +616,7 @@ private:
 	/**
 	* Saves the vector as output stream (ascii serialization).
 	* @param {module:fs.FOut} fout - Output stream.
-	* @returns {module:fs.FOut} fout.
+	* @returns {module:fs.FOut} The output stream `fout`.
 	* @example
 	* // import fs module
 	* var fs = require('qminer').fs;
@@ -506,7 +635,7 @@ private:
 	/**
 	* Loads the vector from input stream (ascii deserialization).
 	* @param {module:fs.FIn} fin - Input stream.
-	* @returns {module:la.<% className %>} Self.
+	* @returns {module:la.<% className %>} Self. The vector is filled using the input stream `fin`.
 	* @example
 	* // import fs module
 	* var fs = require('qminer').fs;

--- a/src/nodejs/la/la_vector_nodejs.h
+++ b/src/nodejs/la/la_vector_nodejs.h
@@ -487,8 +487,7 @@ private:
 	JsDeclareSpecializedFunction(normalize);
 
 	/**
-	* Gives the length of vector.
-	* @returns {number} Length of vector.
+	* Gives the length of vector. Type `number`.
     * @example
     * var la = require('qminer').la;
     * // create a new vector

--- a/src/nodejs/qm/qm_nodejs.h
+++ b/src/nodejs/qm/qm_nodejs.h
@@ -14,7 +14,7 @@
 // The only part of node framework: Init
 
 /**
-* Qminer module.
+* QMiner module.
 * @module qm
 * @example 
 * // import module
@@ -28,91 +28,114 @@ public:
     //   v8::Local<v8::Object> TNodeJsRec::New(const TQm::TRec& Rec, const TInt& _Fq)
     static THash<TStr, TUInt> BaseFPathToId;
 private:
-    /*
+    /**
     * Creates a directory structure.
     * @param {string} [configPath='qm.conf'] - The path to configuration file.
     * @param {boolean} [overwrite=false] - If you want to overwrite the configuration file.
     * @param {number} [portN=8080] - The number of the port. Currently not used.
     * @param {number} [cacheSize=1024] - Sets available memory for indexing (in MB).
     */
-    // exports.config = function(configPath, overwrite, portN, cacheSize) {}
+    //# exports.config = function(configPath, overwrite, portN, cacheSize) {}
     JsDeclareFunction(config);
 
-    /*
+    /**
     * Creates an empty base.
     * @param {string} [configPath='qm.conf'] - Configuration file path.
     * @param {string} [schemaPath=''] - Schema file path.
     * @param {boolean} [clear=false] - Clear the existing db folder.
-    * @returns {module:qm.Base}
+    * @returns {module:qm.Base} The newly created base.
     */
-    // exports.create = function (configPath, schemaPath, clear) { return Object.create(require('qminer').Base.prototype); }
+    //# exports.create = function (configPath, schemaPath, clear) { return Object.create(require('qminer').Base.prototype); }
     JsDeclareFunction(create);
 
-    /*
+    /**
     * Opens a base.
     * @param {string} [configPath='qm.conf'] - The configuration file path.
-    * @param {boolean} [readOnly=false] - Open in read only mode?
-    * @returns {module:qm.Base}
+    * @param {boolean} [readOnly=false] - Open in read-only mode.
+    * @returns {module:qm.Base} The loaded base.
     */
-    // exports.open = function (configPath, readOnly) { return Object.create(require('qminer').Base.prototype); }
+    //# exports.open = function (configPath, readOnly) { return Object.create(require('qminer').Base.prototype); }
     JsDeclareFunction(open);
     
     /**
     * Set verbosity of QMiner internals.
-    * @param {number} [level=0] - verbosity level: 0 = no output, 1 = log output, 2 = log and debug output.
+    * @param {number} [level=0] - verbosity level. Possible options:
+    * <br>1. `0` - No output, 
+    * <br>2. `1` - Log output, 
+    * <br>3. `2` - Log and debug output.
     */
     //# exports.verbosity = function (level) { }
     JsDeclareFunction(verbosity);
     
     /**
-    * @property {Object} flags - Returns an object with all compile flags
+    * @typedef {Object} QMinerFlags
+    * The object containing the QMiner compile flags.
+    * @property {string} buildTime - The module build time.
+    * @property {boolean} win - True, if the module is compiled for Windows.
+    * @property {boolean} linux - True, if the module is compiled for Linux.
+    * @property {boolean} darwin - True, if the module is compiled for Darwin.
+    * @property {boolean} x86 - True, if the module is compiled for x86 system.
+    * @property {boolean} x64 - True, if the module is compiled for x64 system.
+    * @property {boolean} omp - True, if the module is compiled for omp.
+    * @property {boolean} debug - True, if the module is compiled for debug mode.
+    * @property {boolean} gcc - True, if the module is compiled for gcc.
+    * @property {boolean} clang - True, if the module is compiled for clang.
+    * @property {boolean} blas - True, if the module is compiled with Blas.
+    * @property {boolean} blas_intel - True, if the module is compiled with Intel Blas.
+    * @property {boolean} blas_amd - True, if the module is compiled with AMD Blas.
+    * @property {boolean} blas_openblas - True, if the module is compiled with OpenBLAS.
+    * @property {boolean} lapacke - True, if the module is compiled with Lapacke. 
     */
-    //# exports.flags = {};
+
+    /**
+    * Returns an object with all compile flags. Type {@link module:qm~QMinerFlags}.
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // get the compile flags
+    * var flags = qm.flags;
+    */
+    //# exports.flags = { buildTime: "", win: true, linux: true, darwin: true, x86: true, x64: true, omp: true, debug: true, gcc: true, clang: true, blas: true, blas_intel: true, blas_amd: true, blas_openblas: true, lapacke: true };
     JsDeclareProperty(flags);
+
+    /**
+    * Returns the module version.
+    * @returns {string} The module version.
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // get the module version
+    * var version = qm.version;
+    */
+    //# exports.version = '';
 };
 
 ///////////////////////////////
 // NodeJs QMiner Base
 
 /**
-* Base access modes.
-* @readonly
-* @enum {string}
-*/
-//# var BaseModes = {
-//#    /** sets up the db folder */
-//#    create: 'create',
-//#    /** cleans the db folder and calls create */
-//#    createClean: 'createClean',
-//#    /** opens with write permissions */
-//#    open: 'open',
-//#    /** opens in read-only mode */
-//#    openReadOnly: 'openReadOnly'
-//# }
-
-/**
-* Base constructor parameter object
 * @typedef {Object} BaseConstructorParam
-* @property  {module:qm~BaseModes} [BaseConstructorParam.mode='openReadOnly'] - Base access mode: 
-* <br> create (sets up the db folder), 
-* <br> createClean (cleans db folder and then sets it up), 
-* <br> open (opens the db with read/write permissions), 
-* <br> openReadOnly (opens the db in read only mode).
-* @property  {number} [BaseConstructorParam.indexCache=1024] - The ammount of memory reserved for indexing (in MB).
-* @property  {number} [BaseConstructorParam.storeCache=1024] - The ammount of memory reserved for store cache (in MB).
-* @property  {string} [BaseConstructorParam.schemaPath=''] - The path to schema definition file.
-* @property  {Array<module:qm~SchemaDefinition>} [BaseConstructorParam.schema=[]] - Schema definition object array.
-* @property  {string} [BaseConstructorParam.dbPath='./db/'] - The path to db directory.
+* Base constructor parameter used for {@link module:qm.Base}.
+* @property  {string} [mode='openReadOnly'] - Base access mode. Can be one of the following:
+* <br>1. `'create'` - Sets up the db folder, 
+* <br>2. `'createClean'` - Cleans db folder and then sets it up, 
+* <br>3. `'open'` - Opens the db with read/write permissions, 
+* <br>4. `'openReadOnly'` - Opens the db in read only mode.
+* @property  {number} [indexCache=1024] - The ammount of memory reserved for indexing (in MB).
+* @property  {number} [storeCache=1024] - The ammount of memory reserved for store cache (in MB).
+* @property  {string} [schemaPath=''] - The path to schema definition file.
+* @property  {Array<module:qm~SchemaDef>} [schema=[]] - Schema definition object array.
+* @property  {string} [dbPath='./db/'] - The path to db directory.
 */
 
 /**
-* Store schema definition object
-* @typedef {Object} SchemaDefinition
-* @property {string} SchemaDefinition.name - The name of the store. Store name can be composed by from English letters, numbers, _ or $ characters. It can only begin with a character.
-* @property {Array<module:qm~SchemaFieldDefinition>} SchemaDefinition.fields - The array of field descriptors. 
-* @property {Array<module:qm~SchemaJoinDefinition>} [SchemaDefinition.joins=[]] - The array of join descriptors, used for linking records from different stores.
-* @property {Array<module:qm~SchemaKeyDefinition>} [SchemaDefinition.keys=[]] - The array of key descriptors. Keys define how records are indexed, which is needed for search using the query language.
-* @property {module:qm~SchemaTimeWindowDefinition} [SchemaDefinition.timeWindow] - Time window description. Stores can have a window, which is used by garbage collector to delete records once they fall out of the time window. Window can be defined by number of records or by time.
+* @typedef {Object} SchemaDef
+* Store schema definition used in {@link module:qm~BaseConstructorParam}.
+* @property {string} name - The name of the store. Store name can be composed by from English letters, numbers, _ or $ characters. It can only begin with a character.
+* @property {Array<module:qm~SchemaFieldDef>} fields - The array of field descriptors. 
+* @property {Array<module:qm~SchemaJoinDef>} [joins=[]] - The array of join descriptors, used for linking records from different stores.
+* @property {Array<module:qm~SchemaKeyDef>} [keys=[]] - The array of key descriptors. Keys define how records are indexed, which is needed for search using the query language.
+* @property {module:qm~SchemaTimeWindowDef} [timeWindow] - Time window description. Stores can have a window, which is used by garbage collector to delete records once they fall out of the time window. Window can be defined by number of records or by time.
 * @example
 * var qm = require('qminer');
 * // create a simple movies store, where each record contains only the movie title.
@@ -127,44 +150,29 @@ private:
 */
 
 /**
-* Field types.
-* @readonly
-* @enum {string}
-*/
-//# var FieldTypes = {
-//#     /** signed 32-bit integer */
-//#     int: 'int', 
-//#     /** vector of signed 32-bit integers */
-//#     int_v: 'int_v', 
-//#     /** string */
-//#     string : 'string',
-//#     /** vector of strings */
-//#     string_v : 'string_v',
-//#     /** boolean */
-//#     bool : 'bool',
-//#     /** double precision floating point number */
-//#     float : 'float',
-//#     /** a pair of floats, useful for storing geo coordinates */
-//#     float_pair : 'float_pair',
-//#     /** vector of floats */
-//#     float_v : 'float_v',
-//#     /** date and time format, stored in a form of milliseconds since 1600 */
-//#     datetime : 'datetime',
-//#     /** sparse vector(same format as used by QMiner JavaScript linear algebra library) */
-//#     num_sp_v : 'num_sp_v',
-//# }
-
-/**
-* Store schema field definition object
-* @typedef {Object} SchemaFieldDefinition
-* @property {string} SchemaFieldDefinition.name - The name of the field.
-* @property {module:qm~FieldTypes} SchemaFieldDefinition.type - The type of the field.
-* @property {boolean} [SchemaFieldDefinition.primary=false] - Field which can be used to identify record. There can be only one primary field in a store. There can be at most one record for each value of the primary field. Currently following fields can be marked as primary: int, uin64, string, float, datetime. Primary fields of type string are also used for record names.
-* @property {boolean} [SchemaFieldDefinition.null=false] - When set to true, null is a possible value for a field (allow missing values).
-* @property {string} [SchemaFieldDefinition.store='memory'] - Defines where to store the field, options are: <b>'cache'</b> or <b>'memory'</b>. The default option is <b>'memory'</b>, which stores the values in RAM. Option <b>'cache'</b> stores the values on disk, with a layer of FIFO cache in RAM, storing the most recently used values.
-* @property {Object} [SchemaFieldDefinition.default] - Default value for field when not given for a new record.
-* @property {boolean} [SchemaFieldDefinition.codebook=false] - Useful when many records have only few different values of this field. If set to true, then a separate table of all values is kept, and records only point to this table (replacing variable string field in record serialisation with fixed-length integer). Useful to decrease memory footprint, and faster to update. (STRING FIELD TYPE SPECIFIC).
-* @property {boolean} [SchemaFieldDefinition.shortstring=false] - Useful for string shorter then 127 characters (STRING FIELD TYPE SPECIFIC).
+* @typedef {Object} SchemaFieldDef
+* Store schema field definition used in {@link module:qm~SchemaDef}.
+* @property {string} name - The name of the field.
+* @property {string} type - The type of the field. Possible options:
+* <br>1. `'int'` - Signed 32-bit integer,
+* <br>2. `'uint64'` - Unsigned 64-bit integer,
+* <br>3. `'int_v'` - Array of signed 32-bit integers,
+* <br>4. `'string'` - String,
+* <br>5. `'string_v'` - Array of strings,
+* <br>6. `'bool'` - Boolean,
+* <br>7. `'float'` - Double precision flating point number,
+* <br>8. `'float_pair'` - A pair of floats, useful for storing geo coordinates,
+* <br>9. `'float_v'` - Array of floats,
+* <br>10. `'datetime'` - Date and time format, stored in a form of miliseconds since 1600,
+* <br>11. `'num_sp_v'` - Array of [`int`, `float`] pairs. See constructor array for {@link module:la.SparseVector}.
+* @property {boolean} [primary=false] - Field which can be used to identify record. There can be only one primary field in a store. There can be at most one record for each value of the primary field. Currently following fields can be marked as primary: `int`, `uint64`, `string`, `float`, `datetime`. Primary fields of type `string` are also used for record querying using {@link module:qm.Store#recordByName}.
+* @property {boolean} [null=false] - When set to true, null is a possible value for a field (allow missing values).
+* @property {string} [store='memory'] - Defines where to store the field. Possible options 
+* <br>1. `'memory'` - Stores the values in RAM. 
+* <br>2 `'cache'` - Stores the values on disk, with a layer of FIFO cache in RAM, storing the most recently used values.
+* @property {Object} [default] - Default value for field when not given for a new record.
+* @property {boolean} [codebook=false] - Useful when many records have only few different values of this field. If set to true, then a separate table of all values is kept, and records only point to this table (replacing variable string field in record serialisation with fixed-length integer). Useful to decrease memory footprint, and faster to update. (STRING FIELD TYPE SPECIFIC).
+* @property {boolean} [shortstring=false] - Useful for string shorter then 127 characters (STRING FIELD TYPE SPECIFIC).
 * @example
 *  var qm = require('qminer');
 *  var base = new qm.Base({
@@ -197,13 +205,13 @@ private:
 */
 
 /**
-* Store schema join definition object
-* @typedef {Object} SchemaJoinDefinition
-* @property {string} SchemaJoinDefinition.name - The name of the join.
-* @property {string} SchemaJoinDefinition.type - The supported types are: <b>'field'</b> and <b>'index'</b>. 
-* <br> A join with type=<b>'field'</b> can point to zero or one record and is implemented as an additional hidden field of type uint64, which can hold the ID of the record it links to. Accessing the record's join returns a record.
-* <br> A join with type=<b>'index'</b> can point to any number of records and is implemented using the inverted index, where for each record a list (vector) of linked records is kept. Accessing the record's join returns a record set.
-* @property {string} SchemaJoinDefinition.store - The store name from which the linked records are.
+* @typedef {Object} SchemaJoinDef
+* Store schema join definition used in {@link module:qm~SchemaDef}.
+* @property {string} name - The name of the join.
+* @property {string} type - Join types. Possible options:
+* <br>1. `'field'` - Points to zero or one record and is implemented as an additional hidden field of type `uint64`, which can hold the ID of the record it links to. Accessing the records join returns a record.
+* <br>2. `'index'` - Point to any number of records and is implemented using the inverted index, where for each record a list (vector) of linked records is kept. Accessing the records join returns a record set.
+* @property {string} store - The store name from which the linked records are.
 * @example
 * var qm = require('qminer');
 * // Create two stores: People which stores only names of persons and Movies, which stores only titles.
@@ -249,17 +257,17 @@ private:
 */
 
 /**
-* Store schema key definition object
-* @typedef {Object} SchemaKeyDefinition
-* @property {string} SchemaKeyDefinition.field - The name of the field that will be indexed.
-* @property {string} SchemaKeyDefinition.type - The supported types are: <b>'value'</b>, <b>'text'</b> and <b>'location'</b>.
-* <br> A key with type=<b>'value'</b> indexes records using an inverted index using full value of the field (no processing).
-*  The key type supports 'string', 'string_v' and 'datetime' fields types.
-* <br> A key with type=<b>'text'</b> indexes string fields by using a tokenizer and text processing. Supported by string fields.
-* <br> A key with type=<b>'location'</b> indexes records as points on a sphere and enables nearest-neighbour queries. Supported by float_pair type fields.
-* @property {string} [SchemaKeyDefinition.name] - Allows using a different name for the key in search queries. This allows for multiple keys to be put against the same field. Default value is the name of the field.
-* @property {string} [SchemaKeyDefinition.vocabulary] - defines the name of the vocabulary used to store the tokens or values. This can be used indicate to several keys to use the same vocabulary, to save on memory. Supported by 'value' and 'text' keys.
-* @property {string} [SchemaKeyDefinition.tokenize] - defines the tokenizer that is used for tokenizing the values stored in indexed fields. Tokenizer uses same parameters as in bag-of-words feature extractor. Default is english stopword list and no stemmer. Supported by 'text' keys.
+* @typedef {Object} SchemaKeyDef
+* Store schema key definition used in {@link module:qm~SchemaDef}.
+* @property {string} field - The name of the field that will be indexed.
+* @property {string} type - Key type. Possible options:
+* <br>1. `'value'` - Indexes records using an inverted index using full value of the field (no processing).
+*  The key type supports `'string'`, `'string_v'` and `'datetime'` fields types.
+* <br>2. `'text'` - Indexes string fields by using a tokenizer and text processing. Supported by `'string'` fields.
+* <br>3. `'location'`- Indexes records as points on a sphere and enables nearest-neighbour queries. Supported by `'float_pair'` type fields.
+* @property {string} [name] - Allows using a different name for the key in search queries. This allows for multiple keys to be put against the same field. Default value is the name of the field.
+* @property {string} [vocabulary] - Defines the name of the vocabulary used to store the tokens or values. This can be used indicate to several keys to use the same vocabulary, to save on memory. Supported by `'value'` and `'text'` keys.
+* @property {string} [tokenize] - Defines the tokenizer that is used for tokenizing the values stored in indexed fields. Tokenizer uses same parameters as in bag-of-words feature extractor. Default is english stopword list and no stemmer. Supported by `'text'` keys.
 * @example
 * var qm = require('qminer');
 * // Create a store People which stores only names of persons.
@@ -281,21 +289,21 @@ private:
 * // search based on indexed values
 * base.search({$from : 'People', name: 'John Smith'}); // Return the record set containing 'John Smith'
 * // search based on indexed values
-* base.search({$from : 'People', name: 'Smith'}); // Returns the empty record set.
+* base.search({$from : 'People', name: 'Smith'}); // Returns the empty record set
 * // search based on text indexing
-* base.search({$from : 'People', nameText: 'Smith'}); // Returns both records.
+* base.search({$from : 'People', nameText: 'Smith'}); // Returns both records
 * base.close();
 */
 
 /**
+* @typedef {Object} SchemaTimeWindowDef
 * Stores can have a window, which is used by garbage collector to delete records once they
 * fall out of the time window. Window can be defined by number of records or by time.
-* Window defined by parameter window, its value being the number of records to be kept.
+* Window defined by parameter window, its value being the number of records to be kept. Used in {@link module:qm~SchemaDef}.
 * <br><b>Important:</b> {@link module:qm.Base#garbageCollect} must be called manually to remove records outside time window.
-* @typedef {Object} SchemaTimeWindowDefinition
-* @property {number} SchemaTimeWindowDefinition.duration - the size of the time window (in number of units).
-* @property {string} SchemaTimeWindowDefinition.unit - defines in which units the window size is specified. Possible values are <b>second</b>, <b>minute</b>, <b>hour</b>, <b>day</b>, <b>week</b> or <b>month</b>.
-* @property {string} [SchemaTimeWindowDefinition.field] - name of the datetime filed, which defines the time of the record. In case it is not given, the insert time is used in its place.
+* @property {number} duration - The size of the time window (in number of units).
+* @property {string} unit - Defines in which units the window size is specified. Possible options are `'second'`, `'minute'`, `'hour'`, `'day'`, `'week'` or `'month'`.
+* @property {string} [field] - Name of the datetime field, which defines the time of the record. In case it is not given, the insert time is used in its place.
 * @example <caption>Define window by number of records</caption>
 * var qm = require('qminer');
 * // create base
@@ -320,13 +328,13 @@ private:
 * }
 *
 * // check number of records in store
-* console.log(base.store("TestStore").allRecords.length); // 5
+* base.store("TestStore").allRecords.length; // 5
 * // clean base with garbage collector
 * base.garbageCollect();
 * // check number of records in store
-* console.log(base.store("TestStore").allRecords.length); // 3
-*
+* base.store("TestStore").allRecords.length; // 3
 * base.close();
+*
 * @example <caption>Define window by time</caption>
 * var qm = require('qminer');
 * // create base
@@ -355,12 +363,11 @@ private:
 * }
 *
 * // check number of records in store
-* console.log(base.store("TestStore").allRecords.length); // 5
+* base.store("TestStore").allRecords.length; // 5
 * // clean base with garbage collector
 * base.garbageCollect();
 * // check number of records in store
-* console.log(base.store("TestStore").allRecords.length); // 2
-*
+* base.store("TestStore").allRecords.length; // 2
 * base.close();
 */
 
@@ -382,19 +389,14 @@ typedef TPt<TNodeJsBaseWatcher> PNodeJsBaseWatcher;
 
 /**
 * Base
-* @classdesc Represents the database and holds stores. The base object can be opened in multiple
-* modes: 'create' - create a new database, 'createClean' - force create, and 'openReadOnly' - open in read-only mode.
+* @classdesc Represents the database and holds stores.
 * @class
 * @param {module:qm~BaseConstructorParam} paramObj - The base constructor parameter object.
-* @property {String} paramObj.mode - The mode in which base is opened.
-* @property [String] paramObj.dbPath - The path to the location of the database.
-* @property [Object] paramObj.schema - The database schema.
-* @property [String] paramObj.strictNames - Wether to use JavaScript compliant field/store names. If set to false, all field/store names are allowed.
 * @example
 * // import qm module
 * var qm = require('qminer');
 * // using a constructor, in open mode
-* var base = new qm.Base({mode: 'open'});
+* var base = new qm.Base({ mode: 'open' });
 * base.close();
 */
 //# exports.Base = function (paramObj) { return Object.create(require('qminer').Base.prototype); };
@@ -421,20 +423,37 @@ private:
 private:
     /**
     * Closes the database.
-    * @returns {null}
+    * @returns {null} No value is returned.
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // using a constructor, in open mode
+    * var base = new qm.Base({ mode: 'open' });
+    * // close the database
+    * base.close();
     */
     //# exports.Base.prototype.close = function () { return null; }
     JsDeclareFunction(close);
 
     /**
     * Checks if the base is closed.
-    * @returns {Boolean}
+    * @returns {Boolean} Returns `true`, if the base is closed.
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // using a constructor, in open mode
+    * var base = new qm.Base({ mode: 'open' });
+    * // check if the base is closed
+    * var closed = base.isClosed();
+    * // close the database
+    * base.close();
     */
+    //# exports.Base.prototype.isClosed = function () { return true; }
     JsDeclareFunction(isClosed);
 
     /**
      * Returns the store with the specified name.
-     * @param {string} name - Name of the store.
+     * @param {string} name - Store name.
      * @returns {module:qm.Store} The store.
      * @example
      * // import qm module
@@ -467,9 +486,9 @@ private:
     JsDeclareFunction(store);
 
 	/**
-	 * Returns the store with the specified name.
-	 * @param {string} name - Name of the store.
-	 * @returns {module:qm.Store} The store.
+	 * Checks if there is a store.
+	 * @param {string} name - Store name.
+	 * @returns {boolean} True, if there exists a store with the store `name`. Otherwise, false.
 	 * @example
 	 * // import qm module
 	 * var qm = require('qminer');
@@ -502,16 +521,48 @@ private:
 
 	/**
 	 * Returns a list of store descriptors.
-	 * @returns {Object[]} The list of store descriptors.
+	 * @returns {Array.<object>} An array of store descriptors. The store descriptor `storeDesc` contains the properties:
+     * <br>1. `storeDesc.storeId` - The store ID. Type `number`.
+     * <br>2. `storeDesc.storeName` - Store name. Type `string`.
+     * <br>3. `storeDesc.storeRecords` - Number of records in store. Type `number`.
+     * <br>4. `storeDesc.fields` - The store field schema. Type <code>Array of <a href="module-qm.html#~SchemaFieldDef">module:qm.SchemaFieldDef</a></code>.
+     * <br>5. `storeDesc.keys` - The store key schema. Type <code>Array of <a href="module-qm.html#~SchemaKeyDef">module:qm.SchemaKeyDef</a></code>.
+     * <br>6. `storeDesc.joins` - The store join schema. Type <code>Array of <a href="module-qm.html#~SchemaJoinDef">module:qm.SchemaJoinDef</a></code>.
+     * @example
+     * // import qm module
+     * var qm = require('qminer');
+     * // create a base with two stores
+     * var base = new qm.Base({
+     *    mode: "createClean",
+     *    schema: [
+     *    {
+     *        name: "KwikEMart",
+     *        fields: [
+     *            { name: "Worker", type: "string" },
+     *            { name: "Groceries", type: "string_v" }
+     *        ]
+     *    },
+     *    {
+     *        name: "NuclearPowerplant",
+     *        fields: [
+     *            { name: "Owner", type: "string" },
+     *            { name: "NumberOfAccidents", type: "int" },
+     *            { name: "Workers", type: "string_v" }
+     *        ]
+     *    }]
+     * });
+     * // get the list of store descriptors
+     * var exists = base.getStoreList();
+     * base.close();
 	 */
-	//# exports.Base.prototype.getStoreList = function () { return [{storeId:'', storeName:'', storeRecords:'', fields: [], keys: [], joins: []}]; }
+	//# exports.Base.prototype.getStoreList = function () { return [{storeId: 0, storeName:'', storeRecords: 0, fields: [{}], keys: [{}], joins: [{}]}]; }
 	JsDeclareFunction(getStoreList);
 
     /**
     * Creates a new store.
-    * @param {Array.<module:qm~SchemaDefinition>} storeDef - The definition of the store(s).
+    * @param {Array.<module:qm~SchemaDef>} storeDef - The definition of the store(s).
     * @param {number} [storeSizeInMB = 1024] - The reserved size of the store(s).
-    * @returns {(module:qm.Store | module:qm.Store[])} - Returns a store or an array of stores (if the schema definition was an array).
+    * @returns {(module:qm.Store | Array.<module:qm.Store>)} - Returns a store or an array of stores (if the schema definition was an array).
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -568,30 +619,130 @@ private:
     JsDeclareFunction(addJsStoreCallback);
 
     /**
-    * Creates a new store.
-    * @param {module:qm~QueryObject} query - query language JSON object 
-    * @returns {module:qm.RecordSet} - Returns the record set that matches the search criterion
+    * @typedef {object} QueryObject
+    * The object used for querying records with {@link module:qm.Base#search}.
+    * How to construct a query is found on the <a href="https://github.com/qminer/qminer/wiki/Query-Language">QMiner Wiki page</a>.
+    */
+
+    /**
+    * Makes a query search and returns a record set.
+    * @param {module:qm~QueryObject} query - Query language JSON object.
+    * @returns {module:qm.RecordSet} The record set that matches the search criterion.
     */
     //# exports.Base.prototype.search = function (query) { return Object.create(require('qminer').RecordSet.prototype); }
 
     JsDeclareFunction(search);   
 
     /**
-    * Calls qminer garbage collector to remove records outside time windows.
+    * Calls qminer garbage collector to remove records outside time windows. For application example see {@link module:qm~SchemaTimeWindowDef}.
     */
     //# exports.Base.prototype.garbageCollect = function () { }
     JsDeclareFunction(garbageCollect);
 
     /**
-    * Calls qminer partial flush - base saves dirty data given some time-window.
-    * @param {number} window - Length of available time-window in msec. Default 500.
+    * Base saves dirty data given some time window.
+    * @param {number} [window=500] - Length of available time window in miliseconds.
+    * @returns {number} Number of records it flushed.
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // create a base with two stores
+    * var base = new qm.Base({
+    *    mode: "createClean",
+    *    schema: [
+    *    {
+    *        name: "KwikEMart",
+    *        fields: [
+    *            { name: "Worker", type: "string" },
+    *            { name: "Groceries", type: "string_v" }
+    *        ]
+    *    },
+    *    {
+    *        name: "NuclearPowerplant",
+    *        fields: [
+    *            { name: "Owner", type: "string" },
+    *            { name: "NumberOfAccidents", type: "int" },
+    *            { name: "Workers", type: "string_v" }
+    *        ]
+    *    }]
+    * });
+    * // call the garbage collector
+    * base.partialFlush();
+    * base.close();
     */
-    //# exports.Base.prototype.partialFlush = function () { }
+    //# exports.Base.prototype.partialFlush = function () { return 0; }
 
     JsDeclareFunction(partialFlush);
 
     /**
+    * @typedef {object} PerformanceStat
+    * The performance statistics used to describe {@link module:qm~PerformanceStatBase} and {@link module:qm~PerformanceStatStore}.
+    * @property {number} alloc_count - \\ TODO: Add the description
+    * @property {number} alloc_size - \\ TODO: Add the description
+    * @property {number} alloc_unused_size - \\ TODO: Add the description
+    * @property {number} avg_get_len - \\ TODO: Add the description
+    * @property {number} avg_put_len - \\ TODO: Add the description
+    * @property {number} avg_get_new_len - \\ TODO: Add the description
+    * @property {number} dels - \\ TODO: Add the description
+    * @property {number} gets - \\ TODO: Add the description
+    * @property {number} puts - \\ TODO: Add the description
+    * @property {number} puts_new - \\ TODO: Add the description
+    * @property {number} released_count - \\ TODO: Add the description
+    * @property {number} released_size - \\ TODO: Add the description
+    * @property {number} size_changes - \\ TODO: Add the description
+    */
+
+    /**
+    * @typedef {object} PerformanceStatStore
+    * The performance statistics of the store found in {@link module:qm~PerformanceStatBase}.
+    * @property {string} name - Store name.
+    * @property {module:qm~PerformanceStat} blob_storage_memory - \\ TODO: Add the description
+    * @property {module:qm~PerformanceStat} blob_storage_cache - \\ TODO: Add the description
+    */
+
+    /**
+    * @typedef {object} PerformanceStatBase
+    * The performance statistics that is returned by {@link module:qm.Base#getStats}.
+    * @property {Array.<module:qm~PerformanceStatStore>} stores - The performance statistics of the stores in base. \\ TODO: Check if this is right
+    * @property {object} gix_stats - The statistics of the base. \\ TODO: Check if this is right
+    * @property {number} gix_stats.avg_len - The average length. \\ TODO: Check if this is right
+    * @property {number} gix_stats.cache_all - The number of cache. \\ TODO: Check if this is right
+    * @property {number} gix_stats.cache_all_loaded_perc - \\ TODO: Add the description
+    * @property {number} gix_stats.cache_dirty - \\ TODO: Add the description
+    * @property {number} gix_stats.cache_dirty_loaded_perc - \\ TODO: Add the description
+    * @property {number} gix_stats.mem_sed - \\ TODO: Add the description
+    * @property {module:qm~PerformanceStat} gix_blob - \\ TODO: Add the description
+    */
+
+    /**
     * Retrieves performance statistics for qminer.
+    * @returns {module:qm~PerformanceStatBase} The performance statistics. 
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // create a base with two stores
+    * var base = new qm.Base({
+    *    mode: "createClean",
+    *    schema: [
+    *    {
+    *        name: "KwikEMart",
+    *        fields: [
+    *            { name: "Worker", type: "string" },
+    *            { name: "Groceries", type: "string_v" }
+    *        ]
+    *    },
+    *    {
+    *        name: "NuclearPowerplant",
+    *        fields: [
+    *            { name: "Owner", type: "string" },
+    *            { name: "NumberOfAccidents", type: "int" },
+    *            { name: "Workers", type: "string_v" }
+    *        ]
+    *    }]
+    * });
+    * // call the garbage collector
+    * base.getStats();
+    * base.close();
     */
     //# exports.Base.prototype.getStats = function () { }
     JsDeclareFunction(getStats);
@@ -599,14 +750,96 @@ private:
     /**
     * Gets the stream aggregate of the given name.
     * @param {string} saName - The name of the stream aggregate.
-    * @returns {module:qm.StreamAggr} The stream aggregate whose name is saName.
+    * @returns {module:qm.StreamAggr} The stream aggregate whose name is `saName`.
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // create a simple base containing one store
+    * var base = new qm.Base({
+    *    mode: "createClean",
+    *    schema: [{
+    *        name: "People",
+    *        fields: [
+    *            { name: "Name", type: "string" },
+    *            { name: "Gendre", type: "string" },
+    *        ]
+    *    },
+    *    {
+    *        name: "Laser",
+    *        fields: [
+    *            { name: "Time", type: "datetime" },
+    *            { name: "WaveLength", type: "float" }
+    *        ]
+    *    }]
+    * });
+    *
+    * // create a new time series window buffer stream aggregator for 'Laser' store (with the JSON object)
+    * var wavelength = {
+    *     name: "WaveLengthLaser",
+    *     type: "timeSeriesWinBuf",
+    *     store: "Laser",
+    *     timestamp: "Time",
+    *     value: "WaveLength",
+    *     winsize: 10000
+    * }
+    * var sa = base.store("Laser").addStreamAggr(wavelength);
+    * // get the stream aggregate with the name 'Laser'
+    * var streamAggr = base.getStreamAggr('WaveLengthLaser');
+    * base.close();
     */
     //# exports.Base.prototype.getStreamAggr = function (saName) { return Object.create(require('qminer').StreamAggr.prototype); }
     JsDeclareFunction(getStreamAggr);
 
     /**
     * Gets an array of the stream aggregate names in the base.
-    * @returns {Array.<string>} The array containing the stream aggregat names.
+    * @returns {Array.<string>} The array containing the stream aggregate names.
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // create a simple base containing one store
+    * var base = new qm.Base({
+    *    mode: "createClean",
+    *    schema: [{
+    *        name: "People",
+    *        fields: [
+    *            { name: "Name", type: "string" },
+    *            { name: "Gendre", type: "string" },
+    *        ]
+    *    },
+    *    {
+    *        name: "Laser",
+    *        fields: [
+    *            { name: "Time", type: "datetime" },
+    *            { name: "WaveLength", type: "float" }
+    *        ]
+    *    }]
+    * });
+    *
+    * // create a new stream aggregator for 'People' store, get the length of the record name (with the function object)
+    * var aggr = new qm.StreamAggr(base, new function () {
+    *    var length = 0;
+    *    this.name = 'nameLength',
+    *    this.onAdd = function (rec) {
+    *        length = rec.Name.length;
+    *    };
+    *    this.saveJson = function (limit) {
+    *        return { val: length };
+    *    }
+    * }, "People");
+    *
+    * // create a new time series window buffer stream aggregator for 'Laser' store (with the JSON object)
+    * var wavelength = {
+    *     name: "WaveLengthLaser",
+    *     type: "timeSeriesWinBuf",
+    *     store: "Laser",
+    *     timestamp: "Time",
+    *     value: "WaveLength",
+    *     winsize: 10000
+    * }
+    * var sa = base.store("Laser").addStreamAggr(wavelength);
+    * // get the stream aggregates names
+    * var streamAggrNames = base.getStreamAggrNames();
+    * base.close();
     */
     //# exports.Base.prototype.getStreamAggrNames = function () { return [""]; }
     JsDeclareFunction(getStreamAggrNames);  
@@ -618,7 +851,7 @@ private:
 // NodeJs-Qminer-Store
 
 /**
-* Stores are containers of records. 
+* Stores are containers of records. <br>
 * <b>Factory pattern:</b> this class cannot be construced using the new keyword. This class is constructed when 
 * calling a specific method or attribute, e.g. constructing the {@link module:qm.Base} using schema or with the 
 * {@link module:qm.Base#createStore}.
@@ -705,7 +938,7 @@ private:
     /**
     * Returns a record from the store.
     * @param {string} recName - Record name.
-    * @returns {(module:qm.Record | null)} Returns the record. If the record doesn't exist, it returns null.
+    * @returns {(module:qm.Record | null)} Returns the record. If the record doesn't exist, it returns `null`.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -735,8 +968,8 @@ private:
     /**
     * Executes a function on each record in store.
     * @param {function} callback - Function to be executed. It takes two parameters:
-    * <br>rec - The current record.
-    * <br>[idx] - The index of the current record.
+    * <br>1. `rec` - The current record. Type {@link module:qm.Record}.
+    * <br>2. `idx` - The index of the current record (<i>optional</i>). Type `number`.
     * @returns {module:qm.Store} Self.
     * @example
     * // import qm module
@@ -767,8 +1000,8 @@ private:
     /**
     * Creates an array of function outputs created from the store records.
     * @param {function} callback - Function that generates the array. It takes two parameters:
-    * <br>rec - The current record.
-    * <br>[idx] - The index of the current record.
+    * <br>1. `rec` - The current record. Type {@link module:qm.Record}.
+    * <br>2. `idx` - The index of the current record (<i>optional</i>). Type `number`.
     * @returns {Array<Object>} The array created by the callback function.
     * @example
     * // import qm module
@@ -798,8 +1031,8 @@ private:
 
     /**
     * Adds a record to the store.
-    * @param {Object} rec - The added record. The record must be a JSON object corresponding to the store schema.
-    * @param {boolean} [triggerEvents=true] - If true, all stream aggregate callbacks onAdd will be called after the record is inserted. If false, no stream aggregate will be updated.
+    * @param {object} rec - The added record. The record must be a object corresponding to store schema created at store creation using {@link module:qm~SchemaDef}.
+    * @param {boolean} [triggerEvents=true] - If true, all stream aggregate callbacks `onAdd` will be called after the record is inserted. If false, no stream aggregate will be updated.
     * @returns {number} The ID of the added record.
     * @example
     * // import qm module
@@ -834,8 +1067,8 @@ private:
 
     /**
     * Creates a new record of given store. The record is not added to the store.
-    * @param {Object} json - A JSON value of the record.
-    * @returns {module:qm.Record} The record created by the JSON value and the store.
+    * @param {object} obj - An object describing the record.
+    * @returns {module:qm.Record} The record created by `obj` and the store.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -857,13 +1090,13 @@ private:
     * var planet = base.store("Planets").newRecord({ Name: "Tatooine", Diameter: 10465, NearestStars: ["Tatoo 1", "Tatoo 2"] });
     * base.close();
     */
-    //# exports.Store.prototype.newRecord = function (json) { return Object.create(require('qminer').Record.prototype); };
+    //# exports.Store.prototype.newRecord = function (obj) { return Object.create(require('qminer').Record.prototype); };
     JsDeclareFunction(newRecord);
 
     /**
     * Creates a new record set out of the records in store.
-    * @param {module:la.IntVector} idVec - The integer vector containing the ids of selected records.
-    * @returns {module:qm.RecordSet} The record set that contains the records gained with idVec.
+    * @param {module:la.IntVector} idVec - The integer vector containing the IDs of selected records.
+    * @returns {module:qm.RecordSet} The record set that contains the records gained with `idVec`.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -893,8 +1126,8 @@ private:
 
     /**
     * Creates a record set containing random records from store.
-    * @param {number} sampleSize - The size of the record set.
-    * @returns {module:qm.RecordSet} Returns a record set containing random records.
+    * @param {number} sampleSize - The size of sample.
+    * @returns {module:qm.RecordSet} Returns a record set containing `sampleSize` random records.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -924,8 +1157,14 @@ private:
 
     /**
     * Gets the details of the selected field.
-    * @param {string} fieldName - The name of the field.
-    * @returns {Object} The JSON object containing the details of the field. 
+    * @param {string} fieldName - The field name.
+    * @returns {object} The object containing the details of the field. The properties are: 
+    * <br>1. `id` - The ID of the field. Type ´number´.
+    * <br>2. `name` - The name of the field. Type `string`.
+    * <br>3. `type` - The type of the field. Type `string`.
+    * <br>4. `nullable` - If the field value can be null. Type `boolean`.
+    * <br>5. `internal` - If the field is internal. Type `boolean`.
+    * <br>6. `primary` - If the field is primary. Type `boolean`.
     * @example
     * // import qm module
     * var qm = require("qminer");
@@ -943,16 +1182,16 @@ private:
     * });
     * // get the details of the field "Name" of store "People"
     * // it returns a JSON object:
-    * // { id: 0, name: "Name", type: "string", primary: true }
+    * // { id: 0, name: "Name", type: "string", primary: true, nullable: false, internal: false }
     * var details = base.store("People").field("Name");
     * base.close();
     */
-    //# exports.Store.prototype.field = function (fieldName) { return { id: 0, name:'', type:'', primary:'' }; }; 
+    //# exports.Store.prototype.field = function (fieldName) { return { id: 0, name:'', type:'', primary: true, internal: true, nullable: true }; }; 
     JsDeclareFunction(field);
 
     /**
     * Checks if the field is of numeric type.
-    * @param {string} fieldName - The checked field.
+    * @param {string} fieldName - The field name.
     * @returns {boolean} True, if the field is of numeric type. Otherwise, false.
     * @example
     * // import qm module
@@ -979,7 +1218,7 @@ private:
 
     /**
     * Checks if the field is of string type.
-    * @param {string} fieldName - The checked field.
+    * @param {string} fieldName - The field name.
     * @returns {boolean} True, if the field is of string type. Otherwise, false.
     * @example
     * // import qm module
@@ -1007,7 +1246,7 @@ private:
 
     /**
     * Checks if the field is of type Date.
-    * @param {string} fieldName - The checked field.
+    * @param {string} fieldName - The field name.
     * @returns {boolean} True, if the field is of type Date. Otherwise, false.
     * @example
     * // import qm module
@@ -1034,9 +1273,18 @@ private:
     JsDeclareFunction(isDate)
 
     /**
-    * Returns the details of the selected key as a JSON object.
-    * @param {string} keyName - The selected key as a JSON object.
-    * @returns {Object} The JSON object containing the details of the key.
+    * @typedef {object} DetailKeyObject
+    * The details about the key object used in {@link module:qm.Store#key} and {@link module:qm.Store#keys}.
+    * @property {module:la.IntVector} fq - The frequency.
+    * @property {module:la.StrVector} vocabulary - The vocabulary.
+    * @property {string} name - The key name.
+    * @property {module:qm.Store} store - The store.
+    */
+
+    /**
+    * Returns the details of the selected key as a object.
+    * @param {string} keyName - The key name.
+    * @returns {module:qm~DetailKeyObject} The object containing the details of the key.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -1062,18 +1310,74 @@ private:
     * var details = base.store("Countries").key("Continent");
     * base.close();
     */
-    //# exports.Store.prototype.key = function (keyName) { return { fq: {}, vocabulary: {}, name:'', store: {} }; };
+    //# exports.Store.prototype.key = function (keyName) { return { fq: Object.create(require('qminer').la.IntVector.prototype), vocabulary: Object.create(require('qminer').la.StrVector.prototype), name:'', store: Object.create(require('qminer').Store.prototype) }; }
     JsDeclareFunction(key);
 
     /**
     * Resets all stream aggregates.
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // create a simple base containing one store
+    * var base = new qm.Base({
+    *    mode: "createClean",
+    *    schema: [{
+    *        name: "Laser",
+    *        fields: [
+    *            { name: "Time", type: "datetime" },
+    *            { name: "WaveLength", type: "float" }
+    *        ]
+    *    }]
+    * });
+    *
+    * // create a new time series window buffer stream aggregator for 'Laser' store (with the JSON object)
+    * var wavelength = {
+    *     name: "WaveLengthLaser",
+    *     type: "timeSeriesWinBuf",
+    *     store: "Laser",
+    *     timestamp: "Time",
+    *     value: "WaveLength",
+    *     winsize: 10000
+    * }
+    * var sa = base.store("Laser").addStreamAggr(wavelength);
+    * // reset the stream aggregates on store "Laser"
+    * base.store("Laser").resetStreamAggregates();
+    * base.close();
     */
     //# exports.Store.prototype.resetStreamAggregates = function () { }
     JsDeclareFunction(resetStreamAggregates);
 
     /**
     * Returns an array of the stream aggregates names connected to the store.		
-    * @returns {Array.<string>} An array of stream aggregates names.		
+    * @returns {Array.<string>} An array of stream aggregates names.
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // create a simple base containing one store
+    * var base = new qm.Base({
+    *    mode: "createClean",
+    *    schema: [{
+    *        name: "Laser",
+    *        fields: [
+    *            { name: "Time", type: "datetime" },
+    *            { name: "WaveLength", type: "float" }
+    *        ]
+    *    }]
+    * });
+    *
+    * // create a new time series window buffer stream aggregator for 'Laser' store (with the JSON object)
+    * var wavelength = {
+    *     name: "WaveLengthLaser",
+    *     type: "timeSeriesWinBuf",
+    *     store: "Laser",
+    *     timestamp: "Time",
+    *     value: "WaveLength",
+    *     winsize: 10000
+    * }
+    * var sa = base.store("Laser").addStreamAggr(wavelength);
+    * // get the stream aggregates on store "Laser"
+    * base.store("Laser").getStreamAggrNames();
+    * base.close();
     */		
     //# exports.Store.prototype.getStreamAggrNames = function () { return [""]; }		
     JsDeclareFunction(getStreamAggrNames);		
@@ -1102,12 +1406,12 @@ private:
     * var json = base.store("FootballPlayers").toJSON();
     * base.close();
     */
-    //# exports.Store.prototype.toJSON = function () { return { storeId:0, storeName:'', storeRecords:'', fields:[], keys:[], joins:[] }; };
+    //# exports.Store.prototype.toJSON = function () { return { storeId:0, storeName:'', storeRecords:0, fields:[{}], keys:[{}], joins:[{}] }; };
     JsDeclareFunction(toJSON);
 
     /**
-    * Deletes the records in the store.
-    * @param {number} [num] - The number of deleted records. If the number is given, the first num records will be deleted.
+    * Deletes the first records in the store.
+    * @param {number} [num] - The number of deleted records. If the number is given, the first `num` records will be deleted.
     * @returns {number} The number of remaining records in the store.
     * @example
     * // import qm module
@@ -1140,7 +1444,7 @@ private:
 
     /**
     * Gives a vector containing the field value of each record.
-    * @param {string} fieldName - The field name. Field must be of one-dimensional type, e.g. int, float, string...
+    * @param {string} fieldName - The field name. Field must be of one-dimensional type, e.g. `int`, `float`, `string`...
     * @returns {module:la.Vector} The vector containing the field values of each record.
     * @example
     * // import qm module
@@ -1169,7 +1473,7 @@ private:
 
     /**
     * Gives a matrix containing the field values of each record.
-    * @param {string} fieldName - The field name. Field mustn't be of type string.
+    * @param {string} fieldName - The field name. Field mustn't be of type `string`.
     * @returns {(module:la.Matrix | module:la.SparseMatrix)} The matrix containing the field values. 
     * @example
     * // import qm module
@@ -1204,8 +1508,8 @@ private:
     /**
     * Gives the field value of a specific record.
     * @param {number} recId - The record id.
-    * @param {string} fieldName - The field's name.
-    * @returns {Object} The fieldName value of the record with recId.
+    * @param {string} fieldName - The field name.
+    * @returns {number | string | Array.<number> | Array.<string>} The `fieldName` value of the record with ID `recId`.
     * @example
     * //import qm module
     * var qm = require('qminer');
@@ -1233,74 +1537,87 @@ private:
     JsDeclareFunction(cell);
 
     /**
-    * Calls onAdd callback on all stream aggregates
-    * @param {(module:qm.Record | number)} [arg=this.last] - The record or recordId which will be passed to onAdd callbacks. If the record or recordId is not provided, the last record will be used. Throws exception if cannot be provided.
+    * Calls `onAdd` callback on all stream aggregates.
+    * @param {(module:qm.Record | number)} [arg] - The record or record ID which will be passed to `onAdd` callbacks. If the record or record ID is not provided, the last record will be used. Throws exception if the record cannot be provided.
+    * <br>Defaults to the last {@link module:qm.Record} in store.
     */
     //# exports.Store.prototype.triggerOnAddCallbacks = function (arg) {};
     JsDeclareFunction(triggerOnAddCallbacks);
 
     /**
-    * Gives the name of the store.
+    * Gives the name of the store. Type `string`.
     */
     //# exports.Store.prototype.name = "";
     JsDeclareProperty(name);
 
     /**
-    * Checks if the store is empty.
+    * Checks if the store is empty. Type `boolean`.
     */
     //# exports.Store.prototype.empty = true;
     JsDeclareProperty(empty);
 
     /**
-    * Gives the number of records.
+    * Gives the number of records. Type `number`.
     */
     //# exports.Store.prototype.length = 0;
     JsDeclareProperty(length);
 
     /**
-    * Creates a record set containing all the records from the store.
+    * Creates a record set containing all the records from the store. Type {@link module:qm.RecordSet}.
     */
     //# exports.Store.prototype.allRecords = Object.create(require('qminer').RecordSet.prototype);
     JsDeclareFunction(allRecords);
 
     /**
-    * Gives an array of all field descriptor JSON objects.
+    * Gives an array of all field descriptor objects. Type `Array of objects`, where the objects contain the properties:
+    * <br>1. `id` - The ID of the field. Type ´number´.
+    * <br>2. `name` - The name of the field. Type `string`.
+    * <br>3. `type` - The type of the field. Type `string`.
+    * <br>4. `nullable` - If the field value can be null. Type `boolean`.
+    * <br>5. `internal` - If the field is internal. Type `boolean`.
+    * <br>6. `primary` - If the field is primary. Type `boolean`.
     */
-    //# exports.Store.prototype.fields = undefinied;
+    //# exports.Store.prototype.fields = [{}];
     JsDeclareProperty(fields);
 
     /**
-    * Gives an array of all join descriptor JSON objects.
+    * Gives an array of all join descriptor objects. Type `Array of objects`, where the objects contain the properties:
+    * <br>1. `id` - The ID of the join. Type ´number´.
+    * <br>2. `name` - The name of the join. Type `string`.
+    * <br>2. `store` - The store the join was created in. Type `string`.
+    * <br>2. `inverse` - The inverse join. Type `string`.
+    * <br>3. `type` - The type of the field. Type `string`.
+    * <br>4. `key` - The index key. Type {@link module:qm~DetailKeyObject}.
     */
-    //# exports.Store.prototype.joins = undefined;
+    //# exports.Store.prototype.joins = [{}];
     JsDeclareProperty(joins);
 
     /**
-    * Gives an array of all key descriptor JSON objects.
+    * Gives an array of all key descriptor objects. Type <code>Array of <a href="module-qm.html#~DetailKeyObject">module:qm~DetailKeyObject</a></code>.
     */
-    //# exports.Store.prototype.keys = undefined;
+    //# exports.Store.prototype.keys = [{}];
     JsDeclareProperty(keys);
 
     /**
-    * Returns the first record of the store.
+    * Returns the first record of the store. Type {@link module:qm.Record}.
     */
     //# exports.Store.prototype.first = Object.create(require('qminer').Record.prototype);
     JsDeclareFunction(first);
 
     /**
-    * Returns the last record of the store.
+    * Returns the last record of the store. Type {@link module:qm.Record}.
     */
     //# exports.Store.prototype.last = Object.create(require('qminer').Record.prototype);
     JsDeclareFunction(last);
 
     /**
-    * Returns an iterator for iterating over the store from start to end.
+    * Returns an iterator for iterating over the store from start to end. Type {@link module:qm.Iterator}.
     */
     //# exports.Store.prototype.forwardIter = Object.create(require('qminer').Iterator.prototype);
     JsDeclareFunction(forwardIter);
 
     /**
-    * Returns an iterator for iterating over the store form end to start.
+    * Returns an iterator for iterating over the store form end to start. Type {@link module:qm.Iterator}.
     */
     //# exports.Store.prototype.backwardIter = Object.create(require('qminer').Iterator.prototype);
     JsDeclareFunction(backwardIter);
@@ -1310,14 +1627,14 @@ private:
     /**
     * Gets the record with the given ID.
     * @param {number} recId - The id of the record.
-    * @returns {module:qm.Record} The record with the ID equal to recId.
+    * @returns {module:qm.Record} The record with the ID equal to `recId`.
     * @ignore
     */
     //# exports.Store.prototype.store = function (recId) { };
     JsDeclIndexedProperty(indexId); 
 
     /**
-    * Returns the base, in which the store is contained.
+    * Returns the base, in which the store is contained. Type {@link module:qm.Base}.
     */
     //# exports.Store.prototype.base = Object.create(require('qminer').Base.prototype);
     JsDeclareFunction(base);
@@ -1328,14 +1645,13 @@ private:
 // NodeJs QMiner Record
 
 /**
-* Records are used for storing data 
-* in {@link module:qm.Store}.
+* Records are used for storing data in {@link module:qm.Store}. <br>
 * <b>Factory pattern</b>: this class cannot be construced using the new keyword. This class is constructed
 * when calling a specific method or attribute, e.g. using {@link module:qm.Store#push} to create a new record in 
 * the store or {@link module:qm.Store#newRecord} to create a new record, that is not saved in the store.
 * @class
 */
-//# exports.Record = function () {}; 
+//# exports.Record = function () { return Object.create(require('qminer').qm.Record.prototype); }; 
 class TNodeJsRec: public node::ObjectWrap {
     friend class TNodeJsUtil;
 private:
@@ -1389,31 +1705,72 @@ private:
     JsDeclareFunction(clone);
     
     /**
-    * Adds a join record `joinRecord` to join `jonName` (string) with join frequency `joinFrequency`
-    * @param {string} joinName - join name
-    * @param {(module:qm.Record | number)} joinRecord - joined record or its ID
-    * @param {number} [joinFrequency=1] - frequency attached to the join
-    * @returns {module:qm.Record} Record.
+    * Adds a join record `joinRecord` to join `joinName` (string) with join frequency `joinFrequency`.
+    * @param {string} joinName - Join name.
+    * @param {(module:qm.Record | number)} joinRecord - Joined record or its ID.
+    * @param {number} [joinFrequency=1] - Frequency attached to the join.
+    * @returns {module:qm.Record} The joined record.
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // Create two stores
+    * var base = new qm.Base({
+    *     mode: 'createClean',
+    *     schema: [
+    *       { name: 'People', 
+    *         fields: [{ name: 'name', type: 'string', primary: true }], 
+    *         joins: [{ name: 'directed', 'type': 'index', 'store': 'Movies', 'inverse': 'director' }] },
+    *       { name: 'Movies', 
+    *         fields: [{ name: 'title', type: 'string', primary: true }], 
+    *         joins: [{ name: 'director', 'type': 'field', 'store': 'People', 'inverse': 'directed' }] }
+    *     ]
+    * });
+    * // Add a record to people and a record to movies
+    * base.store('Movies').push({ title: 'Coffee and Cigarettes' });
+    * base.store('People').push({ name: 'Jim Jarmusch' });
+    *
+    * // add a join between the added records
+    * base.store('People')[0].$addJoin('directed', base.store('Movies')[0]);
+    * base.close();
     */
     //# exports.Record.prototype.$addJoin = function (joinName, joinRecord, joinFrequency) { return Object.create(require('qminer').Record.prototype); }
     JsDeclareFunction(addJoin);
 
     /**
     * Deletes join record `joinRecord` from join `joinName` (string) with join frequency `joinFrequency`.
-    * @param {string} joinName - join name
-    * @param {(module:qm.Record | number)} joinRecord - joined record or its ID
-    * @param {number} [joinFrequency=1] - frequency attached to the join
-    * @returns {module:qm.Record} Record.
+    * @param {string} joinName - Join name.
+    * @param {(module:qm.Record | number)} joinRecord - Joined record or its ID.
+    * @param {number} [joinFrequency=1] - Frequency attached to the join.
+    * @returns {module:qm.Record} The joined record.
+    * @example
+    * // import qm module
+    * var qm = require('qminer');
+    * // Create two stores
+    * var base = new qm.Base({
+    *     mode: 'createClean',
+    *     schema: [
+    *       { name: 'People', 
+    *         fields: [{ name: 'name', type: 'string', primary: true }], 
+    *         joins: [{ name: 'directed', 'type': 'index', 'store': 'Movies', 'inverse': 'director' }] },
+    *       { name: 'Movies', 
+    *         fields: [{ name: 'title', type: 'string', primary: true }], 
+    *         joins: [{ name: 'director', 'type': 'field', 'store': 'People', 'inverse': 'directed' }] }
+    *     ]
+    * });
+    * // Add a record to people and a record to movies
+    * base.store('Movies').push({ title: 'Coffee and Cigarettes', director: { name: 'Jim Jarmusch' } });
+    * // delete the join between the added records
+    * base.store('People')[0].$delJoin('directed', base.store('Movies')[0]);
+    * base.close();
     */
     //# exports.Record.prototype.$delJoin = function (joinName, joinRecord, joinFrequency) { return Object.create(require('qminer').Record.prototype); }
     JsDeclareFunction(delJoin);
 
     /**
     * Creates a JSON version of the record.
-    *
-    * @param {Boolean} [joinRecords=false] - include joined records (only IDs)
-    * @param {Boolean} [joinRecordFields=false] - expand joined record fields
-    * @param {Boolean} [sysFields=true] - if set to true system fields, like $id, will be included
+    * @param {Boolean} [joinRecords=false] - Include joined records (only IDs).
+    * @param {Boolean} [joinRecordFields=false] - Expand joined record fields.
+    * @param {Boolean} [sysFields=true] - If set to true system fields, like $id, will be included.
     * @returns {Object} The JSON version of the record.
     *
     * @example
@@ -1440,29 +1797,29 @@ private:
     * var json = base.store("Musicians").recordByName("Beyonce").toJSON();
     * base.close();
     */
-    //# exports.Record.prototype.toJSON = function () {};
+    //# exports.Record.prototype.toJSON = function () { return {}; };
     JsDeclareFunction(toJSON);
 
     /**
-    * Returns the id of the record.
+    * Returns the id of the record. Type `number`.
     */
     //# exports.Record.prototype.$id = 0;
     JsDeclareProperty(id);
 
     /**
-    * Returns the name of the record.
+    * Returns the name of the record. Type `string`.
     */
     //# exports.Record.prototype.$name = "";
     JsDeclareProperty(name);
 
     /**
-    * Returns the frequency of the record.
+    * Returns the frequency of the record. Type `number`.
     */
     //# exports.Record.prototype.$fq = 0;
     JsDeclareProperty(fq);
 
     /**
-    * Returns the store the record belongs to.
+    * Returns the store the record belongs to. Type {@link module:qm.Store}.
     */
     //# exports.Record.prototype.store = Object.create('qminer').Store.prototype;
     JsDeclareFunction(store);
@@ -1500,13 +1857,13 @@ private:
 // NodeJs QMiner Record Set
 
 /**
-* Record Set is a set of records.
+* Record Set is a set of records. <br>
 * <b>Factory pattern</b>: this class cannot be construced using the new keyword. This class is constructed
 * when calling a specific method or attribute, e.g. using {@link module:qm.Store#allRecords} to get all the records
 * in the store as a record set.
 * @class
 */
-//# exports.RecordSet = function () {}
+//# exports.RecordSet = function () { return Object.create(require('qminer').qm.RecordSet.prototype); }
 class TNodeJsRecSet: public node::ObjectWrap {
     friend class TNodeJsUtil;
 private:
@@ -1752,9 +2109,9 @@ private:
     JsDeclareFunction(reverse);
 
     /**
-    * Sorts the records according to record id.
-    * @param {number} [asc=-1] - If asc > 0, it sorts in ascending order. Otherwise, it sorts in descending order.  
-    * @returns {module:qm.RecordSet} Self. Records are sorted according to record id and asc.
+    * Sorts the records according to record ID.
+    * @param {number} [asc=-1] - If `asc` > 0, it sorts in ascending order. Otherwise, it sorts in descending order.  
+    * @returns {module:qm.RecordSet} Self. Records are sorted according to record ID and `asc`.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -1788,8 +2145,8 @@ private:
 
     /**
     * Sorts the records according to their weight.
-    * @param {number} [asc=1] - If asc > 0, it sorts in ascending order. Otherwise, it sorts in descending order.
-    * @returns {module:qm.RecordSet} Self. Records are sorted according to record weight and asc.
+    * @param {number} [asc=1] - If `asc` > 0, it sorts in ascending order. Otherwise, it sorts in descending order.
+    * @returns {module:qm.RecordSet} Self. Records are sorted according to record weight and `asc`.
     */
     //# exports.RecordSet.prototype.sortByFq = function (asc) { return Object.create(require('qminer').RecordSet.prototype); }; 
     JsDeclareFunction(sortByFq);
@@ -1797,8 +2154,8 @@ private:
     /**
     * Sorts the records according to a specific record field.
     * @param {string} fieldName - The field by which the sort will work.
-    * @param {number} [arc=-1] - if asc > 0, it sorts in ascending order. Otherwise, it sorts in descending order.
-    * @returns {module:qm.RecordSet} Self. Records are sorted according to fieldName and arc.
+    * @param {number} [arc=-1] - if `asc` > 0, it sorts in ascending order. Otherwise, it sorts in descending order.
+    * @returns {module:qm.RecordSet} Self. Records are sorted according to `fieldName` and `arc`.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -1831,10 +2188,10 @@ private:
     /**
     * Sorts the records according to the given callback function.
     * @param {function} callback - The function used to sort the records. It takes two parameters:
-    * <br>1. rec - The first record.
-    * <br>2. rec2 - The second record.
-    * <br>It returns a boolean object.
-    * @returns {module:qm.RecordSet} Self. The records are sorted according to the callback function.
+    * <br>1. `rec` - The first record.
+    * <br>2. `rec2` - The second record.
+    * <br>The function return type `boolean`.
+    * @returns {module:qm.RecordSet} Self. The records are sorted according to the `callback` function.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -1869,7 +2226,7 @@ private:
     * @param {number} [minId] - The minimum id.
     * @param {number} [maxId] - The maximum id.
     * @returns {module:qm.RecordSet} Self. 
-    * <br>1. Contains only the records of the original with ids between minId and maxId, if parameters are given.
+    * <br>1. Contains only the records of the original with IDs between `minId` and `maxId`, if parameters are given.
     * <br>2. Contains all the records of the original, if no parameter is given.
     * @example
     * // import qm require
@@ -1907,9 +2264,8 @@ private:
     * @param {number} [minFq] - The minimum value.
     * @param {number} [maxFq] - The maximum value.
     * @returns {module:qm.RecordSet} Self.
-    * <br>1. Contains only the records of the original with weights between minFq and maxFq, if parameters are given.
+    * <br>1. Contains only the records of the original with weights between `minFq` and `maxFq`, if parameters are given.
     * <br>2. Contains all the records of the original, if no parameter is given.
-    * @ignore
     */
     //# exports.RecordSet.prototype.filterByFq = function (minFq, maxFq) { return Object.create(require('qminer').RecordSet.prototype); };
     JsDeclareFunction(filterByFq);
@@ -1918,12 +2274,13 @@ private:
     * Keeps only the records with a specific value of some field.
     * @param {string} fieldName - The field by which the records will be filtered.
     * @param {(string | number)} minVal -
-    * <br>1. Is a string, if the field type is a string. The exact string to compare.
-    * <br>2. Is a number, if the field type is a number. The minimal value for comparison.
+    * <br>1. If the field type is a `string`, the exact string to compare. Type `number`.
+    * <br>2. If the field type is a `number`, the minimal value for comparison. Type `number`.
     * <br>3. TODO Time field
-    * @param {number} maxVal - Only in combination with minVal for non-string fields. The maximal value for comparison.
-    * @returns {module:qm.RecordSet} Self. Containing only the records with the fieldName value between minVal and maxVal. If the fieldName type is string,
-    * it contains only the records with fieldName equal to minVal.
+    * @param {number} maxVal - Only in combination with `minVal` for non-string fields. The maximal value for comparison.
+    * @returns {module:qm.RecordSet} Self. 
+    * <br>1. If the `fieldName` field type is `number`, contains only the records with the `fieldName` value between `minVal` and `maxVal`. 
+    * <br>2. If the `fieldName` field type is `string`, contains only the records with `fieldName` equal to `minVal`.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -1957,8 +2314,10 @@ private:
 
     /**
     * Keeps only the records that pass the callback function.
-    * @param {function} callback - The filter function. It takes one parameter and return a boolean object.
-    * @returns {module:qm.RecordSet} Self. Containing only the record that pass the callback function.
+    * @param {function} callback - The filter function. It takes one parameter:
+    * <br>1. `rec` - The record in the record set. Type {@link module:qm.Record}.
+    * <br> Returns a `boolean` value.
+    * @returns {module:qm.RecordSet} Self. Contains only the records that pass the callback function.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -1988,7 +2347,10 @@ private:
 
     /**
     * Splits the record set into smaller record sets.
-    * @param {function} callback - The splitter function. It takes two parameters (records) and returns a boolean object.
+    * @param {function} callback - The splitter function. It takes two parameters:
+    * <br>1. `rec` - The first record. Type {@link module:qm.Record}.
+    * <br>2. `rec2` - The second record. Type {@link module:qm.Record}.
+    * <br> Returns a `boolean` value.
     * @returns {Array.<module:qm.RecordSet>} An array containing the smaller record sets. The records are split according the callback function.
     * @example
     * // import qm module
@@ -2026,9 +2388,9 @@ private:
     JsDeclareFunction(split);
 
     /**
-    * Deletes the records, that are also in the other record set.
-    * @param {module:qm.RecordSet} rs - The other record set.
-    * @returns {module:qm.RecordSet} Self. Contains only the records, that are not in rs.
+    * Deletes the records, that are also in the second record set.
+    * @param {module:qm.RecordSet} rs - The second record set.
+    * @returns {module:qm.RecordSet} Self. Contains only the records, that are not in `rs`.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -2090,14 +2452,14 @@ private:
     * var json = recordSet.toJSON();
     * base.close();
     */
-    //# exports.RecordSet.prototype.toJSON = function () {};
+    //# exports.RecordSet.prototype.toJSON = function () { return {}; };
     JsDeclareFunction(toJSON);
 
     /**
     * Executes a function on each record in record set.
     * @param {function} callback - Function to be executed. It takes two parameters:
-    * <br>rec - The current record.
-    * <br>[idx] - The index of the current record.
+    * <br>1. `rec` - The current record. Type {@link module:qm.Record}.
+    * <br>2. `idx` - The index of the current record (<i>optional</i>). Type `number`.
     * @returns {module:qm.RecordSet} Self.
     * @example
     * // import qm module
@@ -2129,8 +2491,8 @@ private:
     /**
     * Creates an array of function outputs created from the records in record set.
     * @param {function} callback - Function that generates the array. It takes two parameters:
-    * <br>rec - The current record.
-    * <br>[idx] - The index of the current record.
+    * <br>1. `rec` - The current record. Type {@link module:qm.Record}.
+    * <br>2. `idx` - The index of the current record (<i>optional</i>). Type `number`.
     * @returns {Array<Object>} The array created by the callback function.
     * @example
     * // import qm module
@@ -2197,7 +2559,7 @@ private:
 
     /**
     * Creates the set union of two record sets.
-    * @param {module:qm.RecordSet} rs - The other record set.
+    * @param {module:qm.RecordSet} rs - The second record set.
     * @returns {module:qm.RecordSet} The union of the two record sets.
     * @example
     * // import qm module
@@ -2270,7 +2632,7 @@ private:
 
     /**
     * Creates a vector containing the field values of records.
-    * @param {string} fieldName - The field from which to take the values. It's type must be one-dimensional, e.g. float, int, string,...
+    * @param {string} fieldName - The field from which to take the values. It's type must be one-dimensional, e.g.  `int`, `float`, `string`...
     * @returns {module:la.Vector} The vector containing the field values of records. The type it contains is dependant of the field type.
     * @example
     * // import qm module
@@ -2304,7 +2666,7 @@ private:
 
     /**
     * Creates a vector containing the field values of records.
-    * @param {string} fieldName - The field from which to take the values. It's type must be numeric, e.g. float, int, float_v, num_sp_v,...
+    * @param {string} fieldName - The field from which to take the values. It's type must be numeric, e.g. `int`, `float`, `float_v`, `num_sp_v`...
     * @returns {(module:la.Matrix|module:la.SparseMatrix)} The matrix containing the field values of records.
     * @example
     * // import qm module
@@ -2339,25 +2701,25 @@ private:
     JsDeclareFunction(getMatrix);
     
     /**
-    * Returns the store, where the records in the record set are stored.
+    * Returns the store, where the records in the record set are stored. Type {@link module:qm.Store}.
     */
     //# exports.RecordSet.prototype.store = Object.create(require('qminer').Store.prototype);
     JsDeclareFunction(store);
 
     /**
-    * Returns the number of records in record set.
+    * Returns the number of records in record set. Type `number`.
     */
     //# exports.RecordSet.prototype.length = 0;
     JsDeclareProperty(length);
 
     /**
-    * Checks if the record set is empty. If the record set is empty, then it returns true. Otherwise, it returns false.
+    * Checks if the record set is empty. If the record set is empty, then it returns true. Otherwise, it returns false. Type `boolean`.
     */
     //# exports.RecordSet.prototype.empty = true;
     JsDeclareProperty(empty);
 
     /**
-    * Checks if the record set is weighted. If the record set is weighted, then it returns true. Otherwise, it returns false.
+    * Checks if the record set is weighted. If the record set is weighted, then it returns true. Otherwise, it returns false. Type `boolean`.
     */
     //# exports.RecordSet.prototype.weighted = true;
     JsDeclareProperty(weighted);
@@ -2369,7 +2731,7 @@ private:
 ///////////////////////////////
 // NodeJs QMiner Store Iterator
 /**
-* Store Iterators allows you to iterate through the records in the store.
+* Store Iterators allows you to iterate through the records in the store. <br>
 * <b>Factory pattern</b>: this class cannot be construced using the new keyword. It is constructed by calling
 * a specific method or attribute, e.g. calling {@link module:qm.Store#forwardIter} to construct the Iterator.
 * @class
@@ -2427,8 +2789,8 @@ public:
     /**
     * Moves to the next record.
     * @returns {boolean} 
-    * <br>1. True, if the iteration successfully moves to the next record.
-    * <br>2. False, if there is no record left.
+    * <br>1. `True`, if the iteration successfully moves to the next record.
+    * <br>2. `False`, if there is no record left.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -2461,13 +2823,13 @@ public:
     JsDeclareFunction(next);
 
     /**
-    * Gives the store of the iterator.
+    * Gives the store of the iterator. Type {@link module:qm.Store}.
     */
     //# exports.Iterator.prototype.store = Object.create(require('qminer').Store.prototype);
     JsDeclareFunction(store);
 
     /**
-    * Gives the current record.
+    * Gives the current record. Type {@link module:qm.Record}.
     */
     //# exports.Iterator.prototype.record = Object.create(require('qminer').Record.prototype);
     JsDeclareFunction(record);
@@ -2593,8 +2955,8 @@ public:
 // NodeJs QMiner Feature Space
 
 /**
-* Feature extractor types.
-* @typedef {Object} FeatureExtractors
+* Feature extractor types. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @typedef {Object} FeatureExtractor
 * @property {module:qm~FeatureExtractorConstant} constant - The constant type.
 * @property {module:qm~FeatureExtractorRandom} random - The random type.
 * @property {module:qm~FeatureExtractorNumeric} numeric - The numeric type.
@@ -2611,10 +2973,10 @@ public:
 
 /**
 * @typedef {Object} FeatureExtractorConstant
-* The feature extractor of type 'contant'.
-* @property {string} FeatureExtractorConstant.type - The type of the extractor. It must be equal <b>'constant'</b>.
-* @property {number} [FeatureExtractorConstant.const = 1.0] - A constant number.
-* @property {module:qm~FeatureSource} FeatureExtractorConstant.source - The source of the extractor.
+* The feature extractor of type `'contant'`. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'constant'`.
+* @property {number} [const = 1.0] - A constant number.
+* @property {string} source - The store name.
 * @example
 * var qm = require('qminer');
 * // create a simple base, where each record contains only a persons name
@@ -2632,10 +2994,10 @@ public:
 
 /**
 * @typedef {Object} FeatureExtractorRandom
-* The feature extractor of type 'random'.
-* @property {string} FeatureExtractorRandom.type - The type of the extractor. It must be equal <b>'random'</b>.
-* @property {number} [FeatureExtractorRandom.seed = 0] - The seed number used to construct the random number.
-* @property {module:qm~FeatureSource} FeatureExtractorRandom.source - The source of the extractor.
+* The feature extractor of type `'random'`. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'random'`.
+* @property {number} [seed = 0] - The seed number used to construct the random number.
+* @property {string} source - The store name.
 * @example
 * var qm = require('qminer');
 * // create a simple base, where each record contains only a persons name
@@ -2653,13 +3015,13 @@ public:
 
 /**
 * @typedef {Object} FeatureExtractorNumeric
-* The feature extractor of type 'numeric'.
-* @property {string} FeatureExtractorNumeric.type - The type of the extractor. It must be equal <b>'numeric'</b>.
-* @property {boolean} [FeatureExtractorNumeric.normalize = 'false'] - Normalize values between 0.0 and 1.0.
-* @property {number} [FeatureExtractorNumeric.min] - The minimal value used to form the normalization.
-* @property {number} [FeatureExtractorNumeric.max] - The maximal value used to form the normalization.
-* @property {string} FeatureExtractorNumeric.field - The name of the field from which to take the value.
-* @property {module:qm~FeatureSource} FeatureExtractorNumeric.source - The source of the extractor.
+* The feature extractor of type `'numeric'`. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'numeric'`.
+* @property {boolean} [normalize = 'false'] - Normalize values between 0.0 and 1.0.
+* @property {number} [min] - The minimal value used to form the normalization.
+* @property {number} [max] - The maximal value used to form the normalization.
+* @property {string} field - The name of the field from which to take the value.
+* @property {string} source - The store name.
 * @example
 * var qm = require('qminer');
 * // create a simple base, where each record contains the student name and it's grade
@@ -2681,12 +3043,12 @@ public:
 
 /**
 * @typedef {Object} FeatureExtractorSparseVector
-* The feature extractor of type 'num_sp_v'.
-* @property {string} FeatureExtractorSparseVector.type - The type of the extractor. It must be equal <b>'num_sp_v'</b>.
-* @property {number} [FeatureExtractorSparseVector.dimension = 0] - Dimensionality of sparse vectors.
-* @property {boolean} [FeatureExtractorSparseVector.normalize = false] - Normalize vectors to L2 norm of 1.0.
-* @property {string} FeatureExtractorSparseVector.field - The name of the field from which to take the value.
-* @property {module:qm~FeatureSource} FeatureExtractorSparseVector.source - The source of the extractor.
+* The feature extractor of type `'num_sp_v'`. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'num_sp_v'`.
+* @property {number} [dimension = 0] - Dimensionality of sparse vectors.
+* @property {boolean} [normalize = false] - Normalize vectors to L2 norm of 1.0.
+* @property {string} field - The name of the field from which to take the value.
+* @property {string} source - The store name.
 * @example
 * var qm = require('qminer');
 * // create a simple base, where each record contains the student name and it's grade
@@ -2708,12 +3070,12 @@ public:
 
 /**
 * @typedef {Object} FeatureExtractorCategorical
-* The feature extractor of type 'categorical'.
-* @property {string} FeatureExtractorCategorical.type - The type of the extractor. It must be equal <b>'categorical'</b>.
-* @property {Array.<Object>} [FeatureExtractorCategorical.values] - A fixed set of values, which form a fixed feature set. No dimensionality changes if new values are seen in the upgrades.
-* @property {number} [FeatureExtractorCategorical.hashDimension] - A hashing code to set the fixed dimensionality. All values are hashed and divided modulo hasDimension to get the corresponding dimension.
-* @property {string} FeatureExtractorCategorical.field - The name of the field form which to take the values.
-* @property {module:qm~FeatureSource} FeatureExtractorCategorical.source - The source of the extractor.
+* The feature extractor of type `'categorical'`. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'categorical'`.
+* @property {Array.<Object>} [values] - A fixed set of values, which form a fixed feature set. No dimensionality changes if new values are seen in the upgrades.
+* @property {number} [hashDimension] - A hashing code to set the fixed dimensionality. All values are hashed and divided modulo hasDimension to get the corresponding dimension.
+* @property {string} field - The name of the field form which to take the values.
+* @property {string} source - The store name.
 * @example
 * var qm = require('qminer');
 * // create a simple base, where each record contains the student name and it's study group
@@ -2736,16 +3098,17 @@ public:
 
 /**
 * @typedef {Object} FeatureExtractorMultinomial
-* The feature extractor of type 'multinomial'.
-* @property {string} FeatureExtractorMultinomial.type - The type of the extractor. It must be equal <b>'multinomial'</b>.
-* @property {boolean} [FeatureExtractorMultinomial.normalize = 'false'] - Normalize the resulting vector of the extractor to have L2 norm 1.0.
-* @property {Array.<Object>} [FeatureExtractorMultinomial.values] - A fixed set of values, which form a fixed feature set, no dimensionality changes if new values are seen in the updates. Cannot be used the same time as datetime.
-* @property {number} [FeatureExtractorMultinomial.hashDimension] - A hashing code to set the fixed dimensionality. All values are hashed and divided modulo hashDimension to get the corresponding dimension.
-* @property {Object} [FeatureExtractorMultinomial.datetime = false] - Same as 'values', only with predefined values which are extracted from date and time (month, day of month, day of week, time of day, hour).
+* The feature extractor of type `'multinomial'`. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'multinomial'`.
+* @property {boolean} [normalize = 'false'] - Normalize the resulting vector of the extractor to have L2 norm 1.0.
+* @property {Array.<Object>} [values] - A fixed set of values, which form a fixed feature set, no dimensionality changes if new values are seen in the updates. Cannot be used the same time as datetime.
+* @property {number} [hashDimension] - A hashing code to set the fixed dimensionality. All values are hashed and divided modulo hashDimension to get the corresponding dimension.
+* @property {Object} [datetime = false] - Same as `'values'`, only with predefined values which are extracted from date and time (`month`, `day of month`, `day of week`, `time of day`, `hour`).
 * <br> This fixes the dimensionality of feature extractor at the start, making it not dimension as new dates are seen. Cannot be used the same time as values.
-* @property {(string|Array.<String>)} FeatureExtractorMultinomial.field - The name of the field from which to take the key value.
-* @property {(string|Array.<String>)} [FeatureExtractorMultinomial.valueField] - The name of the field from which to take the numeric value. When not provided, 1.0 is used as default numeric values for non-zero elements in the vector.
-* @property {module:qm~FeatureSource} FeatureExtractorMultinomial.source - The source of the extractor.
+* @property {(string|Array.<String>)} field - The name of the field from which to take the key value.
+* @property {(string|Array.<String>)} [valueField] - The name of the field from which to take the numeric value. 
+* <br> Defaults to 1.0 for non-zero elements in the vector.
+* @property {string} source - The store name.
 * @example
 * var qm = require('qminer');
 * // create a simple base, where each record contains the student name and an array of study groups
@@ -2770,16 +3133,26 @@ public:
 
 /**
 * @typedef {Object} FeatureExtractorText
-* The feature extractor of type 'text'.
-* @property {string} FeatureExtractorText.type - The type of the extractor. It must be equal <b>'text'</b>.
-* @property {boolean} [FeatureExtractorText.normalize = 'true'] - Normalize the resulting vector of the extractor to have L2 norm 1.0.
-* @property {module:qm~FeatureWeight} [FeatureExtractorText.weight = 'tfidf'] - Type of weighting used for scoring terms.
-* @property {number} [FeatureExtractorText.hashDimension] - A hashing code to set the fixed dimensionality. All values are hashed and divided modulo hashDimension to get the corresponding dimension.
-* @property {string} FeatureExtractorText.field - The name of the field from which to take the value.
-* @property {module:qm~FeatureTokenizer} FeatureExtractorText.tokenizer - The settings for extraction of text.
-* @property {module:qm~FeatureMode} FeatureExtractorText.mode - How are multi-record cases combined into single vector.
-* @property {module:qm~FeatureStream} FeatureExtractorText.stream - Details on forgetting old IDFs when running on stream.
-* @property {module:qm~FeatureSource} FeatureExtractorText.source - The source of the extractor.
+* The feature extractor of type `'text'`. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'text'`.
+* @property {boolean} [normalize = 'true'] - Normalize the resulting vector of the extractor to have L2 norm 1.0.
+* @property {string} [weight = 'tfidf'] - Type of weighting used for scoring terms. Possible options are:
+* <br>1. `'none'` - Sets 1 if the term occurs and 0 otherwise.
+* <br>2. `'tf'` - Sets the term frequency in the document.
+* <br>3. `'idf'` - Sets the inverse document frequency in the document.
+* <br>4. `'tfidf'` - Sets the product of the `tf` and `idf` frequency.
+* @property {number} [hashDimension] - A hashing code to set the fixed dimensionality. All values are hashed and divided modulo hashDimension to get the corresponding dimension.
+* @property {string} field - The name of the field from which to take the value.
+* @property {module:qm~FeatureTokenizer} tokenizer - The settings for extraction of text.
+* @property {string} [mode] - How are multi-record cases combined into single vector. Possible options: 
+* <br>1. `'concatenate'` - Multi-record cases are merged into one document.
+* <br>2. `'centroid'` - Treat each case as a seperate document.
+* <br>3. `'tokenized'` - use the tokenizer option.
+* @property {string} [stream] - Details on forgetting old IDFs when running on stream. Possible options:
+* <br>1. `'field'` - Field name which is providing timestamp. If missing, system time is used (<i>optional</i>).
+* <br>2. `'factor'` - Forgetting factor, by which the olf IDFs are multiplied after each iteration.
+* <br>3. `'interval'` - The time between iterations when the factor is applied, standard JSON time format is used to specify the interval duration.
+* @property {string} source - The store name.
 * @example
 * var qm = require('qminer');
 * // create a simple base, where each record contains the title of the article and it's content
@@ -2804,10 +3177,10 @@ public:
 
 /**
 * @typedef {Object} FeatureExtractorJoin
-* The feature extractor of type 'join'.
-* @property {string} FeatureExtractorJoin.type - The type of the extractor. It must be equal <b>'join'</b>.
-* @property {number} [FeatureExtractorJoin.bucketSize = 1] - The size of the bucket in which we group consecutive records.
-* @property {module:qm~FeatureSource} FeatureExtractorJoin.source - The source of the extractor.
+* The feature extractor of type `'join'`. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'join'`.
+* @property {number} [bucketSize = 1] - The size of the bucket in which we group consecutive records.
+* @property {string} source - The store name.
 * @example
 * // import qm module
 * var qm = require('qminer');
@@ -2815,26 +3188,26 @@ public:
 
 /**
 * @typedef {Object} FeatureExtractorPair
-* The feature extractor of type 'pair'.
-* @property {string} FeatureExtractorPair.type - The type of the extractor. It must be equal <b>'pair'</b>.
-* @property {module:qm~FeatureExtractors} FeatureExtractorPair.first - The first feature extractor.
-* @property {module:qm~FeatureExtractors} FeatureExtractorPair.second - The second feature extractor.
-* @property {module:qm~FeatureSource} FeatureExtractorPair.source - The source of the extractor.
+* The feature extractor of type `'pair'`. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'pair'`.
+* @property {module:qm~FeatureExtractors} first - The first feature extractor.
+* @property {module:qm~FeatureExtractors} second - The second feature extractor.
+* @property {source} source - The store name.
 * @example
 * var qm = require('qminer');
 */
 
 /**
 * @typedef {Object} FeatureExtractorDateWindow
-* The feature extractor of type 'dateWindow'.
-* @property {string} FeatureExtractorDateWindow.type - The type of the extractor. It must be equal <b>'dateWindow'</b>.
-* @property {string} [FeatureExtractorDateWindow.unit = 'day'] - How granular is the time window. The options are: 'day', 'week', 'month', 'year', '12hours', '6hours', '4hours', '2hours',
-* 'hour', '30minutes', '15minutes', '10minutes', 'minute', 'second'.
-* @property {number} [FeatureExtractorDateWindow.window = 1] - The size of the window.
-* @property {boolean} [FeatureExtractorDateWindow.normalize = 'false'] - Normalize the resulting vector of the extractor to have L2 norm 1.0. //TODO
-* @property {number} FeatureExtractorDateWindow.start - //TODO
-* @property {number} FeatureExtractorDateWindow.end - //TODO
-* @property {module:qm~FeatureSource} FeatureExtractorDateWindow.source - The source of the extractor.
+* The feature extractor of type `'dateWindow'`. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'dateWindow'`.
+* @property {string} [unit = 'day'] - How granular is the time window. Possible options are `'day'`, `'week'`, `'month'`, `'year'`, `'12hours'`, `'6hours'`, `'4hours'`, `'2hours'`,
+* `'hour'`, `'30minutes'`, `'15minutes'`, `'10minutes'`, `'minute'`, `'second'`.
+* @property {number} [window = 1] - The size of the window.
+* @property {boolean} [normalize = 'false'] - Normalize the resulting vector of the extractor to have L2 norm 1.0. //TODO
+* @property {number} start - //TODO
+* @property {number} end - //TODO
+* @property {string} source - The store name.
 * @example
 * // import qm module
 * var qm = require('qminer');
@@ -2842,12 +3215,14 @@ public:
 
 /**
 * @typedef {Object} FeatureExtractorJsfunc
-* The feature extractor of type 'jsfunc'.
-* @property {string} FeatureExtractorJsfunc.type - The type of the extractor. It must be equal <b>'jsfunc'</b>.
-* @property {string} FeatureExtractorJsfunc.name - The feature's name.
-* @property {function} FeatureExtractorJsfunc.fun - The javascript function callback. It should take a record as input and return a number or a dense vector.
-* @property {number} [FeatureExtractorJsfunc.dim = 1] - The dimension of the feature extractor.
-* @property {module:qm~FeatureSource} FeatureExtractorJsfunc.source - The source of the extractor.
+* The feature extractor of type `'jsfunc'`. Used for constructing {@link module:qm.FeatureSpace} objects.
+* @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'jsfunc'`.
+* @property {string} name - The features name.
+* @property {function} fun - The javascript function callback. It takes one parameter: 
+* <br>1. `rec` - The record. Type {@link module:qm.Record}.
+* It returns `number` or {@link module:la.Vector}.
+* @property {number} [dim = 1] - The dimension of the feature extractor.
+* @property {string} source - The store name.
 * @example
 * var qm = require('qminer');
 * // create a simple base, where each record contains the name of the student and his study groups
@@ -2873,122 +3248,37 @@ public:
 */
 
 /**
-* From where are the input records taken.
-* @typedef {Object} FeatureSource
-* @property {string} FeatureSource.store - The store name.
-*/
-
-/**
-* Type of weighting used for scoring terms.
-* @readonly
-* @enum {string}
-*/
-//# var FeatureWeight = {
-//#     /** Sets 1 if term occurs, 0 otherwise. */
-//#     none: 'none',
-//#     /** Sets the term frequency in the document. */
-//#     tf: 'tf',
-//#     /** Sets the inverse document frequency in the document. */
-//#     idf: 'idf',
-//#     /** Sets the product of the tf and idf frequency. */
-//#     tfidf: 'tfidf'
-//# }
-
-/**
-* The settings for extraction of text.
+* The settings for extraction of text used in {@link module:qm~FeatureExtractorText}.
 * @typedef {Object} FeatureTokenizer
-* @property {module:qm~FeatureTokenizerType} [FeatureTokenizer.type = 'simple'] - The type of the encoding text.
-* @property {module:qm~FeatureTokenizerStopwords} [FeatureTokenizer.stopwords = 'en'] - The stopwords used for extraction.
-* @property {module:qm~FeatureTokenizerStemmer} [FeatureTokenizer.stemmer = 'none'] - The stemmer used for extraction.
-* @property {boolean} [FeatureTokenizer.uppercase = 'true'] - Changing all words to uppercase.
+* @property {string} [type = 'simple'] - The type of the encoding text. Possible options:
+* <br>1. `'simple'` - The simple encoding.
+* <br>2. `'html'` - The html encoding.
+* <br>3.²`'unicode'` - The unicode encoding.
+* @property {string | Array.<string>} [stopwords = 'en'] - The stopwords used for extraction. Possible options:
+* <br>1. `'none'` - No pre-defined stopword list. Type `string`.
+* <br>2. `'en'` - The english pre-defined stopword list. Type `string`.
+* <br>3. `'si'` - The slovene pre-defined stopword list. Type `string`.
+* <br>4. `'es'` - The spanish pre-defined stopword list. Type `string`.
+* <br>5. `'de'` - The german pre-defined stopword list. Type `string`.
+* <br>6. `array` - An array of stopwords. The array must be given as a parameter. Type `Array of strings`.
+* @property {string} [stemmer = 'none'] - The stemmer used for extraction. Possible options:
+* <br>1. `'true'` - Using the porter stemmer. 
+* <br>2. `'porter'` - Using the porter stemmer. 
+* <br>3. `'none'` - Using no stemmer. 
+* @property {boolean} [uppercase = 'true'] - Changing all words to uppercase.
 */
-
-/**
-* The type of the encoding text.
-* @readonly
-* @enum {string}
-*/
-//# var FeatureTokenizerType = {
-//#     /** The simple encoding. */
-//#     simple: 'simple',
-//#     /** The html encoding. */
-//#     html: 'html',
-//#     /** The unicode encoding. */
-//#     unicode: 'unicode'
-//# }
-
-/**
-* THe stopwords used for extraction.
-* @readonly
-* @enum {Object}
-*/
-//# var FeatureTokenizerStopwords = {
-//#     /** The pre-defined stopword list (none). */
-//#     none: 'none',
-//#     /** The pre-defined stopword list (english). */
-//#     en: 'en',
-//#     /** The pre-defined stopword list (slovene). */
-//#     si: 'si',
-//#     /** The pre-defined stopword list (spanish). */
-//#     es: 'es',
-//#     /** The pre-defined stopword list (german). */
-//#     de: 'de',
-//#     /** An array of stopwords. The array must be given as a parameter instead of 'array'! */
-//#     array: 'array'
-//# }
-
-/**
-* The steemer used for extraction.
-* @readonly
-* @enum {Object}
-*/
-//# var FeatureTokenizerStemmer = {
-//#     /** For using the porter stemmer. */
-//#     boolean: 'true',
-//#     /** For using the porter stemmer. */
-//#     porter: 'porter',
-//#     /** For using no stemmer. */
-//#     none: 'none',
-//# }
-
-/**
-* How are multi-record cases combined into a single vector. //TODO not implemented for join record cases (works only if the start store and the
-* feature store are the same)
-* @readonly
-* @enum {string}
-*/
-//# var FeatureMode = {
-//#     /** Multi-record cases are merged into one document. */
-//#     concatenate: 'concatenate', 
-//#     /** Treat each case as a separate document. */
-//#     centroid: 'centroid', 
-//#     /** Use the tokenizer option */
-//#     tokenized : 'tokenized'
-//# }
-
-/**
-* Details on forgetting old IDFs when running on stream.
-* @readonly
-* @enum {string}
-*/
-//# var FeatureStream = {
-//#     /** (optional) Field name which is providing timestamp, if missing system time is used. */
-//#     field: 'field',
-//#     /** Forgetting factor, by which the old IDFs are multiplied after each iteration. */
-//#     factor: 'factor',
-//#     /** The time between iterations when the factor is applied, standard JSon time format is used to specify the interval duration. */
-//#     interval: 'interval'
-//# }
 
 /////////////////////////////
 // Feature Space Desc
 
 /**
 * Feature Space
-* @classdesc Represents the feature space. It contains any of the {@link module:qm~FeatureExtractors}.
+* @classdesc Represents the feature space. It contains any of the {@link module:qm~FeatureExtractor} objects.
 * @class
 * @param {module:qm.Base} base - The base where the features are extracted from.
-* @param {(Array.<Object> | module:fs.FIn)} param - Array with definiton of extractors or input stream.
+* @param {(Array.<module:qm~FeatureExtractor> | module:fs.FIn)} arg - Constructor arguments. There are two ways of constructing:
+* <br>1. Using an array of {@link module:qm~FeatureExtractor} objects, 
+* <br>2. using a file input stream {@link module:fs.FIn}.
 * @example
 * // import qm module
 * var qm = require('qminer');
@@ -3016,7 +3306,7 @@ public:
 * var ftr = new qm.FeatureSpace(base, { type: "numeric", source: "FtrSpace", field: "Value" });
 * base.close();
 */
-//# exports.FeatureSpace = function (base, extractors) { return Object.create(require('qminer').FeatureSpace.prototype); };
+//# exports.FeatureSpace = function (base, arg) { return Object.create(require('qminer').FeatureSpace.prototype); };
 
 class TNodeJsFtrSpace : public node::ObjectWrap {
     friend class TNodeJsUtil;
@@ -3064,13 +3354,13 @@ private:
 public:
 
     /**
-    * Returns the dimension of the feature space.
+    * Returns the dimension of the feature space. Type `number`.
     */
     //# exports.FeatureSpace.prototype.dim = 0;
     JsDeclareProperty(dim);
     
     /**
-    * Returns an array of the dimensions of each feature extractor in the feature space.
+    * Returns an array of the dimensions of each feature extractor in the feature space. Type `Array of numbers`.
     */
     //# exports.FeatureSpace.prototype.dims = [0];
     JsDeclareProperty(dims);
@@ -3078,14 +3368,14 @@ public:
     /**
     * Serialize the feature space to an output stream.
     * @param {module:fs.FOut} fout - The output stream.
-    * @returns {module:fs.FOut} The output stream.
+    * @returns {module:fs.FOut} The output stream `fout`.
     */
     //# exports.FeatureSpace.prototype.save = function (fout) { return Object.create(require('qminer').fs.FOut.prototype); };
     JsDeclareFunction(save);
 
     /**
     * Clears the feature space.
-    * @returns {module:qm.FeatureSpace} Self. 
+    * @returns {module:qm.FeatureSpace} Self. Features space has been cleared.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -3118,7 +3408,7 @@ public:
 
     /**
     * Adds a new feature extractor to the feature space.
-    * @param {Object} obj - The added feature extractor. It must be given as a JSON object.
+    * @param {module:qm~FeatureExtractor} ftExt - The added feature extractor.
     * @returns {module:qm.FeatureSpace} Self.
     * @example
     * // import qm module
@@ -3149,7 +3439,7 @@ public:
     * ftr.addFeatureExtractor({ type: "text", source: "WeatherForcast", field: "Weather", normalize: true, weight: "tfidf" });      
     * base.close();
     */
-    //# exports.FeatureSpace.prototype.addFeatureExtractor = function (obj) { return Object.create(require('qminer').FeatureSpace.prototype); };
+    //# exports.FeatureSpace.prototype.addFeatureExtractor = function (ftExt) { return Object.create(require('qminer').FeatureSpace.prototype); };
     JsDeclareFunction(addFeatureExtractor);
 
     /**
@@ -3159,7 +3449,7 @@ public:
     * <br> For jsfunc feature extractors, it can update a parameter used in it's function.
     * <br> For dateWindow feature extractor, it can update the start and the end of the window period to form the normalization.
     * @param {module:qm.Record} rec - The record, which updates the feature space.
-    * @returns {module:qm.FeatureSpace} Self.
+    * @returns {module:qm.FeatureSpace} Self. The feature space has been updated.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -3207,7 +3497,7 @@ public:
     * <br> For jsfunc feature extractors, it can update a parameter used in it's function.
     * <br> For dateWindow feature extractor, it can update the start and the end of the window period to form the normalization.
     * @param {module:qm.RecordSet} rs - The record set, which updates the feature space.
-    * @returns {module:qm.FeatureSpace} Self.
+    * @returns {module:qm.FeatureSpace} Self. The feature space has been updated.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -3252,8 +3542,8 @@ public:
     /**
     * Creates a sparse feature vector from the given record.
     * @param {module:qm.Record} rec - The given record.
-    * @param {number} [featureExtractorId] - when given, only use specified feature extractor.
-    * @returns {module:la.SparseVector} The sparse feature vector gained from rec.
+    * @param {number} [idx] - When given, only use specified feature extractor.
+    * @returns {module:la.SparseVector} The sparse feature vector gained from `rec` and `idx`.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -3287,14 +3577,14 @@ public:
     * var vec = ftr.extractSparseVector(base.store("Class")[0]);
     * base.close();
     */
-    //# exports.FeatureSpace.prototype.extractSparseVector = function (rec) { return Object.create(require('qminer').la.SparseVector.prototype); }
+    //# exports.FeatureSpace.prototype.extractSparseVector = function (rec, idx) { return Object.create(require('qminer').la.SparseVector.prototype); }
     JsDeclareFunction(extractSparseVector);
 
     /**
     * Creates a feature vector from the given record.
     * @param {module:qm.Record} rec - The given record.
-    * @param {number} [featureExtractorId] - when given, only use specified feature extractor.
-    * @returns {module:la.Vector} The feature vector gained from rec.
+    * @param {number} [idx] - when given, only use specified feature extractor.
+    * @returns {module:la.Vector} The feature vector gained from `rec` and `idx`.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -3328,22 +3618,23 @@ public:
     * var vec = ftr.extractVector(base.store("Class")[0]);
     * base.close();
     */
-    //# exports.FeatureSpace.prototype.extractVector = function (rec) { return Object.create(require('qminer').la.Vector.prototype); };
+    //# exports.FeatureSpace.prototype.extractVector = function (rec, idx) { return Object.create(require('qminer').la.Vector.prototype); };
     JsDeclareFunction(extractVector);
 
     /**
-     * Extracts a single feature using the feature extractor at index ftrIdx.
-     *
-     * @param {Integer} ftrIdx - index of the feature extractor
-     * @param {Number} val - value to extract
+     * Extracts a single feature using the feature extractor.
+     * @param {Integer} idx - Index of the feature extractor.
+     * @param {Number} val - Value to extract.
+     * @returns {object} The extracted single feature.
      */
+    //# exports.FeatureSpace.prototyp.extractFeature = function (idx, val) { }
     JsDeclareFunction(extractFeature);
     
     /**
     * Extracts the sparse feature vectors from the record set and returns them as columns of the sparse matrix.
     * @param {module:qm.RecordSet} rs - The given record set.
-    * @param {number} [featureExtractorId] - when given, only use specified feature extractor
-    * @returns {module:la.SparseMatrix} The sparse matrix, where the i-th column is the sparse feature vector of the i-th record in rs.
+    * @param {number} [idx] - When given, only use specified feature extractor.
+    * @returns {module:la.SparseMatrix} The sparse matrix, where the i-th column is the sparse feature vector of the i-th record in `rs`.
     * @example
     * // import qm module
     * var qm = require("qminer");
@@ -3371,15 +3662,14 @@ public:
     * var sparseMatrix = ftr.extractSparseMatrix(base.store("Class").allRecords);
     * base.close();
     */
-    //# exports.FeatureSpace.prototype.extractSparseMatrix = function (rs) { return Object.create(require('qminer').la.SparseMatrix.prototype); };
+    //# exports.FeatureSpace.prototype.extractSparseMatrix = function (rs, idx) { return Object.create(require('qminer').la.SparseMatrix.prototype); };
     JsDeclareFunction(extractSparseMatrix);
 
     /**
     * Extracts the feature vectors from the recordset and returns them as columns of a dense matrix.
     * @param {module:qm.RecordSet} rs - The given record set.
-    * @param {number} [featureExtractorId] - when given, only use specified feature extractor.
-
-    * @returns {module:la.Matrix} The dense matrix, where the i-th column is the feature vector of the i-th record in rs.
+    * @param {number} [idx] - when given, only use specified feature extractor.
+    * @returns {module:la.Matrix} The dense matrix, where the i-th column is the feature vector of the i-th record in `rs`.
     * @example
     * // import qm module
     * var qm = require("qminer");
@@ -3410,7 +3700,7 @@ public:
     * var matrix = ftr.extractMatrix(base.store("Class").allRecords);
     * base.close();
     */
-    //# exports.FeatureSpace.prototype.extractMatrix = function (rs) { return Object.create(require('qminer').la.Matrix.prototype); };
+    //# exports.FeatureSpace.prototype.extractMatrix = function (rs, idx) { return Object.create(require('qminer').la.Matrix.prototype); };
     JsDeclareFunction(extractMatrix);
 
     JsDeclareAsyncFunction(extractMatrixAsync, TExtractMatrixTask);
@@ -3418,7 +3708,7 @@ public:
     /**
     * Gives the name of feature extractor at given position.
     * @param {number} idx - The index of the feature extractor in feature space (zero based).
-    * @returns {String} The name of the feature extractor at position idx.
+    * @returns {String} The name of the feature extractor at position `idx`.
     * @example
     * // import qm module
     * var qm = require("qminer");
@@ -3450,7 +3740,7 @@ public:
     /**
     * Gives the name of the feature at the given position.
     * @param {number} idx - The index of the feature in feature space (zero based).
-    * @returns {String} The name of the feature at the position idx.
+    * @returns {String} The name of the feature at the position `idx`.
     * @example
     * // import qm module
     * var qm = require("qminer");
@@ -3487,9 +3777,9 @@ public:
     JsDeclareFunction(getFeature);
 
     /**
-    * Performs the inverse operation of ftrVec. Works only for numeric feature extractors.
+    * Performs the inverse operation of `ftrVec`. Works only for numeric feature extractors.
     * @param {(module:la.Vector | Array.<Object>)} ftr - The feature vector or an array with feature values.
-    * @returns {Array} The inverse of ftr as an Array.
+    * @returns {Array.<Object>} The inverse of `ftr` as an array.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -3532,7 +3822,7 @@ public:
     * Calculates the inverse of a single feature using a specific feature extractor.
     * @param {number} idx - The index of the specific feature extractor.
     * @param {Object} val - The value to be inverted.
-    * @returns {Object} The inverse of val using the feature extractor with index idx.
+    * @returns {Object} The inverse of `val` using the feature extractor with index `idx`.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -3576,8 +3866,8 @@ public:
     * @param {number} idx - The index of the feature extractor.
     * @param {boolean} [keepOffset = 'true'] - For keeping the original indexing in the new vector.
     * @returns {(module:la.Vector | module:la.SparseVector)} 
-    * <br>1. module:la.Vector, if vec is of type module:la.Vector.
-    * <br>2. module:la.SparseVector, if vec is of type module:la.SparseVector.
+    * <br>1. {@link module:la.Vector}, if `vec` is {@link module:la.Vector}.
+    * <br>2. {@link module:la.SparseVector}, if `vec` is {@link module:la.SparseVector}.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -3619,7 +3909,7 @@ public:
 
     /**
     * Extracts string features from the record.
-    * @param {module:qm.Record} rec
+    * @param {module:qm.Record} rec - The record.
     * @returns {Array.<string>} An array containing the strings gained by the extractor.
     * @ignore
     */

--- a/src/nodejs/qm/qm_nodejs_streamaggr.h
+++ b/src/nodejs/qm/qm_nodejs_streamaggr.h
@@ -9,7 +9,7 @@
 #define QMINER_QM_NODEJS_STREAMAGGR
 
 /**
-* Qminer module.
+* QMiner module.
 * @module qm
 * @example
 * // import module
@@ -18,12 +18,14 @@
 
 /**
 * Stream Aggregate
-* @classdesc Represents the stream aggregate. The class can construct these {@link module:qm~StreamAggregators}. Also turn to these stream aggregators to see 
-* which methods are implemented for them.
+* @classdesc Represents a stream aggregate. The class can construct these {@link module:qm~StreamAggregator} objects. Also turn to these stream aggregators to see 
+* which methods are implemented.
 * @class
 * @param {module:qm.Base} base - The base object on which it's created.
-* @param {(Object | function)} json - The JSON object containing the schema of the stream aggregate or the function object defining the operations of the stream aggregate.
-* @param {(string | Array.<string>)} [storeName] - A store name or an array of store names, where the aggregate will be registered.
+* @param {(module:qm~StreamAggregator | function)} arg - Constructor arguments. There are two argument types:
+* <br>1. Using the {@link module:qm~StreamAggregator} object,
+* <br>2. using a function/JavaScript class. The function has defined The object containing the schema of the stream aggregate or the function object defining the operations of the stream aggregate.
+* @param {(string | Array.<string>)} [storeName] - The store names where the aggregate will be registered.
 * @example
 * // import qm module
 * var qm = require('qminer');
@@ -48,14 +50,26 @@
 *
 * // create a new stream aggregator for 'People' store, get the length of the record name (with the function object)
 * var aggr = new qm.StreamAggr(base, new function () {
-*    var length = 0;
+*    var numOfAdds = 0;
+*    var numOfUpdates = 0;
+*    var numOfDeletes = 0;
+*    var time = "";
 *    this.name = 'nameLength',
 *    this.onAdd = function (rec) {
-*        length = rec.Name.length;
+*        numOfAdds += 1;
+*    };
+*    this.onUpdate = function (rec) {
+*        numOfUpdates += 1;
+*    };
+*    this.onDelete = function (rec) {
+*        numOfDeletes += 1;
+*    };
+*    this.onTime = function (ts) {
+*        time = ts;
 *    };
 *    this.saveJson = function (limit) {
-*        return { val: length };
-*    }
+*        return { adds: numOfAdds, updates: numOfUpdates, deletes: numOfDeletes, time: time };
+*    };
 * }, "People");
 *
 * // create a new time series window buffer stream aggregator for 'Laser' store (with the JSON object)
@@ -73,41 +87,41 @@
 //# exports.StreamAggr = function (base, json, storeName) { return Object.create(require('qminer').StreamAggr.prototype); };
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregators
+* @typedef {module:qm.StreamAggr} StreamAggregator
 * Stream aggregator types.
-* @property {module:qm~StreamAggregateTimeSeriesWindow} timeSeries - The time series type.
-* @property {module:qm~StreamAggregateTimeSeriesWindowVector} timeSeriesBufferVector - The time series buffer vector type.
-* @property {module:qm~StreamAggregateRecordBuffer} recordBuffer - The record buffer type.
-* @property {module:qm~StreamAggregateSum} sum - The sum type.
-* @property {module:qm~StreamAggregateMin} min - The minimal type.
-* @property {module:qm~StreamAggregateMax} max - The maximal type.
-* @property {module:qm~StreamAggregateSparseVecSum} sum - The sparse-vector-sum type.
-* @property {module:qm~StreamAggregateTimeSeriesTick} tick - The time series tick type.
-* @property {module:qm~StreamAggregateMovingAverage} ma - The moving average type.
-* @property {module:qm~StreamAggregateEMA} ema - The exponental moving average type.
-* @property {module:qm~StreamAggregateEMASpVec} ema - The exponental moving average for sparse vectors type.
-* @property {module:qm~StreamAggregateMovingVariance} var - The moving variance type.
-* @property {module:qm~StreamAggregateMovingCovariance} cov - The moving covariance type.
-* @property {module:qm~StreamAggregateMovingCorrelation} cor - The moving correlation type.
-* @property {module:qm~StreamAggregateResampler} res - The resampler type.
-* @property {module:qm~StreamAggregateMerger} mer - The merger type.
-* @property {module:qm~StreamAggregateHistogram} hist - The online histogram type.
-* @property {module:qm~StreamAggregateSlottedHistogram} slotted-hist - The online slotted-histogram type.
-* @property {module:qm~StreamAggregateVecDiff} vec-diff - The difference of two vectors (e.g. online histograms) type.
-* @property {module:qm~StreamAggregateSimpleLinearRegression} linReg - The linear regressor type.
+* @property {module:qm~StreamAggrTimeSeriesWindow} timeSeries - The time series type.
+* @property {module:qm~StreamAggrTimeSeriesWindowVector} timeSeriesBufferVector - The time series buffer vector type.
+* @property {module:qm~StreamAggrRecordBuffer} recordBuffer - The record buffer type.
+* @property {module:qm~StreamAggrSum} sum - The sum type.
+* @property {module:qm~StreamAggrMin} min - The minimal type.
+* @property {module:qm~StreamAggrMax} max - The maximal type.
+* @property {module:qm~StreamAggrSparseVecSum} sum - The sparse-vector-sum type.
+* @property {module:qm~StreamAggrTimeSeriesTick} tick - The time series tick type.
+* @property {module:qm~StreamAggrMovingAverage} ma - The moving average type.
+* @property {module:qm~StreamAggrEMA} ema - The exponental moving average type.
+* @property {module:qm~StreamAggrEMASpVec} ema - The exponental moving average for sparse vectors type.
+* @property {module:qm~StreamAggrMovingVariance} var - The moving variance type.
+* @property {module:qm~StreamAggrMovingCovariance} cov - The moving covariance type.
+* @property {module:qm~StreamAggrMovingCorrelation} cor - The moving correlation type.
+* @property {module:qm~StreamAggrResampler} res - The resampler type.
+* @property {module:qm~StreamAggrMerger} mer - The merger type.
+* @property {module:qm~StreamAggrHistogram} hist - The online histogram type.
+* @property {module:qm~StreamAggrSlottedHistogram} slotted-hist - The online slotted-histogram type.
+* @property {module:qm~StreamAggrVecDiff} vec-diff - The difference of two vectors (e.g. online histograms) type.
+* @property {module:qm~StreamAggrSimpleLinearRegression} linReg - The linear regressor type.
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateTimeSeriesWindow
+* @typedef {module:qm.StreamAggr} StreamAggrTimeSeriesWindow
 * This stream aggregator represents the time series window buffer. It stores the values inside a moving window. 
-* It implements all the methods of <b>except</b> {@link module:qm.StreamAggr#getFloat}, {@link module:qm.StreamAggr#getTimestamp}.
-* @property {string} StreamAggregateTimeSeriesWindow.name - The given name of the stream aggregator.
-* @property {string} StreamAggregateTimeSeriesWindow.type - The type of the stream aggregator. It must be equal to <b>'timeSeriesWinBuf'</b>.
-* @property {string} StreamAggregateTimeSeriesWindow.store - The name of the store from which to takes the data.
-* @property {string} StreamAggregateTimeSeriesWindow.timestamp - The field of the store, where it takes the timestamp.
-* @property {string} StreamAggregateTimeSeriesWindow.value - The field of the store, where it takes the values.
-* @property {number} StreamAggregateTimeSeriesWindow.winsize - The size of the window, in milliseconds.
-* @property {number} StreamAggregateTimeSeriesWindow.delay - Delay in milliseconds.
+* It implements all the stream aggregate methods <b>except</b> {@link module:qm.StreamAggr#getFloat} and {@link module:qm.StreamAggr#getTimestamp}.
+* @property {string} name - The given name of the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'timeSeriesWinBuf'`.
+* @property {string} store - The name of the store from which to takes the data.
+* @property {string} timestamp - The field of the store, where it takes the timestamp.
+* @property {string} value - The field of the store, where it takes the values.
+* @property {number} winsize - The size of the window, in milliseconds.
+* @property {number} delay - Delay in milliseconds.
 * @example 
 * // import the qm module
 * var qm = require('qminer');
@@ -139,13 +153,13 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateTimeSeriesWindowVector
+* @typedef {module:qm.StreamAggr} StreamAggrTimeSeriesWindowVector
 * This stream aggregator represents the values read from a time series window buffer.
-* It implements {@link module:qm.StreamAggr#getFloatVector}, {@link module:qm.StreamAggr#getFloatAt}, {@link module:qm.StreamAggr#getFloatLength}.
-* @property {string} StreamAggregateTimeSeriesWindowVector.name - The given name of the stream aggregator.
-* @property {string} StreamAggregateTimeSeriesWindowVector.type - The type of the stream aggregator. It must be equal to <b>'timeSeriesWinBuf'</b>.
-* @property {string} StreamAggregateTimeSeriesWindowVector.store - The name of the store from which to takes the data.
-* @property {string} StreamAggregateTimeSeriesWindowVector.inAggr - The name of the window buffer aggregate that represents the input
+* It implements {@link module:qm.StreamAggr#getFloatVector}, {@link module:qm.StreamAggr#getFloatAt} and {@link module:qm.StreamAggr#getFloatLength}.
+* @property {string} name - The given name of the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'timeSeriesWinBuf'`.
+* @property {string} store - The name of the store from which to takes the data.
+* @property {string} inAggr - The name of the window buffer aggregate that represents the input.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -187,12 +201,12 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateRecordBuffer
+* @typedef {module:qm.StreamAggr} StreamAggrRecordBuffer
 * This stream aggregator represents record buffer. It stores the values inside a moving window.
-* It implements all the methods of <b>except</b> {@link module:qm.StreamAggr#getFloat}, {@link module:qm.StreamAggr#getTimestamp}.
-* @property {string} StreamAggregateTimeSeriesWindow.name - The given name of the stream aggregator.
-* @property {string} StreamAggregateTimeSeriesWindow.type - The type of the stream aggregator. It must be equal to <b>'recordBuffer'</b>.
-* @property {number} StreamAggregateTimeSeriesWindow.size - The size of the window.
+* It implements all the stream aggregate methods <b>except</b> {@link module:qm.StreamAggr#getFloat} and {@link module:qm.StreamAggr#getTimestamp}.
+* @property {string} name - The given name of the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'recordBuffer'`.
+* @property {number} size - The size of the window.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -220,15 +234,15 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateSum
+* @typedef {module:qm.StreamAggr} StreamAggrSum
 * This stream aggregator represents the sum moving window buffer. It sums all the values, that are in the connected stream aggregator.
 * It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloat} returns the sum of the values of the records in the it's buffer window.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
-* @property {string} StreamAggregateSum.name - The given name of the stream aggregator.
-* @property {string} StreamAggregateSum.type - The type of the stream aggregator. It must be equal to <b>'winBufSum'</b>.
-* @property {string} StreamAggregateSum.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateSum.inAggr - The name of the stream aggregator to which it connects and gets data.
+* <br>1. {@link module:qm.StreamAggr#getFloat} returns the sum of the values of the records in its buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in its buffer window.
+* @property {string} name - The given name of the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'winBufSum'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} inAggr - The name of the stream aggregator to which it connects and gets data.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -269,15 +283,15 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateMin
+* @typedef {module:qm.StreamAggr} StreamAggrMin
 * This stream aggregator represents the minimum moving window buffer. It monitors the minimal value in the connected stream aggregator.
 * It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloat} returns the minimal value of the records in it's buffer window.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
-* @property {string} StreamAggregateMin.name - The given name of the stream aggregator.
-* @property {string} StreamAggregateMin.type - The type of the stream aggregator. It must be equal to <b>'winBufMin'</b>.
-* @property {string} StreamAggregateMin.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateMin.inAggr - The name of the stream aggregator to which it connects and gets data.
+* <br>1. {@link module:qm.StreamAggr#getFloat} returns the minimal value of the records in its buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in its buffer window.
+* @property {string} name - The given name of the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'winBufMin'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} inAggr - The name of the stream aggregator to which it connects and gets data.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -318,15 +332,15 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateMax
+* @typedef {module:qm.StreamAggr} StreamAggrMax
 * This stream aggregator represents the maximum moving window buffer. It monitors the maximal value in the connected stream aggregator. 
 * It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloat} returns the maximal value of the records in the it's buffer window.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
-* @property {string} StreamAggregateMax.name - The given name of the stream aggregator.
-* @property {string} StreamAggregateMax.type - The type for the stream aggregator. It must be equal to <b>'winBufMax'</b>.
-* @property {string} StreamAggregateMax.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateMax.inAggr - The name of the stream aggregator to which it connects and gets data.
+* <br>1. {@link module:qm.StreamAggr#getFloat} returns the maximal value of the records in its buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in its buffer window.
+* @property {string} name - The given name of the stream aggregator.
+* @property {string} type - The type for the stream aggregator. <b>Important:</b> It must be equal to `'winBufMax'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} inAggr - The name of the stream aggregator to which it connects and gets data.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -367,15 +381,15 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateSparseVecSum
+* @typedef {module:qm.StreamAggr} StreamAggrSparseVecSum
 * This stream aggregator represents the sparse-vector-sum moving window buffer. It sums all the sparse-vector values, that are in the connected stream aggregator.
 * It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getValueVector} returns the sum of the values of the records in it's buffer window.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
-* @property {string} StreamAggregateSum.name - The given name of the stream aggregator.
-* @property {string} StreamAggregateSum.type - The type of the stream aggregator. It must be equal to <b>'winBufSpVecSum'</b>.
-* @property {string} StreamAggregateSum.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateSum.inAggr - The name of the stream aggregator to which it connects and gets data.
+* <br>1. {@link module:qm.StreamAggr#getValueVector} returns the sum of the values of the records in its buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in its buffer window.
+* @property {string} name - The given name of the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'winBufSpVecSum'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} inAggr - The name of the stream aggregator to which it connects and gets data.
 * @example
 * var qm = require('qminer');
 * var base = new qm.Base({
@@ -425,16 +439,16 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateTimeSeriesTick
+* @typedef {module:qm.StreamAggr} StreamAggrTimeSeriesTick
 * This stream aggregator represents the time series tick window buffer. It exposes the data to other stream aggregators 
-* (similar to {@link module:qm~StreamAggr_TimeSeriesWindow}). It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloat} returns the last value added in it's buffer.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer.
-* @property {string} StreamAggregateTimeSeriesTick.name - The given name for the stream aggregator.
-* @property {string} StreamAggregateTimeSeriesTick.type - The type of the stream aggregator. It must be equal to <b>'timeSeriesTick'</b>.
-* @property {string} StreamAggregateTimeSeriesTick.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateTimeSeriesTick.value - The name of the store field, from which it takes the values.
-* @property {string} StreamAggregateTimeSeriesTick.timestamp - The name of the store field, from which it takes the timestamp.
+* (similar to {@link module:qm~StreamAggrTimeSeriesWindow}). It implements the following methods:
+* <br>1. {@link module:qm.StreamAggr#getFloat} returns the last value added in its buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in its buffer window.
+* @property {string} name - The given name for the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'timeSeriesTick'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} value - The name of the store field, from which it takes the values.
+* @property {string} timestamp - The name of the store field, from which it takes the timestamp.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -465,15 +479,15 @@
 */
 
 /**
-* @typedef {module:qmStreamAggr} StreamAggregateMovingAverage
+* @typedef {module:qmStreamAggr} StreamAggrMovingAverage
 * This stream aggregator represents the moving average window buffer. It calculates the moving average value of the connected stream aggregator values.
 * It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloat} returns the average of the values in it's buffer window.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
-* @property {string} StreamAggregateMovingAverage.name - The given name of the stream aggregator.
-* @property {string} StreamAggregateMovingAverage.type - The type of the stream aggregator. It must be equal to <b>'ma'</b>.
-* @property {string} StreamAggregateMovingAverage.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateMovingAverage.inAggr - The name of the stream aggregator to which it connects and gets data.
+* <br>1. {@link module:qm.StreamAggr#getFloat} returns the average of the values in its buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in its buffer window.
+* @property {string} name - The given name of the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'ma'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} inAggr - The name of the stream aggregator to which it connects and gets data.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -514,22 +528,22 @@
 */
 
 /**
-* @typedef {module:qmStreamAggr} StreamAggregateEMA
+* @typedef {module:qmStreamAggr} StreamAggrEMA
 * This stream aggregator represents the exponential moving average window buffer. It calculates the weighted moving average 
 * of the values in the connected stream aggregator, where the weights are exponentially decreasing.  It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloat} returns the exponentional average of the values in it's buffer window.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
-* @property {string} StreamAggregateEMA.name - The given name for the stream aggregator.
-* @property {string} StreamAggregateEMA.type - The type of the stream aggregator. It must be equal to <b>'ema'</b>.
-* @property {string} StreamAggregateEMA.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateEMA.inAggr - The name of the stream aggregator to which it connects and gets data. 
-* It <b>cannot</b> connect to the {@link module:qm~StreamAggr_TimeSeriesWindow}.
-* @property {string} StreamAggregateEMA.emaType - The type of interpolation. The choices are 'previous', 'linear' and 'next'.
-* <br> Type 'previous' interpolates with the previous value. 
-* <br> Type 'next' interpolates with the next value.
-* <br> Type 'linear' makes a linear interpolation.
-* @property {number} StreamAggregateEMA.interval - The time interval defining the decay. It must be greater than initWindow.
-* @property {number} StreamAggregateEMA.initWindow - The time window of required values for initialization.
+* <br>1. {@link module:qm.StreamAggr#getFloat} returns the exponentional average of the values in its buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in its buffer window.
+* @property {string} name - The given name for the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'ema'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} inAggr - The name of the stream aggregator to which it connects and gets data. 
+* It <b>cannot</b> be connect to the {@link module:qm~StreamAggrTimeSeriesWindow}.
+* @property {string} emaType - The type of interpolation. Possible options are:
+* <br>1. `'previous'` - Interpolates with the previous value. 
+* <br>2. `'next'` - Interpolates with the next value.
+* <br>3. `'linear'` - Makes a linear interpolation.
+* @property {number} interval - The time interval defining the decay. It must be greater than `initWindow`.
+* @property {number} initWindow - The time window of required values for initialization.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -573,18 +587,17 @@
 */
 
 /**
-* @typedef {module:qmStreamAggr} StreamAggregateThreshold
+* @typedef {module:qmStreamAggr} StreamAggrThreshold
 * This stream aggregator represents a threshold indicator. It outputs 1 if the current value in the data streams is
-* above the threshold and 0 otherwise.
-*
-* <br>{@link module:qm.StreamAggr#getFloat} returns the exponentional average of the values in it's buffer window.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
-* @property {string} StreamAggregateThreshold.name - The given name for the stream aggregator.
-* @property {string} StreamAggregateThreshold.type - The type of the stream aggregator. It must be equal to <b>'ema'</b>.
-* @property {string} StreamAggregateThreshold.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateThreshold.inAggr - The name of the stream aggregator to which it connects and gets data.
-* It <b>cannot</b> connect to the {@link module:qm~StreamAggr_TimeSeriesWindow}.
-* @property {string} StreamAggregateEMA.threshold - The threshold mentioned above.
+* above the threshold and 0 otherwise. It implements the following methods:
+* <br>1. {@link module:qm.StreamAggr#getFloat} returns the exponentional average of the values in its buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in its buffer window.
+* @property {string} name - The given name for the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'ema'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} inAggr - The name of the stream aggregator to which it connects and gets data.
+* It <b>cannot</b> be connect to the {@link module:qm~StreamAggrTimeSeriesWindow}.
+* @property {string} threshold - The threshold mentioned above.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -626,23 +639,23 @@
 */
 
 /**
-* @typedef {module:qmStreamAggr} StreamAggregateEMASpVec
+* @typedef {module:qmStreamAggr} StreamAggrEMASpVec
 * This stream aggregator represents the exponential moving average window buffer for sparse vectors. It calculates the weighted moving average
-* of the values in the connected stream aggregator, where the weights are exponentially decreasing.  It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getValueVector} returns the exponentional average of the sparse-vector values in it's buffer window.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
-* @property {string} StreamAggregateEMA.name - The given name for the stream aggregator.
-* @property {string} StreamAggregateEMA.type - The type of the stream aggregator. It must be equal to <b>'ema'</b>.
-* @property {string} StreamAggregateEMA.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateEMA.inAggr - The name of the stream aggregator to which it connects and gets data.
-* It <b>cannot</b> connect to the {@link module:qm~StreamAggr_TimeSeriesWindow}.
-* @property {string} StreamAggregateEMA.emaType - The type of interpolation. The choices are 'previous', 'linear' and 'next'.
-* <br> Type 'previous' interpolates with the previous value.
-* <br> Type 'next' interpolates with the next value.
-* <br> Type 'linear' makes a linear interpolation.
-* @property {number} StreamAggregateEMA.interval - The time interval defining the decay. It must be greater than initWindow.
-* @property {number} StreamAggregateEMA.initWindow - The time window of required values for initialization. Optional, default is 0.
-* @property {number} StreamAggregateEMA.cuttof - Minimal value for any dimension. If value of certain dimension falls bellow thsi value, the dimension is pruned from average. Optional, default is 0.001.
+* of the values in the connected stream aggregator, where the weights are exponentially decreasing. It implements the following methods:
+* <br>1. {@link module:qm.StreamAggr#getValueVector} returns the exponentional average of the sparse vector values in its buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in its buffer window.
+* @property {string} name - The given name for the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'ema'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} inAggr - The name of the stream aggregator to which it connects and gets data.
+* It <b>cannot</b> be connect to the {@link module:qm~StreamAggrTimeSeriesWindow}.
+* @property {string} emaType - The type of interpolation. Possible options:
+* <br>1. `'previous'` - Interpolates with the previous value.
+* <br>2. `'next'` - Interpolates with the next value.
+* <br>3. `'linear'` - Makes a linear interpolation.
+* @property {number} interval - The time interval defining the decay. It must be greater than `initWindow`.
+* @property {number} [initWindow=0] - The time window of required values for initialization.
+* @property {number} [cuttof=0.001] - Minimal value for any dimension. If value of certain dimension falls bellow this value, the dimension is pruned from average.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -659,7 +672,7 @@
 *    }]
 * });
 * var store = base.store("Data");
-* // create a new time series that emits data as sparse vector, based on text.
+* // create a new time series that emits data as sparse vector, based on text
 * var aggr = {
 *    name: 'featureSpaceWindow',
 *    type: 'timeSeriesWinBufFeatureSpace',
@@ -700,16 +713,17 @@
 * ema.getValueVector().print();
 * base.close();
 */
+
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateMovingVariance
+* @typedef {module:qm.StreamAggr} StreamAggrMovingVariance
 * This stream aggregator represents the moving variance window buffer. It calculates the moving variance of the stream aggregator, that it's connected to. 
 * It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloat} returns the variance of the values in it's buffer window.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
-* @property {string} StreamAggregateMovingVariance.name - The given name for the stream aggregator.
-* @property {string} StreamAggregateMovingVariance.type - The type of the stream aggregator. It must be equal to <b>'variance'</b>.
-* @property {string} StreamAggregateMovingVariance.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateMovingVariance.inAggr - The name of the stream aggregator to which it connects and gets data.
+* <br>1. {@link module:qm.StreamAggr#getFloat} returns the variance of the values in its buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in its buffer window.
+* @property {string} name - The given name for the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'variance'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} inAggr - The name of the stream aggregator to which it connects and gets data.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -727,7 +741,7 @@
 * });
 *
 * // create a new time series stream aggregator for the 'Heat' store, that takes the values from the 'Celsius' field
-* // and the timestamp from the 'Time' field. The size of the window is 1 day.
+* // and the timestamp from the 'Time' field. The size of the window is 1 day
 * var timeser = {
 *    name: 'TimeSeriesAggr',
 *    type: 'timeSeriesWinBuf',
@@ -750,16 +764,16 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateMovingCovariance
+* @typedef {module:qm.StreamAggr} StreamAggrMovingCovariance
 * This stream aggregator represents the moving covariance window buffer. It calculates the moving covariance of the two stream aggregators, that it's connected to.
 * It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloat} returns the covariance of the values in it's buffer window.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
-* @property {string} StreamAggregateMovingCovariance.name - The given name for the stream aggregator.
-* @property {string} StreamAggregateMovingCovariance.type - The type of the stream aggregator. It must be equal to <b>'covariance'</b>.
-* @property {string} StreamAggregateMovingCovariance.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateMovingCovariance.inAggrX - The name of the first stream aggregator to which it connects and gets data.
-* @property {string} StreamAggregateMovingCovariance.inAggrY - The name of the recond stream aggregator to which it connects and gets data.
+* <br>1. {@link module:qm.StreamAggr#getFloat} returns the covariance of the values in its buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in its buffer window.
+* @property {string} name - The given name for the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'covariance'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} inAggrX - The name of the first stream aggregator to which it connects and gets data.
+* @property {string} inAggrY - The name of the recond stream aggregator to which it connects and gets data.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -812,17 +826,17 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateMovingCorrelation
+* @typedef {module:qm.StreamAggr} StreamAggrMovingCorrelation
 * This stream aggregator represents the moving covariance window buffer. It calculates the moving correlation of the three stream aggregators,
 * that it's connected to. It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloat} returns the correlation of the values in it's buffer window.
-* <br>{@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
-* @property {string} StreamAggregateMovingCorrelation.name - The given name for the stream aggregator.
-* @property {string} StreamAggregateMovingCorrelation.type - The type of the stream aggregator. It must be equal to <b>'correlation'</b>.
-* @property {string} StreamAggregateMovingCorrelation.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateMovingCorrelation.inAggrCov - The name of the covariance stream aggregator.
-* @property {string} StreamAggregateMovingCorrelation.inAggrVarX - The name of the first variance stream aggregator.
-* @property {string} StreamAggregateMovingCorrelation.inAggrVarY - The name of the second variance stream aggregator.
+* <br>1. {@link module:qm.StreamAggr#getFloat} returns the correlation of the values in it's buffer window.
+* <br>2. {@link module:qm.StreamAggr#getTimestamp} returns the timestamp of the newest record in it's buffer window.
+* @property {string} name - The given name for the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'correlation'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} inAggrCov - The name of the covariance stream aggregator.
+* @property {string} inAggrVarX - The name of the first variance stream aggregator.
+* @property {string} inAggrVarY - The name of the second variance stream aggregator.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -841,7 +855,7 @@
 * });
 *
 * // create a new time series stream aggregator for the 'Heat' store, that takes the values from the 'Celsius' field
-* // and the timestamp from the 'Time' field. The size of the window is 1 day.
+* // and the timestamp from the 'Time' field. The size of the window is 1 day
 * var Celsius = {
 *    name: 'CelsiusAggr',
 *    type: 'timeSeriesWinBuf',
@@ -852,7 +866,7 @@
 * }; base.store("Heat").addStreamAggr(Celsius);
 *
 * // create a new time series stream aggregator for the 'Heat' store, that takes the values from the 'WaterConsumption' field
-* // and the timestamp from the 'Time' field. The size of the window is 1 day.
+* // and the timestamp from the 'Time' field. The size of the window is 1 day
 * var water = {
 *    name: 'WaterAggr',
 *    type: 'timeSeriesWinBuf',
@@ -871,7 +885,7 @@
 *    inAggrY: 'WaterAggr'
 * }; base.store("Heat").addStreamAggr(covariance);
 *
-* // add the two variance aggregators, that take from the 'Celsius' and 'WaterConsumption' fields, respectively.
+* // add the two variance aggregators, that take from the 'Celsius' and 'WaterConsumption' fields, respectively
 * var celVar = {
 *    name: 'CelsiusVarAggr',
 *    type: 'variance',
@@ -900,20 +914,19 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateResampler
+* @typedef {module:qm.StreamAggr} StreamAggrResampler
 * This stream aggregator represents the resampler window buffer. It creates new values that are interpolated by using the values from an existing store.
 * No methods are implemented for this aggregator. 
-* @property {string} StreamAggregateResampler.name - The given name for the stream aggregator.
-* @property {string} StreamAggregateResampler.type - The type of the stream aggregator. It must be equal to <b>'resampler'</b>.
-* @property {string} StreamAggregateResampler.store - The name of the store from which it takes the data.
-* @property {string} StreamAggregateResampler.outStore - The store in which the samples are stored.
-* @property {string} StreamAggregateResampler.timestamp - The store field from which it takes the timestamps.
-* @property {Object} StreamAggregateResampler.fields - The json, which contains:
-* <br> name (string) - the store field from which it takes the values.
-* <br> interpolator (string) - the type of the interpolation. The options are 'previous', 'next' and 'linear'.
-* <br> The 'previous' type interpolates with the previous value.
-* @property {boolean} StreamAggregateResampler.createStore - If the outStore must be created.
-* @property {number} StreamAggregateResampler.interval - The size/frequency the interpolated values should be given.
+* @property {string} name - The given name for the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'resampler'`.
+* @property {string} store - The name of the store from which it takes the data.
+* @property {string} outStore - The store in which the samples are stored.
+* @property {string} timestamp - The store field from which it takes the timestamps.
+* @property {Array.<Object>} fields - The array off `field` objects from which it takes the values. The `field` object contain the properties: 
+* <br>`field.name` - The store field from which it takes the values. Type `string`.
+* <br>`field.interpolator` - The type of the interpolation. The options are `'previous'`, `'next'` and `'linear'`. Type `string`.
+* @property {boolean} createStore - If true, `outStore` must be created.
+* @property {number} interval - The interval size. The frequency on which it makes the interpolated values.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -938,7 +951,7 @@
 * });
 * // create a new resampler stream aggregator for the 'Heat' store, that takes the values from the 'Celsius' field
 * // and the timestamp from the 'Time' field. The interpolated values are stored in the 'interpolatedValues' store.
-* // The interpolation should be linear and the interval should be 2 seconds.
+* // The interpolation should be linear and the interval should be 2 seconds
 * var res = {
 *    name: 'resamplerAggr',
 *    type: 'resampler',
@@ -957,21 +970,21 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateMerger
+* @typedef {module:qm.StreamAggr} StreamAggrMerger
 * This stream aggregator represents the merger aggregator. It merges records from two or more stores into a new store
 * depending on the timestamp. No methods are implemented for this aggregator.
 * <image src="pictures/merger.gif" alt="Merger Animation">
-* @property {string} StreamAggregateMerger.name - The given name for the stream aggregator.
-* @property {string} StreamAggregateMerger.type - The type of the stream aggregator. It must be equal to <b>'merger'</b>.
-* @property {string} StreamAggregateMerger.outStore - The name of the store where it saves the merged records.
-* @property {boolean} StreamAggregateMerger.createStore - If the outStore must be created.
-* @property {string} StreamAggregateMerger.timestamp - The store field of outStore, where the timestamp is saved.
-* @property {Array.<Object>} StreamAggregateMerger.fields - An array of json objects. The json objects contain:
-* <br> source (string) - The name of the store, from which it takes the values.
-* <br> inField (string) - The field name of source, from which it takes the values.
-* <br> outField (string) - The field name of outStore, into which it saves the values.
-* <br> interpolation (string) - The type of the interpolation. The options are: 'previous', 'next' and 'linear'.
-* <br> timestamp (string) - The field name of source, where the timestamp is saved. 
+* @property {string} name - The given name for the stream aggregator.
+* @property {string} type - The type of the stream aggregator. <b>Important:</b> It must be equal to `'merger'`.
+* @property {string} outStore - The name of the store where it saves the merged records.
+* @property {boolean} createStore - If the outStore must be created.
+* @property {string} timestamp - The store field of outStore, where the timestamp is saved.
+* @property {Array.<Object>} fields - An array of `field` objects. The `field` object contain the properties: 
+* <br>`field.source` - The name of the store, from which it takes the values. Type `string`.
+* <br>`field.inField` - The field name of source, from which it takes the values. Type `string`.
+* <br>`field.outField` - The field name of outStore, into which it saves the values. Type `string`.
+* <br>`field.interpolation` - The type of the interpolation. The options are: `'previous'`, `'next'` and `'linear'`. Type `string`.
+* <br>`field.timestamp` - The field name of source, where the timestamp is saved. Type `string`.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -1020,28 +1033,25 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateHistogram
-* This stream aggregator represents an online histogram. It can connect to a buffered aggregate (such as {@link module:qm~StreamAggregateTimeSeriesWindow})
+* @typedef {module:qm.StreamAggr} StreamAggrHistogram
+* This stream aggregator represents an online histogram. It can connect to a buffered aggregate (such as {@link module:qm~StreamAggrTimeSeriesWindow})
 * or a time series (such as {@link module:qm~StreamAggregateEMA}).
-* The aggregate defines an ordered set of points p(0), ..., p(n) that define n bins. Infinites at both ends are allowed.
-* A new measurement is tested for inclusion in the left-closed right-opened intervals [p(i), p(i+1)) and the corresponding
+* The aggregate defines an ordered set of points `p(0), ..., p(n)` that define n bins. Infinites at both ends are allowed.
+* A new measurement is tested for inclusion in the left-closed right-opened intervals `[p(i), p(i+1))` and the corresponding
 * bin counter is increased for the appropriate bin (or decreased if the point is outgoing from the buffer).
-
 * It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloatLength} returns the number of bins.
-* <br>{@link module:qm.StreamAggr#getFloatAt} returns the count for a bin index.
-* <br>{@link module:qm.StreamAggr#getFloatVector} returns the vector of counts, the length is equal to the number of bins.
-
+* <br>1. {@link module:qm.StreamAggr#getFloatLength} returns the number of bins.
+* <br>2. {@link module:qm.StreamAggr#getFloatAt} returns the count for a bin index.
+* <br>3. {@link module:qm.StreamAggr#getFloatVector} returns the vector of counts, the length is equal to the number of bins.
 * @property {string} name - The given name of the stream aggregator.
-* @property {string} type - The type for the stream aggregator. It must be equal to <b>'onlineHistogram'</b>.
+* @property {string} type - The type for the stream aggregator. <b>Important:</b> It must be equal to `'onlineHistogram'`.
 * @property {string} store - The name of the store from which it takes the data.
 * @property {string} inAggr - The name of the stream aggregator to which it connects and gets data.
 * @property {number} lowerBound - The lowest non-infinite bin point.
 * @property {number} upperBound - The highest non-infinite bin point.
 * @property {number} [bins=5] - The number of bins bounded by `lowerBound` and `upperBound`.
-* @property {boolean} [addNegInf=false] - Include a bin [-Inf, lowerBound].
-* @property {boolean} [addPosInf=false] - Include a bin [upperBound, Inf].
-
+* @property {boolean} [addNegInf=false] - Include a bin `[-Inf, lowerBound]`.
+* @property {boolean} [addPosInf=false] - Include a bin `[upperBound, Inf]`.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -1087,27 +1097,25 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateSlottedHistogram
-* This stream aggregator represents an online slotted histogram. It can connect to a buffered aggregate (such as {@link module:qm~StreamAggregateTimeSeriesWindow})
+* @typedef {module:qm.StreamAggr} StreamAggrSlottedHistogram
+* This stream aggregator represents an online slotted histogram. It can connect to a buffered aggregate (such as {@link module:qm~StreamAggrTimeSeriesWindow})
 * or a time series (such as {@link module:qm~StreamAggregateEMA}). 
 * It maps historical values into single period (e.g. into hours of the week). 
-* The aggregate defines an ordered set of points p(0), ..., p(n) that define n bins. Infinites at both ends are NOT allowed.
-* A new measurement is tested for inclusion in the left-closed right-opened intervals [p(i), p(i+1)) and the corresponding
+* The aggregate defines an ordered set of points `p(0), ..., p(n)` that define n bins. Infinites at both ends are NOT allowed.
+* A new measurement is tested for inclusion in the left-closed right-opened intervals `[p(i), p(i+1))` and the corresponding
 * bin counter is increased for the appropriate bin (or decreased if the point is outgoing from the buffer).
-
 * It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloatLength} returns the number of bins.
-* <br>{@link module:qm.StreamAggr#getFloatAt} returns the count for a bin index.
-* <br>{@link module:qm.StreamAggr#getFloatVector} returns the vector of counts, the length is equal to the number of bins.
-
+* <br>1. {@link module:qm.StreamAggr#getFloatLength} returns the number of bins.
+* <br>2. {@link module:qm.StreamAggr#getFloatAt} returns the count for a bin index.
+* <br>3. {@link module:qm.StreamAggr#getFloatVector} returns the vector of counts, the length is equal to the number of bins.
 * @property {string} name - The given name of the stream aggregator.
-* @property {string} type - The type for the stream aggregator. It must be equal to <b>'onlineHistogram'</b>.
+* @property {string} type - The type for the stream aggregator. <b>Important:</b> It must be equal to `'onlineHistogram'`.
 * @property {string} store - The name of the store from which it takes the data.
 * @property {string} inAggr - The name of the stream aggregator to which it connects and gets data.
-* @property {number} period - Cycle length in msec.
+* @property {number} period - Cycle length in miliseconds.
 * @property {number} window - Window length that is reported when aggregate is queried.
-* @property {number} bins - The number of bins - input data is expected to be withing interval [0, bins-1].
-* @property {number} granularity - Storage granularity in msec. History is stored in slots with this length. Number of slots=period/granularity
+* @property {number} bins - The number of bins - input data is expected to be withing interval `[0, bins-1]`.
+* @property {number} granularity - Storage granularity in miliseconds. History is stored in slots with this length. Number of slots is equal to period/granularity.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -1125,7 +1133,7 @@
 * });
 *
 * // create a new time series stream aggregator for the 'Heat' store, that takes the values from the 'Celsius' field
-* // and the timestamp from the 'Time' field. The size of the window is 4 weeks.
+* // and the timestamp from the 'Time' field. The size of the window is 4 weeks
 * var timeser = {
 *    name: 'TimeSeriesBuffer',
 *    type: 'timeSeriesWinBuf',
@@ -1153,16 +1161,14 @@
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateVecDiff
+* @typedef {module:qm.StreamAggr} StreamAggrVecDiff
 * This stream aggregator represents difference between two vectors (e.g. online histograms). 
-*
 * It implements the following methods:
-* <br>{@link module:qm.StreamAggr#getFloatLength} returns the number of bins.
-* <br>{@link module:qm.StreamAggr#getFloatAt} returns the count for a bin index.
-* <br>{@link module:qm.StreamAggr#getFloatVector} returns the vector of counts, the length is equal to the number of bins.
-*
+* <br>1. {@link module:qm.StreamAggr#getFloatLength} returns the number of bins.
+* <br>2. {@link module:qm.StreamAggr#getFloatAt} returns the count for a bin index.
+* <br>3. {@link module:qm.StreamAggr#getFloatVector} returns the vector of counts, the length is equal to the number of bins.
 * @property {string} name - The given name of the stream aggregator.
-* @property {string} type - The type for the stream aggregator. It must be equal to <b>'onlineVecDiff'</b>.
+* @property {string} type - The type for the stream aggregator. <b>Important:</b> It must be equal to `'onlineVecDiff'`.
 * @property {string} storeX - The name of the store from which it takes the data for the first vector.
 * @property {string} storeY - The name of the store from which it takes the data for the second vector.
 * @property {string} inAggrX - The name of the first stream aggregator to which it connects and gets data.
@@ -1252,33 +1258,31 @@
 */
 
 /**
-* @typedef {Object} StreamAggregateSimpleLinearRegressionResult
-* Simple linear regression result JSON
-* @property {number} StreamAggregateSimpleLinearRegressionResult.intercept - Regressor intercept.
-* @property {number} StreamAggregateSimpleLinearRegressionResult.slope - Regressor slope.
-* @property {Array<number>} [StreamAggregateSimpleLinearRegressionResult.quantiles] - Quantiles for which bands will be computed.
-* @property {Array<number>} [StreamAggregateSimpleLinearRegressionResult.bands] - Computed band intercepts.
+* @typedef {Object} StreamAggrSimpleLinearRegressionResult
+* Simple linear regression result JSON returned by {@link module:qm~StreamAggrSimpleLinearRegression}.
+* @property {number} intercept - Regressor intercept.
+* @property {number} slope - Regressor slope.
+* @property {Array<number>} [quantiles] - Quantiles for which bands will be computed.
+* @property {Array<number>} [bands] - Computed band intercepts.
 */
 
 /**
-* @typedef {module:qm.StreamAggr} StreamAggregateSimpleLinearRegression
+* @typedef {module:qm.StreamAggr} StreamAggrSimpleLinearRegression
 * This stream aggregator computes a simple linear regression given two stream aggregates 
-* that support the getFloatVector methods and represent variates (input) and covariates (output).
-* Optionally the aggregate computes quantile bands: for each quantile q a parallel line to the fitted
-* line is found, so that q fraction of (x,y) datapoints fall below the line. For example, under Gaussian noise,
-* if Y = a + k X + N(0,sig) then the 0.95 quantile band will equal a + 2 sig. This means that 95% of (x,y) pairs
-* lie below the line Y = a + 2 sig + k X.
-*
-* The results are returned as a JSON by calling saveJson and are of type {@link module:qm~StreamAggregateSimpleLinearRegressionResult}.
-* 
+* that support the {@link module:qm.StreamAggr#getFloatVector} method and represent variates (input) and covariates (output).
+* Optionally the aggregate computes quantile bands: for each quantile `q` a parallel line to the fitted
+* line is found, so that `q` fraction of `(x,y)` datapoints fall below the line. For example, under Gaussian noise,
+* if `Y = a + k X + N(0,sig)` then the 0.95 quantile band will equal `a + 2 sig`. This means that 95% of `(x,y)` pairs
+* lie below the line `Y = a + 2 sig + k X`.
+* The results are returned as a JSON by calling {@link module:qm.StreamAggr#saveJson} and are of type {@link module:qm~StreamAggrSimpleLinearRegressionResult}.
 *
 * @property {string} name - The given name of the stream aggregator.
-* @property {string} type - The type for the stream aggregator. It must be equal to <b>'onlineVecDiff'</b>.
+* @property {string} type - The type for the stream aggregator. <b>Important:</b> It must be equal to `'onlineVecDiff'`.
 * @property {string} storeX - The name of the store from which it takes the data for the first vector.
 * @property {string} storeY - The name of the store from which it takes the data for the second vector.
 * @property {string} inAggrX - The name of the first stream aggregator to which it connects and gets data.
 * @property {string} inAggrY - The name of the second stream aggregator to which it connects and gets data.
-* @property {string} quantiles - An array of numbers between 0 and 1 for which the quantile bands will be computed.
+* @property {Array.<number>} quantiles - An array of numbers between 0 and 1 for which the quantile bands will be computed.
 * @example
 * // import the qm module
 * var qm = require('qminer');
@@ -1332,8 +1336,8 @@
 * store.push({ Time: '2015-06-10T14:13:32.008', X: 1, Y: 3 });
 *
 * var res = linReg.saveJson();
-* res.bands[0] // -1.5
-* res.bands[1] // 1.5
+* res.bands[0]; // -1.5
+* res.bands[1]; // 1.5
 *
 * base.close();
 */
@@ -1362,13 +1366,52 @@ public:
 public:
     /**
     * Resets the state of the aggregate.
-    * @returns {module:qm.StreamAggr} Self.
+    * @returns {module:qm.StreamAggr} Self. The state has been reset.
+    * @example
+    * // import the qm module
+    * var qm = require('qminer');
+    * // create a base with a simple store
+    * var base = new qm.Base({
+    *    mode: "createClean",
+    *    schema: [
+    *    {
+    *        name: "Heat",
+    *        fields: [
+    *            { name: "Celsius", type: "float" },
+    *            { name: "Time", type: "datetime" }
+    *        ]
+    *    }]
+    * });
+    *
+    * // create a new time series stream aggregator for the 'Heat' store, that takes the values from the 'Celsius' field
+    * // and the timestamp from the 'Time' field. The size of the window should be 1 day.
+    * var timeser = {
+    *    name: 'TimeSeriesAggr',
+    *    type: 'timeSeriesWinBuf',
+    *    store: 'Heat',
+    *    timestamp: 'Time',
+    *    value: 'Celsius',
+    *    winsize: 86400000
+    * };
+    * var timeSeries = base.store("Heat").addStreamAggr(timeser);
+    *
+    * // add a moving average aggregator, that is connected with the 'TimeSeriesAggr' aggregator
+    * var ma = {
+    *    name: 'movingAverageAggr',
+    *    type: 'ma',
+    *    store: 'Heat',
+    *    inAggr: 'TimeSeriesAggr'
+    * };
+    * var movingAverage = base.store("Heat").addStreamAggr(ma);
+    * // reset the moving average aggregate
+    * movingAverage.reset();
+    * base.close();
     */
     //# exports.StreamAggr.prototype.reset = function () { return Object.create(require('qminer').StreamAggr.prototype);  };
     JsDeclareFunction(reset);
 
     /**
-    * Executes the function that updates the aggregate at a given timestamp
+    * Executes the function that updates the aggregate at a given timestamp. For use example see {@link module:qm.StreamAggr} constructor example.
     * @param {TmMsec} ts - Timestamp in milliseconds.
     * @returns {module:qm.StreamAggr} Self. Values in the stream aggregator are changed as defined in the inner onTime function.
     */
@@ -1376,7 +1419,7 @@ public:
     JsDeclareFunction(onTime);
 
     /**
-    * Executes the function when a new record is put in store.
+    * Executes the function when a new record is put in store. For use example see {@link module:qm.StreamAggr} constructor example.
     * @param {module:qm.Record} rec - The record given to the stream aggregator.
     * @returns {module:qm.StreamAggr} Self. Values in the stream aggregator are changed as defined in the inner onAdd function.
     */
@@ -1384,7 +1427,7 @@ public:
     JsDeclareFunction(onAdd);
 
     /**
-    * Executes the function when a record in the store is updated.
+    * Executes the function when a record in the store is updated. For use example see {@link module:qm.StreamAggr} constructor example.
     * @param {module:qmRecord} rec - The updated record given to the stream aggregator.
     * @returns {module:qm.StreamAggr} Self. Values in the stream aggregator are changed as defined in the inner onUpdate function.
     */
@@ -1392,7 +1435,7 @@ public:
     JsDeclareFunction(onUpdate);
 
     /**
-    * Executes the function when a record in the store is deleted.
+    * Executes the function when a record in the store is deleted. For use example see {@link module:qm.StreamAggr} constructor example.
     * @param {module:qm.Record} rec - The deleted record given to the stream aggregator.
     * @returns {module:qm.StreamAggr} Self. The values in the stream aggregator are changed as defined in the inner onDelete function.
     */
@@ -1400,17 +1443,17 @@ public:
     JsDeclareFunction(onDelete);
     
     /**
-    * When executed it return a JSON object as defined by the user.
+    * When executed it return a JSON object as defined by the user. For use example see {@link module:qm.StreamAggr} constructor example.
     * @param {number} [limit] - The meaning is specific to each type of stream aggregator.
     * @returns {Object} A JSON object as defined by the user.
     */
-    //# exports.StreamAggr.prototype.saveJson = function (limit) {};
+    //# exports.StreamAggr.prototype.saveJson = function (limit) { return {}; };
     JsDeclareFunction(saveJson);
 
     /**
     * Saves the current state of the stream aggregator.
     * @param {module:fs.FOut} fout - The output stream.
-    * @returns {module:fs.FOut} The output stream given as the parameter.
+    * @returns {module:fs.FOut} The output stream `fout`.
     */
     //# exports.StreamAggr.prototype.save = function (fout) { return Object.create(require('qminer').fs.FOut.prototype); }
     JsDeclareFunction(save);
@@ -1428,7 +1471,7 @@ public:
     JsDeclareFunction(getInteger);
 
     /**
-    * Returns the value of the specific stream aggregator. For return values see {@link module:qm~StreamAggregators}.
+    * Returns the value of the specific stream aggregator. For return values see {@link module:qm~StreamAggregator}.
     * @returns {number} The value of the stream aggregator.
     * @example
     * // import qm module
@@ -1567,7 +1610,7 @@ public:
     /**
     * Returns the value of the vector containing the values of the stream aggregator at a specific index.
     * @param {number} idx - The index.
-    * @returns {number} The value of the float vector at position idx.
+    * @returns {number} The value of the float vector at position `idx`.
     * @example 
     * // import qm module
     * var qm = require('qminer');
@@ -1691,7 +1734,7 @@ public:
     /**
     * Gets the timestamp from the timestamp vector of the stream aggregator at the specific index.
     * @param {number} idx - The index.
-    * @returns {number} The timestamp of the timestamp vector at position idx.
+    * @returns {number} The timestamp of the timestamp vector at position `idx`.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -1773,7 +1816,39 @@ public:
     * Gets a vector containing the values that are entering the stream aggregator.
     * @returns {module:la.Vector} The vector containing the values that are entering the buffer.
     * @example
-    * // TODO + add unit test!
+    * // import qm module
+    * var qm = require('qminer');
+    * // create a simple base containing one store
+    * var base = new qm.Base({
+    *    mode: 'createClean',
+    *    schema: [{
+    *        name: 'Noise',
+    *        fields: [
+    *            { name: 'Decibels', type: 'float' },
+    *            { name: 'Time', type: 'datetime' }
+    *        ]
+    *    }]
+    * });
+    * // create a time series stream aggregator that takes the values from the 'Decibels' field
+    * // and timestamps from the 'Time' fields. The window size should be 1 second.
+    * var ts = {
+    *    name: 'Music',
+    *    type: 'timeSeriesWinBuf',
+    *    store: 'Noise',
+    *    timestamp: 'Time',
+    *    value: 'Decibels',
+    *    winsize: 1000
+    * };
+    * var music = base.store('Noise').addStreamAggr(ts);
+    * // add some records in the store
+    * base.store('Noise').push({ Decibels: 54, Time: '2015-07-21T14:43:00.0' });
+    * base.store('Noise').push({ Decibels: 55, Time: '2015-07-21T14:43:00.200' });
+    * base.store('Noise').push({ Decibels: 53, Time: '2015-07-21T14:43:00.800' });
+    * base.store('Noise').push({ Decibels: 54, Time: '2015-07-21T14:43:01.0' });
+    * base.store('Noise').push({ Decibels: 53, Time: '2015-07-21T14:43:01.2' });
+    * // get the in vector
+    * var vec = music.getInFloatVector();
+    * base.close();
     */
     //# exports.StreamAggr.prototype.getInFloatVector = function () { return Object.create(require('qminer').la.Vector.prototype); };
     JsDeclareFunction(getInFloatVector);
@@ -1782,7 +1857,39 @@ public:
     * Gets a vector containing the timestamps that are entering the stream aggregator.
     * @returns {module:la.Vector} The vector containing the timestamps that are entering the buffer.
     * @example
-    * // TODO + add unit test!
+    * // import qm module
+    * var qm = require('qminer');
+    * // create a simple base containing one store
+    * var base = new qm.Base({
+    *    mode: 'createClean',
+    *    schema: [{
+    *        name: 'Noise',
+    *        fields: [
+    *            { name: 'Decibels', type: 'float' },
+    *            { name: 'Time', type: 'datetime' }
+    *        ]
+    *    }]
+    * });
+    * // create a time series stream aggregator that takes the values from the 'Decibels' field
+    * // and timestamps from the 'Time' fields. The window size should be 1 second.
+    * var ts = {
+    *    name: 'Music',
+    *    type: 'timeSeriesWinBuf',
+    *    store: 'Noise',
+    *    timestamp: 'Time',
+    *    value: 'Decibels',
+    *    winsize: 1000
+    * };
+    * var music = base.store('Noise').addStreamAggr(ts);
+    * // add some records in the store
+    * base.store('Noise').push({ Decibels: 54, Time: '2015-07-21T14:43:00.0' });
+    * base.store('Noise').push({ Decibels: 55, Time: '2015-07-21T14:43:00.200' });
+    * base.store('Noise').push({ Decibels: 53, Time: '2015-07-21T14:43:00.800' });
+    * base.store('Noise').push({ Decibels: 54, Time: '2015-07-21T14:43:01.0' });
+    * base.store('Noise').push({ Decibels: 53, Time: '2015-07-21T14:43:01.2' });
+    * // get the in timestamps
+    * var vec = music.getInTimestampVector();
+    * base.close();
     */
     //# exports.StreamAggr.prototype.getInTimestampVector = function () { return Object.create(require('qminer').la.Vector.prototype); };
     JsDeclareFunction(getInTimestampVector);
@@ -1915,7 +2022,7 @@ public:
     // IValTmIO
     /**
     * Gets the vector of 'just-in' values (values that have just entered the buffer). Values can be floats or sparse vectors.
-    * @returns {(module:la.Vector | module:la.SparseMatrix)} Vector of floats or a vector of sparse vectors
+    * @returns {(module:la.Vector | module:la.SparseMatrix)} The vector or sparse matrix of values that just entered the buffer.
     * @example
     * // import qm module
     * var qm = require('qminer');
@@ -1976,44 +2083,42 @@ public:
     JsDeclareFunction(getInValueVector);
     
     /**
-    * Gets the vector of 'just-out values (values that have just fallen out of the buffer). Values can be floats or sparse vectors.
-    * @returns {(module:la.Vector | module:la.SparseMatrix)} Vector of floats or a vector of sparse vectors
-    * @example
-    * // look at the example for getInValueVector
+    * Gets the vector of 'just-out' values (values that have just fallen out of the buffer). Values can be floats or sparse vectors.
+    * For use example see {@link module:qm.StreamAggr#getOutFloatVector} example.
+    * @returns {(module:la.Vector | module:la.SparseMatrix)} Vector of floats or a vector of sparse vectors.
     */
     //# exports.StreamAggr.prototype.getOutValueVector = function () { };
     JsDeclareFunction(getOutValueVector);
     
     // IValVec
     /**
-    * Gets the vector of values in the buffer. Values can be floats or sparse vectors.
+    * Gets the vector of values in the buffer. Values can be floats or sparse vectors. For use example see {@link module:qm.SreamAggr#getInValueVector}.
     * @returns {(module:la.Vector | module:la.SparseMatrix)} Vector of floats or a vector of sparse vectors
-    * @example
-    * // look at the example for getInValueVector
     */
     //# exports.StreamAggr.prototype.getValueVector = function () { };
     JsDeclareFunction(getValueVector);
 
     /**
-    * Returns a feature space
+    * Returns a feature space.
+    * @returns {module:qm.FeatureSpace} The feature space.
     */
     //# exports.StreamAggr.prototype.getFeatureSpace = function() { return Object.create(require('qminer').FeatureSpace.prototype); };
     JsDeclareFunction(getFeatureSpace);
 
     /**
-    * Returns the name of the stream aggregate.
+    * Returns the name of the stream aggregate. Type `string`.
     */
     //# exports.StreamAggr.prototype.name = "";
     JsDeclareProperty(name);
 
     /**
-    * Returns the JSON object of the stream aggregate. Same as the method saveJson.
+    * Returns the JSON object of the stream aggregate. Same as the method saveJson. Type `object`.
     */
-    //# exports.StreamAggr.prototype.val = undefined;
+    //# exports.StreamAggr.prototype.val = {};
     JsDeclareProperty(val);
 
     /**
-    * Returns true when the stream aggregate has enough data to initialize its internal state.
+    * Returns true when the stream aggregate has enough data to initialize its internal state. Type `init`.
     */
     //# exports.StreamAggr.prototype.init = false;
     JsDeclareProperty(init);

--- a/src/nodejs/scripts/analytics.js
+++ b/src/nodejs/scripts/analytics.js
@@ -1457,7 +1457,7 @@ module.exports = exports = function (pathQmBinary) {
     * @class
     * @classdesc Principal Components Analysis
     * @param {module:analytics~PCAParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
-    * <br>1. Using the parameter object {@link module:analytics~PCAParam},
+    * <br>1. Using the {@link module:analytics~PCAParam} object,
     * <br>2. using the file input stream {@link module:fs.FIn}.
     * @example <caption>Using default constructor</caption>
     * // import analytics module
@@ -1801,7 +1801,7 @@ module.exports = exports = function (pathQmBinary) {
     }
 
     /**
-    * Returns the model
+    * Returns the model.
     * @returns {Object} The `KMeansModel` object containing the properites:
     * <br> 1. `KMeansModel.C` - The {@link module:la.Matrix} or {@link module:la.SparseMatrix} containing the centroids,
     * <br> 2. `KMeansModel.medoids` - The {@link module:la.IntVector} of cluster medoids of the training data,

--- a/src/nodejs/scripts/analytics.js
+++ b/src/nodejs/scripts/analytics.js
@@ -25,7 +25,7 @@ module.exports = exports = function (pathQmBinary) {
     ///////////////////////////////////////////////////
 
     /**
-    * Preprocessing
+    * PreprocessingF
     * @namespace
     * @desc Preprocessing functions for preparing labels in formats accepted
     * by learning modules in {@link module:analytics}.
@@ -1729,7 +1729,7 @@ module.exports = exports = function (pathQmBinary) {
    
 
     /**
-     * @typedef {Object} KMeansExplanation
+     * @typedef {Object} KMeansExplain
      * The examplanation returned by {@link module:analytics.KMeans#explain}.
      * @property {number} medoidID - The ID of the nearest medoids.
      * @property {module:la.IntVector} featureIDs - The IDs of features, sorted by contribution.
@@ -1739,7 +1739,7 @@ module.exports = exports = function (pathQmBinary) {
     /**
      * Returns the IDs of the nearest medoid for each example.
      * @param {(module:la.Matrix | module:la.SparseMatrix)} X - Matrix whose columns correspond to examples.
-     * @returns {Array.<module:analytics~KMeansExplanation>} Array containing the KMeans explanantions.
+     * @returns {Array.<module:analytics~KMeansExplain>} Array containing the KMeans explanantions.
      * @example
      * // import analytics module
      * var analytics = require('qminer').analytics;

--- a/src/nodejs/scripts/analytics.js
+++ b/src/nodejs/scripts/analytics.js
@@ -28,7 +28,7 @@ module.exports = exports = function (pathQmBinary) {
     * Preprocessing
     * @namespace
     * @desc Preprocessing functions for preparing labels in formats accepted
-    * by learning moduls in qm.analytics.
+    * by learning modules in {@link module:analytics}.
     */
     var preprocessing = preprocessing || {};
     // namespacing: http://addyosmani.com/blog/essential-js-namespacing/
@@ -41,17 +41,15 @@ module.exports = exports = function (pathQmBinary) {
     * numeric value for elements when label matches specified label and
     * for other elements. By default, these values are +1 for matching
     * labels, and -1 for the rest.
-    * @param {Array} y - labels
-    * @param {(string | number)} positiveLabel - positive label
-    * @param {number} [positiveId = 1] - value when matching positive label
-    * @param {number} [negativeId = -1] - value when not matching positive label
+    * @param {Array} y - Labels.
+    * @param {string | number} positiveLabel - Positive label.
+    * @param {number} [positiveId = 1] - Value when matching positive label.
+    * @param {number} [negativeId = -1] - Value when not matching positive label.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
     * // create binarizer with 'b' as positive label
     * var binarizer = new analytics.preprocessing.Binarizer('b');
-    * // get vector with binarized labels
-    * var bins = binarizer.transform(['a','b','a','c']);
     */
     preprocessing.Binarizer = function (positiveLabel, positiveId, negativeId) {
         if (positiveLabel == undefined) { throw "Binarizer needs positive label"; }
@@ -66,8 +64,15 @@ module.exports = exports = function (pathQmBinary) {
 
         /**
         * Transform given array of labels to binary numeric vector.
-        * @param {(Array<number> | Array<string> | module:la.Vector | module:la.StrVector)} y - labels
-        * @return {modul:la.Vector} binarized vector
+        * @param {(Array<number> | Array<string> | module:la.Vector | module:la.StrVector)} y - Labels.
+        * @return {modul:la.Vector} Binarized vector.
+        * @example
+        * // import analytics module
+        * var analytics = require('qminer').analytics;
+        * // create binarizer with 'b' as positive label
+        * var binarizer = new analytics.preprocessing.Binarizer('b');
+        * // get vector with binarized labels
+        * var bins = binarizer.transform(['a','b','a','c']);
         */
         this.transform = function (y) {
             var target = new la.Vector();
@@ -78,7 +83,19 @@ module.exports = exports = function (pathQmBinary) {
         }
     };
 
+    /**
+    * Applies the model's `decisionFunction` method (if exists) on each column of matrix `X`.
+    * @param {Object} model - The model, that has the `decisionFunction` method.
+    * @param {module:la.SparseMatrix} X - The matrix.
+    * @returns {module:la.Vector} The dense vector where the i-th value is the value the `model.decisionFunction`
+    * returned for the sparse vector `X[i]`.
+    * @example
+    * // TODO
+    */
     preprocessing.applyModel = function (model, X) {
+        if (model.decisionFunction == undefined) {
+            throw "preprocessing.applyModel: model doesn't have a method called decisionFunction!";
+        }
         var target = new la.Vector();
         for (var i = 0; i < X.cols; i++) {
             target.push(model.decisionFunction(X[i]));
@@ -93,7 +110,7 @@ module.exports = exports = function (pathQmBinary) {
     /**
 	* Get the model.
 	* @returns {Object} The `svmModel` object containing the property:
-    * <br> 1. `svmModel.weights` - The SVM normal vector, type {@link module:la.Vector}.
+    * <br> 1. `svmModel.weights` - The weights of the model. Type {@link module:la.Vector}.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
@@ -106,7 +123,7 @@ module.exports = exports = function (pathQmBinary) {
     /**
 	* Get the model.
 	* @returns {Object} The `svmModel` object containing the property:
-    * <br> 1. `svmModel.weights` - The SVM normal vector, type {@link module:la.Vector}.
+    * <br> 1. `svmModel.weights` - The weights of the model. Type {@link module:la.Vector}.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
@@ -121,14 +138,14 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Gets the model.
     * @returns {Object} The `ridgeRegModel` object containing the property:
-    * <br> 1. `ridgeRegModel.weights` - The Ridge Regression model vector, type {@link module:la.Vector}.
+    * <br> 1. `ridgeRegModel.weights` - The weights of the model. Type {@link module:la.Vector}.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
     * // create the Ridge Regression model
     * var regmod = new analytics.RidgeReg();
     * // get the model
-    * var model = regmod.getModel(); // returns { weights: new require('qminer').la.Vector(); }
+    * var model = regmod.getModel();
     */
     exports.RidgeReg.prototype.getModel = function () { return { weights: this.weights }; }
 
@@ -136,7 +153,7 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Gets the model.
     * @returns {Object} The `recLinRegModel` object containing the property:
-    * <br> 1. `recLinRegModel.weights` - The Recursive Linear Regression model vector, type {@link module:la.Vector}.
+    * <br> 1. `recLinRegModel.weights` - The weights of the model. Type {@link module:la.Vector}.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
@@ -149,38 +166,38 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
     * @typedef {Object} oneVsAllParam
-    * The parameter given to the OneVsAll object. A Json object containing the parameter keys with values.
-    * @param {function} [model] - Constructor for binary model to be
+    * An object used for the construction of {@link module:analytics.OneVsAll}.
+    * @property {function} [model] - Constructor for binary model to be
     * used internaly. Constructor should expect only one parameter.
-    * @param {Object} [modelParam] - Parameter for oneVsAllParam.model constructor.
-    * @param {number} [categories] - Number of categories.
-    * @param {boolean} [verbose = false] - If false, the console output is supressed.
+    * @property {Object} [modelParam] - Parameter for `oneVsAllParam.model` constructor.
+    * @property {number} [categories] - Number of categories.
+    * @property {boolean} [verbose = false] - If false, the console output is supressed.
     */
 
     /**
-    * @classdesc One vs. all model for multiclass prediction. Builds binary model
+    * @classdesc One vs All model for multiclass prediction. Builds binary model
     * for each category and predicts the one with the highest score. Binary model is
     * provided as part of the constructor.
     * @class
-    * @param {module:analytics~oneVsAllParam} [oneVsAllParam] - Constructor parameters.
+    * @param {module:analytics~oneVsAllParam} [arg] - Construction arguments.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
     * // create a new OneVsAll object with the model analytics.SVC
     * var onevsall = new analytics.OneVsAll({ model: analytics.SVC, modelParam: { c: 10, maxTime: 12000 }, cats: 2 });
     */
-    exports.OneVsAll = function (oneVsAllParam) {
+    exports.OneVsAll = function (arg) {
         // remember parameters
-        var model = oneVsAllParam.model;
-        var modelParam = oneVsAllParam.modelParam;
-        var cats = oneVsAllParam.cats;
-        var verbose = oneVsAllParam.verbose == undefined ? false : oneVsAllParam.verbose;
+        var model = arg.model;
+        var modelParam = arg.modelParam;
+        var cats = arg.cats;
+        var verbose = arg.verbose == undefined ? false : arg.verbose;
         // trained models
         var models = [ ];
 
         /**
         * Gets the parameters.
-        * @returns {Object} Json object containing the parameters.
+        * @returns {module:analytics~oneVsAllParam} The constructor parameters.
         * @example
         * // import analytics module
         * var analytics = require('qminer').analytics;
@@ -197,6 +214,7 @@ module.exports = exports = function (pathQmBinary) {
 
         /**
         * Sets the parameters.
+        * @param {module:analytics~OneVsAllParam} params - The constructor parameters.
         * @returns {module:analytics.OneVsAll} Self. The parameters are changed.
         * @example
         * // import analytics module
@@ -206,21 +224,21 @@ module.exports = exports = function (pathQmBinary) {
         * // set the parameters
         * var params = onevsall.setParams({ model: analytics.SVR, modelParam: { c: 12, maxTime: 10000}, cats: 3, verbose: true });
         */
-        this.setParams = function (oneVsAllParam) {
-            model = oneVsAllParam.model == undefined ? model : oneVsAllParam.model;
-            modelParam = oneVsAllParam.modelParam == undefined ? modelParam : oneVsAllParam.modelParam;
-            cats = oneVsAllParam.cats == undefined ? cats : oneVsAllParam.cats;
-            verbose = oneVsAllParam.verbose == undefined ? verbose : oneVsAllParam.verbose;
+        this.setParams = function (params) {
+            model = params.model == undefined ? model : params.model;
+            modelParam = params.modelParam == undefined ? modelParam : params.modelParam;
+            cats = params.cats == undefined ? cats : params.cats;
+            verbose = params.verbose == undefined ? verbose : params.verbose;
         }
 
         /**
          * Apply all models to the given vector and returns a vector of scores, one for each category.
-         * Semantic of scores depand on the provided binary model.
+         * Semantic of scores depend on the provided binary model.
          * @param {module:la.Vector | module:la.SparseVector | module:la.Matrix | module:la.SparseMatrix} X -
-         * Input feature vector or matrix with feature vectors as columns.
-         * @returns {module:la.Vector | module:la.Matrix} The score and label of the input:
-         * <br>1. {@link module:la.Vector} of scores, if X is of type {@link module:la.Vector} or {@link module:la.SparseVector}.
-         * <br>2. {@link module:la.Matrix} with columns corresponding to instances, and rows corresponding to labels, if X is of type {@link module:la.Matrix} or {@link module:la.SparseMatrix}.
+         * Feature vector or matrix with feature vectors as columns.
+         * @returns {module:la.Vector | module:la.Matrix} The score and label of the input `X`:
+         * <br>1. {@link module:la.Vector} of scores, if `X` is of type {@link module:la.Vector} or {@link module:la.SparseVector}.
+         * <br>2. {@link module:la.Matrix} with columns corresponding to instances, and rows corresponding to labels, if `X` is of type {@link module:la.Matrix} or {@link module:la.SparseMatrix}.
          * @example
          * // import modules
          * var analytics = require('qminer').analytics;
@@ -235,7 +253,7 @@ module.exports = exports = function (pathQmBinary) {
          * // create the vector for the decisionFunction
          * var test = new la.Vector([1, 2]);
          * // give the vector to the decision function
-         * var prediction = onevsall.predict(test); // returns the vector of scores
+         * var prediction = onevsall.decisionFunction(test); // returns the vector of scores
          */
         this.decisionFunction = function(X) {
             // check what is our input
@@ -264,10 +282,10 @@ module.exports = exports = function (pathQmBinary) {
         /**
          * Apply all models to the given vector and returns category with the highest score.
          * @param {module:la.Vector | module:la.SparseVector | module:la.Matrix | module:la.SparseMatrix} X -
-         * Input feature vector or matrix with feature vectors as columns.
-         * @returns {number | module:la.IntVector} Returns:
-         * <br>1. number of the category with the higher score, if X is {@link module:la.Vector} or {@link module:la.SparseVector}.
-         * <br>2. {@link module:la.IntVector} of categories with the higher score for each column of X, if X is {@link module:la.Matrix} or {@link module:la.SparseMatrix}.
+         * Feature vector or matrix with feature vectors as columns.
+         * @returns {number | module:la.IntVector}
+         * <br>1. number of the category with the higher score, if `X` is {@link module:la.Vector} or {@link module:la.SparseVector}.
+         * <br>2. {@link module:la.IntVector} of categories with the higher score for each column of `X`, if `X` is {@link module:la.Matrix} or {@link module:la.SparseMatrix}.
          * @example
          * // import modules
          * var analytics = require('qminer').analytics;
@@ -307,8 +325,8 @@ module.exports = exports = function (pathQmBinary) {
          * Apply all models to the given vector and returns category with the highest score.
          * @param {module:la.Matrix | module:la.SparseMatrix} X - training instance feature vectors.
          * @param {module:la.Vector} y - target category for each training instance. Categories must
-         * be integer numbers between 0 and oneVsAllParam.categories - 1.
-         * @returns {module:analytics.OneVsAll} Self. The models are now fitted.
+         * be integer numbers between `0` and `oneVsAllParam.categories-1`.
+         * @returns {module:analytics.OneVsAll} Self. The models have been fitted.
          * @example
          * // import modules
          * var analytics = require('qminer').analytics;
@@ -345,6 +363,16 @@ module.exports = exports = function (pathQmBinary) {
         }
     };
 
+    /**
+     * Threshold Model
+     * @class
+     * @classdesc The Threshold model. Uses the methods from the {@link module:analytics.metrics}.
+     * @param {Object} [arg] - The constructor parameters.
+     * @param {string} [arg.target] - Target type. Possible options are `"recall"` and `"precision"`.
+     * @param {TODO} [arg.level] - TODO
+     * @example
+     * // TODO
+     */
     exports.ThresholdModel = function(params) {
         // what do we optimize
         this.target = params.target;
@@ -357,6 +385,15 @@ module.exports = exports = function (pathQmBinary) {
         // apply all models to the given vector and return distance to the class boundary
         // x = dense vector with prediction score for each class
         // result = traslated predictions based on thresholds
+        /**
+         * Apply all models to the given vector and returns the distance to the class boundary.
+         * @param {number | module:la.Vector} x - The prediction score for each class.
+         * @returns {number | module:la.Vector}
+         * <br>1. value of the translated prediction based on the threshold, if `x` is `number`,
+         * <br>2. {@link module:la.Vector} of translated prediction based on the threshold, if `x` is {@link module:la.Vector}.
+         * @example
+         * // TODO
+         */
         this.decisionFunction = function(x) {
             if (x instanceof Number) {
                 // just transate based on the model's threshold
@@ -376,6 +413,15 @@ module.exports = exports = function (pathQmBinary) {
         // return the most likely category
         // x = dense vector with prediction score for each class
         // result = array of positive label ids
+        /**
+         * Returns the most likely category.
+         * @param {number | module:la.Vector} x - The prediction score for each class.
+         * @returns {number | module:la.Vector}
+         * <br>1. value of the positive label IDs, if `x` is `number`,
+         * <br>2. {@link module:la.Vector} of the positive label IDs, if `x` is {@link module:la.Vector}.
+         * @example
+         * // TODO
+         */
         this.predict = function(x) {
             // evaluate all models
             var scores = this.decisionFunction(x)
@@ -393,6 +439,13 @@ module.exports = exports = function (pathQmBinary) {
 
         // X = vector of predictions for each instance (output of decision_funcition)
         // y = target labels (1 or -1)
+        /**
+         * Fits the model.
+         * @param {module:la.Vector} X - Prediction for each instance (output of descisionFunction).
+         * @param {number} y - The target labels (1 or -1).
+         * @example
+         * // TODO
+         */
         this.fit = function(X, y) {
             if (this.target === "f1") {
                 // find threshold that maximizes F1 measure
@@ -413,7 +466,7 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Metrics
     * @namespace
-    * @desc Classification and regression metrics
+    * @desc Classification and regression metrics.
     * @example <caption>Batch classification example</caption>
     * // import metrics module
     * var analytics = require('qminer').analytics;
@@ -478,24 +531,24 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * For evaluating provided categories from binary? classifiers.
     * @class
-    * @classdesc Class implements several classification measures (precision, recall, F1, accuracy)
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lable(s)
-    * @param {(Array<number> | module:la.Vector)} yPred - Predicted (estimated) lable(s)
+    * @classdesc Class implements several classification measures (precision, recall, F1, accuracy).
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lable(s).
+    * @param {(Array<number> | module:la.Vector)} yPred - Predicted (estimated) lable(s).
     */
     metrics.ClassificationScore = function (yTrue, yPred) {
         /**
-        * Returns `Object` containing different classification measures
-        * @returns {Object} scores - Object with different classification socres
-        * @returns {number} scores.count - Count
-        * @returns {number} scores.TP - Number of true positives
-        * @returns {number} scores.TN - Number of true negative
-        * @returns {number} scores.FP - Number of false positives
-        * @returns {number} scores.FN - Number of false positives
-        * @returns {number} scores.all - Number of all results
-        * @returns {number} scores.accuracy - Accuracy score. Formula: (tp + tn) / (tp + fp + fn + tn)
-        * @returns {number} scores.precision - Precision score. Formula: tp / (tp + fp)
-        * @returns {number} scores.recall - Recall score. Formula: tp / (tp + fn)
-        * @returns {number} scores.f1 - F1 score. Formula:  2 * (precision * recall) / (precision + recall)
+        * Returns `Object` containing different classification measures.
+        * @returns {Object} scores - Object with different classification socres.
+        * @returns {number} scores.count - Count.
+        * @returns {number} scores.TP - Number of true positives.
+        * @returns {number} scores.TN - Number of true negative.
+        * @returns {number} scores.FP - Number of false positives.
+        * @returns {number} scores.FN - Number of false positives.
+        * @returns {number} scores.all - Number of all results.
+        * @returns {number} scores.accuracy - Accuracy score. Formula: `(tp + tn) / (tp + fp + fn + tn)`.
+        * @returns {number} scores.precision - Precision score. Formula: `tp / (tp + fp)`.
+        * @returns {number} scores.recall - Recall score. Formula: `tp / (tp + fn)`.
+        * @returns {number} scores.f1 - F1 score. Formula:  `2 * (precision * recall) / (precision + recall)`.
         */
         this.scores = {
             count: 0, predictionCount: 0,
@@ -509,7 +562,7 @@ module.exports = exports = function (pathQmBinary) {
         };
 
         /**
-        * Adds prediction to the current statistics. Labels can be either integers
+        * Adds prediction to the current statistics. Labels can be either integers.
         * or integer array (when there are zero or more then one lables).
         * @param {number} correct - Correct lable.
         * @param {number} predicted - Predicted lable.
@@ -557,10 +610,10 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Accuracy score is the proportion of true results (both true positives and true negatives)
     * among the total number of cases examined.
-    * Formula: (tp + tn) / (tp + fp + fn + tn).
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables
-    * @param {(Array<number> | module:la.Vector)} yPred - Predicted (estimated) lables
-    * @returns {number} Accuracy value
+    * Formula: `(tp + tn) / (tp + fp + fn + tn)`.
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables.
+    * @param {(Array<number> | module:la.Vector)} yPred - Predicted (estimated) lables.
+    * @returns {number} Accuracy value.
     */
     metrics.accuracyScore = function (yTrue, yPred) {
         return new metrics.ClassificationScore(yTrue, yPred).scores.accuracy();
@@ -569,10 +622,10 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Precision score is defined as the proportion of the true positives against all the
     * positive results (both true positives and false positives).
-    * Formula: tp / (tp + fp).
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables
-    * @param {(Array<number> | module:la.Vector)} yPred - Predicted (estimated) lables
-    * @returns {number} Precission score
+    * Formula: `tp / (tp + fp)`.
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables.
+    * @param {(Array<number> | module:la.Vector)} yPred - Predicted (estimated) lables.
+    * @returns {number} Precission score.
     */
     metrics.precisionScore = function (yTrue, yPred) {
         return new metrics.ClassificationScore(yTrue, yPred).scores.precision();
@@ -580,10 +633,10 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
     * Recall score is intuitively the ability of the classifier to find all the positive samples.
-    * Formula: tp / (tp + fn).
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables
-    * @param {(Array<number> | module:la.Vector)} yPred - Predicted (estimated) lables
-    * @returns {number} Recall score
+    * Formula: `tp / (tp + fn)`.
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables.
+    * @param {(Array<number> | module:la.Vector)} yPred - Predicted (estimated) lables.
+    * @returns {number} Recall score.
     */
     metrics.recallScore = function (yTrue, yPred) {
         return new metrics.ClassificationScore(yTrue, yPred).scores.recall();
@@ -593,21 +646,21 @@ module.exports = exports = function (pathQmBinary) {
     * The F1 score can be interpreted as a weighted average of the precision and recall, where
     * an F1 score reaches its best value at 1 and worst score at 0. The relative contribution of
     * precision and recall to the F1 score are equal.
-    * Formula: 2 * (precision * recall) / (precision + recall)
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables
-    * @param {(Array<number> | module:la.Vector)} yPred - Predicted (estimated) lables
-    * @returns {number} F1 score
+    * Formula: `2 * (precision * recall) / (precision + recall)`.
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables.
+    * @param {(Array<number> | module:la.Vector)} yPred - Predicted (estimated) lables.
+    * @returns {number} F1 score.
     */
     metrics.f1Score = function (yTrue, yPred) {
         return new metrics.ClassificationScore(yTrue, yPred).scores.f1();
     };
 
     /**
-    * Class implements several prediction curve measures (ROC, AOC, Precision-Recall, ...)
+    * Class implements several prediction curve measures (ROC, AOC, Precision-Recall, ...).
     * @class
-    * @classdesc used for computing ROC curve and other related measures such as AUC
+    * @classdesc Used for computing ROC curve and other related measures such as AUC.
     * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lable(s) of binary classification in range {-1, 1} or {0, 1}.
-    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities
+    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities.
     * @example
     * // import metrics module
     * var metrics = require('qminer').analytics.metrics;
@@ -631,32 +684,32 @@ module.exports = exports = function (pathQmBinary) {
     */
     metrics.PredictionCurve = function (yTrue, yPred) {
         /**
-        * Count of all examples
+        * Count of all examples.
         * @name module:analytics~metrics.PredictionCurve#length
         * @type number
         */
         this.length = 0;
         /**
-        * Count of all positive examples
+        * Count of all positive examples.
         * @name module:analytics~metrics.PredictionCurve#allPositives
         * @type number
         */
         this.allPositives = 0;
         /**
-        * Count of all negative examples
+        * Count of all negative examples.
         * @name module:analytics~metrics.PredictionCurve#allNegatives
         * @type number
         */
         this.allNegatives = 0;
         // store of predictions and ground truths
         /**
-        * Store of ground truths
+        * Store of ground truths.
         * @name module:analytics~metrics.PredictionCurve#grounds
         * @type module:la.Vector
         */
         this.grounds = new la.Vector();
         /**
-        * Store of predictions
+        * Store of predictions.
         * @name module:analytics~metrics.PredictionCurve#predictions
         * @type module:la.Vector
         */
@@ -698,9 +751,9 @@ module.exports = exports = function (pathQmBinary) {
         }
 
         /**
-        * Get  Receiver Operating Characteristic (ROC) parametrization sampled on `sample` points
-        * @param {number} [sample=10] - Desired number of samples in output
-        * @returns {module:la.Matrix} A matrix with increasing false and true positive rates
+        * Get Receiver Operating Characteristic (ROC) parametrization sampled on `sample` points.
+        * @param {number} [sample=10] - Desired number of samples in output.
+        * @returns {module:la.Matrix} A matrix with increasing false and true positive rates.
         */
         this.roc = function (sample) {
             // default sample size is 10
@@ -750,9 +803,9 @@ module.exports = exports = function (pathQmBinary) {
         }
 
         /**
-        * Get Area Under the Curve (AUC) of the current curve
-        * @param {number} [sample=10] - Desired number of samples in output
-        * @returns {number} Area under ROC curve
+        * Get Area Under the Curve (AUC) of the current curve.
+        * @param {number} [sample=10] - Desired number of samples in output.
+        * @returns {number} Area under ROC curve.
         */
         this.auc = function (sample) {
             // default sample size is 10
@@ -774,9 +827,9 @@ module.exports = exports = function (pathQmBinary) {
         }
 
         /**
-        * evalPrecisionRecall
+        * evalPrecisionRecall.
         * @private
-        * @param {callback} callback
+        * @param {callback} callback.
         */
         this.evalPrecisionRecall = function (callback) {
             // sort according to predictions
@@ -802,8 +855,8 @@ module.exports = exports = function (pathQmBinary) {
         }
 
         /**
-        * Get precision recall curve sampled on `sample` points
-        * @param {number} [sample=10] - Desired number of samples in output
+        * Get precision recall curve sampled on `sample` points.
+        * @param {number} [sample=10] - Desired number of samples in output.
         * @returns {module:la.Matrix} Precision-recall pairs.
         */
         this.precisionRecallCurve = function (sample) {
@@ -838,7 +891,7 @@ module.exports = exports = function (pathQmBinary) {
         };
 
         /**
-        * Get break-even point, the value where precision and recall intersect
+        * Get break-even point, the value where precision and recall intersect.
         * @returns {number} Break-even point.
         */
         this.breakEvenPoint = function () {
@@ -853,7 +906,7 @@ module.exports = exports = function (pathQmBinary) {
         }
 
         /**
-        * Gets threshold for prediction score, which results in the highest F1
+        * Gets threshold for prediction score, which results in the highest F1.
         * @returns {number} Threshold with highest F1 score.
         */
         this.bestF1 = function () {
@@ -871,9 +924,9 @@ module.exports = exports = function (pathQmBinary) {
         }
 
         /**
-        * Gets threshold for prediction score, nearest to specified recall
+        * Gets threshold for prediction score, nearest to specified recall.
         * @param {number} desiredRecall - Desired recall score.
-        * @returns {number} recal score threshold - Threshold for recall score, nearest to specified `recall`
+        * @returns {number} Recal Score Threshold. Threshold for recall score, nearest to specified `recall`.
         */
         this.desiredRecall = function (desiredRecall) {
             return this.evalPrecisionRecall(new function () {
@@ -890,9 +943,9 @@ module.exports = exports = function (pathQmBinary) {
         }
 
         /**
-        * Gets threshold for prediction score, nearest to specified precision
+        * Gets threshold for prediction score, nearest to specified precision.
         * @param {number} desiredPrecision - Desired precision score.
-        * @returns {number} Threshold for prediction score, nearest to specified `precision`
+        * @returns {number} Threshold for prediction score, nearest to specified `precision`.
         */
         this.desiredPrecision = function (desiredPrecision) {
             return this.evalPrecisionRecall(new function () {
@@ -910,11 +963,11 @@ module.exports = exports = function (pathQmBinary) {
     };
 
     /**
-    * Get ROC parametrization sampled on `sample` points
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables
-    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities
-    * @param {number} [sample=10] - Desired number of samples in output
-    * @returns {module:la.Matrix} A matrix with increasing false and true positive rates
+    * Get ROC parametrization sampled on `sample` points.
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables.
+    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities.
+    * @param {number} [sample=10] - Desired number of samples in output.
+    * @returns {module:la.Matrix} A matrix with increasing false and true positive rates.
     * @example
     * // import metrics module
     * var metrics = require('qminer').analytics.metrics;
@@ -931,11 +984,11 @@ module.exports = exports = function (pathQmBinary) {
     };
 
     /**
-    * Get AUC of the current curve
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables
-    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities
-    * @param {number} [sample=10] - Desired number of samples in output
-    * @returns {number} Area under ROC curve
+    * Get AUC of the current curve.
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables.
+    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities.
+    * @param {number} [sample=10] - Desired number of samples in output.
+    * @returns {number} Area under ROC curve.
     * @example
     * // import metrics module
     * var metrics = require('qminer').analytics.metrics;
@@ -952,53 +1005,53 @@ module.exports = exports = function (pathQmBinary) {
     };
 
     /**
-    * Get precision recall curve sampled on `sample` points
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables
-    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities
-    * @param {number} [sample=10] - Desired number of samples in output
-    * @returns {module:la.Matrix} Precision-recall pairs
+    * Get precision recall curve sampled on `sample` points.
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables.
+    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities.
+    * @param {number} [sample=10] - Desired number of samples in output.
+    * @returns {module:la.Matrix} Precision-recall pairs.
     */
     metrics.precisionRecallCurve = function (yTrue, yPred, sample) {
         return new metrics.PredictionCurve(yTrue, yPred).precisionRecallCurve(sample);
     };
 
     /**
-    * Get break-even point, the value where precision and recall intersect
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables
-    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities
-    * @returns {number} Break-even point score
+    * Get break-even point, the value where precision and recall intersect.
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables.
+    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities.
+    * @returns {number} Break-even point score.
     */
     metrics.breakEventPointScore = function (yTrue, yPred) {
         return new metrics.PredictionCurve(yTrue, yPred).breakEvenPoint();
     };
 
     /**
-    * Gets threshold for prediction score, which results in the highest F1
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables
-    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities
-    * @returns {number} Threshold with highest F1 score
+    * Gets threshold for prediction score, which results in the highest F1.
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables.
+    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities.
+    * @returns {number} Threshold with highest F1 score.
     */
     metrics.bestF1Threshold = function (yTrue, yPred) {
         return new metrics.PredictionCurve(yTrue, yPred).bestF1();
     };
 
     /**
-    * Gets threshold for recall score, nearest to specified recall
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables
-    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities
+    * Gets threshold for recall score, nearest to specified recall.
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables.
+    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities.
     * @param {number} desiredRecall - Desired recall score.
-    * @returns {number} Threshold for recall score, nearest to specified `recall`
+    * @returns {number} Threshold for recall score, nearest to specified `recall`.
     */
     metrics.desiredRecallThreshold = function (yTrue, yPred, desiredRecall) {
         return new metrics.PredictionCurve(yTrue, yPred).desiredRecall(desiredRecall);
     };
 
     /**
-    * Gets threshold for prediction score, nearest to specified precision
-    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables
-    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities
+    * Gets threshold for prediction score, nearest to specified precision.
+    * @param {(Array<number> | module:la.Vector)} yTrue - Ground truth (correct) lables.
+    * @param {(Array<number> | module:la.Vector)} yPred - Estimated probabilities.
     * @param {number} desiredPrecision - Desired precision score.
-    * @returns {number} Threshold for prediction score, nearest to specified `precision`
+    * @returns {number} Threshold for prediction score, nearest to specified `precision`.
     */
     metrics.desiredPrecisionThreshold = function (yTrue, yPred, desiredPrecision) {
         return new metrics.PredictionCurve(yTrue, yPred).desiredPrecision(desiredPrecision);
@@ -1036,8 +1089,8 @@ module.exports = exports = function (pathQmBinary) {
 
         /**
         * Updates metric with ground truth target value `yTrue` and estimated target value `yPred`.
-        * @param {number} yTrue - Ground truth (correct) target value
-        * @param {number} yPred - Estimated target value
+        * @param {number} yTrue - Ground truth (correct) target value.
+        * @param {number} yPred - Estimated target value.
         */
         this.push = function (yTrue, yPred, ref_num) {
             // set default values of optional input parameters
@@ -1051,16 +1104,16 @@ module.exports = exports = function (pathQmBinary) {
 
         /**
         * Returns error value.
-        * @returns {number} Error value
+        * @returns {number} Error value.
         */
         this.getError = function () {
             return error;
         }
 
         /**
-	    * Save metric state to provided output stream `FOut`.
-	    * @param {module:fs.FOut} FOut - The output stream.
-	    * @returns {module:fs.FOut} Provided output stream `FOut`.
+	    * Save metric state to provided output stream `fout`.
+	    * @param {module:fs.FOut} fout - The output stream.
+	    * @returns {module:fs.FOut} The output stream `fout`.
         */
         this.save = function (fout) {
             fout.writeJson(this.metric.state);
@@ -1068,9 +1121,9 @@ module.exports = exports = function (pathQmBinary) {
         }
 
         /**
-	    * Load metric state from provided input stream `FIn`.
-	    * @param {module:fs.FIn} FIn - The output stream.
-	    * @returns {module:fs.FIn} Provided output stream `FIn`.
+	    * Load metric state from provided input stream `fin`.
+	    * @param {module:fs.FIn} fin - The output stream.
+	    * @returns {module:fs.FIn} The output stream `fin`.
         */
         this.load = function (fin) {
             this.metric.state = fin.readJson();
@@ -1084,8 +1137,8 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Create new (online) mean error instance.
     * @class
-    * @classdesc Online Mean Error (ME) instance
-    * @param {module:fs.FIn} [FIn] - Saved state can be loaded via constructor
+    * @classdesc Online Mean Error (ME) instance.
+    * @param {module:fs.FIn} [fin] - Saved state can be loaded via constructor.
     * @extends module:analytics~createOnlineMetric
     */
     metrics.MeanError = function (fin) {
@@ -1117,8 +1170,8 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Create new (online) mean absolute error instance.
     * @class
-    * @classdesc Online Mean Absolute Error (MAE) instance
-    * @param {module:fs.FIn} [FIn] - Saved state can be loaded via constructor
+    * @classdesc Online Mean Absolute Error (MAE) instance.
+    * @param {module:fs.FIn} [fin] - Saved state can be loaded via constructor.
     * @extends module:analytics~createOnlineMetric
     */
     metrics.MeanAbsoluteError = function (fin) {
@@ -1150,8 +1203,8 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Create new (online) mean square error instance.
     * @class
-    * @classdesc Online Mean Square Error (MSE) instance
-    * @param {module:fs.FIn} [FIn] - Saved state can be loaded via constructor
+    * @classdesc Online Mean Square Error (MSE) instance.
+    * @param {module:fs.FIn} [fin] - Saved state can be loaded via constructor.
     * @extends module:analytics~createOnlineMetric
     */
     metrics.MeanSquareError = function (fin) {
@@ -1183,8 +1236,8 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Create new (online) root mean square error instance.
     * @class
-    * @classdesc Online Root Mean Square Error (RMSE) instance
-    * @param {module:fs.FIn} [FIn] - Saved state can be loaded via constructor
+    * @classdesc Online Root Mean Square Error (RMSE) instance.
+    * @param {module:fs.FIn} [fin] - Saved state can be loaded via constructor.
     * @extends module:analytics~createOnlineMetric
     */
     metrics.RootMeanSquareError = function (fin) {
@@ -1216,8 +1269,8 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Create new (online) mean absolute percentage error instance.
     * @class
-    * @classdesc Online Mean Absolute Percentage Error (MAPE) instance
-    * @param {module:fs.FIn} [FIn] - Saved state can be loaded via constructor
+    * @classdesc Online Mean Absolute Percentage Error (MAPE) instance.
+    * @param {module:fs.FIn} [fin] - Saved state can be loaded via constructor.
     * @extends module:analytics~createOnlineMetric
     */
     metrics.MeanAbsolutePercentageError = function (fin) {
@@ -1251,8 +1304,8 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Create new (online) R Square instance. This statistic measures how successful the fit is in explaining the variation of the data. Best possible score is 1.0, lower values are worse.
     * @class
-    * @classdesc Online R Squared (R2) score instance
-    * @param {module:fs.FIn} [FIn] - Saved state can be loaded via constructor
+    * @classdesc Online R Squared (R2) score instance.
+    * @param {module:fs.FIn} [fin] - Saved state can be loaded via constructor.
     * @extends module:analytics~createOnlineMetric
     */
     metrics.R2Score = function (fin) {
@@ -1331,9 +1384,9 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
     * Mean error (ME) regression loss.
-    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`
-    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec`
-    * @returns {number} Error value
+    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`.
+    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec`.
+    * @returns {number} Error value.
     */
     metrics.meanError = function (yTrueVec, yPredVec) {
         return new calcBatchError(yTrueVec, yPredVec).ME()
@@ -1341,9 +1394,9 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
     * Mean absolute error (MAE) regression loss.
-    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`
-    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec`
-    * @returns {number} Error value
+    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`.
+    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec`.
+    * @returns {number} Error value.
     */
     metrics.meanAbsoluteError = function (yTrueVec, yPredVec) {
         return new calcBatchError(yTrueVec, yPredVec).MAE()
@@ -1351,9 +1404,9 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
     * Mean square error (MSE) regression loss.
-    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`
-    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec`
-    * @returns {number} Error value
+    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`.
+    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec`.
+    * @returns {number} Error value.
     */
     metrics.meanSquareError = function (yTrueVec, yPredVec) {
         return new calcBatchError(yTrueVec, yPredVec).MSE()
@@ -1361,9 +1414,9 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
     * Root mean square (RMSE) error regression loss.
-    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`
-    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec`
-    * @returns {number} Error value
+    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`.
+    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec`.
+    * @returns {number} Error value.
     */
     metrics.rootMeanSquareError = function (yTrueVec, yPredVec) {
         return new calcBatchError(yTrueVec, yPredVec).RMSE()
@@ -1371,9 +1424,9 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
     * Mean absolute percentage error (MAPE) regression loss.
-    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`
-    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec`
-    * @returns {number} Error value
+    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`.
+    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec.`
+    * @returns {number} Error value.
     */
     metrics.meanAbsolutePercentageError = function (yTrueVec, yPredVec) {
         return new calcBatchError(yTrueVec, yPredVec).MAPE()
@@ -1381,9 +1434,9 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
     * R^2 (coefficient of determination) regression score.
-    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`
-    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec`
-    * @returns {number} Error value
+    * @param {(Array<number> | module:la.Vector)} yTrueVec - ground truth values in `yTrueVec`.
+    * @param {(Array<number> | module:la.Vector)} yPredVec - estimated values in `yPredVec`.
+    * @returns {number} Error value.
     */
     metrics.r2Score = function (yTrueVec, yPredVec) {
         return new calcBatchError(yTrueVec, yPredVec).R2()
@@ -1393,56 +1446,64 @@ module.exports = exports = function (pathQmBinary) {
     exports.metrics = metrics;
 
     /**
-    * @typedef {Object} pcaParams
+    * @typedef {Object} PCAParam
+    * An object used for the construction of {@link module:analytics.PCA}.
     * @property {number} [k = null] - Number of eigenvectors to be computed.
     * @property {number} [iter = 100] - Number of iterations.
     */
 
     /**
-    * @classdesc Principal components analysis
+    * Principal Components Analysis
     * @class
-    * @param {module:analytics~pcaParams | module:fs.FIn} [params] - The constructor parameters.
+    * @classdesc Principal Components Analysis
+    * @param {module:analytics~PCAParam | module:fs.FIn} [arg] - Construction arguments. There are two ways of constructing:
+    * <br>1. Using the parameter object {@link module:analytics~PCAParam},
+    * <br>2. using the file input stream {@link module:fs.FIn}.
     * @example <caption>Using default constructor</caption>
     * // import analytics module
     * var analytics = require('qminer').analytics;
     * // construct model
     * var pca = new analytics.PCA();
+    *
     * @example <caption>Using custom constructor</caption>
     * // import analytics module
     * var analytics = require('qminer').analytics;
     * // construct model
     * var pca = new analytics.PCA({ k: 5, iter: 50 });
     */
-    exports.PCA = function (param) {
+    exports.PCA = function (arg) {
         var iter, k;
         var initParam;
         this.P = undefined;
         this.mu = undefined;
         this.lambda = undefined;
         var count = 1;
-        if (param != undefined && param.constructor.name == 'FIn') {
+        if (arg != undefined && arg.constructor.name == 'FIn') {
             this.P = new la.Matrix();
-            this.P.load(param);
+            this.P.load(arg);
             this.mu = new la.Vector();
-            this.mu.load(param);
+            this.mu.load(arg);
             this.lambda = new la.Vector();
-            this.lambda.load(param);
+            this.lambda.load(arg);
             var params_vec = new la.Vector();
-            params_vec.load(param);
+            params_vec.load(arg);
             iter = params_vec[0];
             k = params_vec[1];
-        } else if (param == undefined || typeof param == 'object') {
-            param = param == undefined ? {} : param;
+        } else if (arg == undefined || typeof arg == 'object') {
+            arg = arg == undefined ? {} : arg;
             // Fit params
-            var iter = param.iter == undefined ? 100 : param.iter;
-            var k = param.k; // can be undefined
+            var iter = arg.iter == undefined ? 100 : arg.iter;
+            var k = arg.k; // can be undefined
         } else {
             throw "PCA.constructor: parameter must be a JSON object or a fs.FIn!";
         }
         initParam = { iter: iter, k: k };
         /**
-        * Returns the model
-        * @returns {Object} The model object whose keys are: P (eigenvectors), lambda (eigenvalues) and mu (mean)
+        * Returns the model.
+        * @returns {Object} The object `pcaModel` containing the properties:
+        * <br>1. `pcaModel.P` - The eigenvectors. Type {@link module:la.Matrix}.
+        * <br>2. `pcaModel.lambda` - The eigenvalues. Type {@link module:la.Vector}.
+        * <br>3. `pcaModel.mu` - The mean values. Type {@link module:la.Vector}.
         * @example
         * // import analytics module
         * var analytics = require('qminer').analytics;
@@ -1462,7 +1523,7 @@ module.exports = exports = function (pathQmBinary) {
         /**
         * Saves the model.
         * @param {module:fs.FOut} fout - The output stream.
-        * @returns {module:fs.FOut} The given output stream fout.
+        * @returns {module:fs.FOut} The output stream `fout`.
         * @example
         * // import analytics module
         * var analytics = require('qminer').analytics;
@@ -1498,8 +1559,8 @@ module.exports = exports = function (pathQmBinary) {
         
 
         /**
-        * Sets parameters
-        * @param {p} Object whose keys are: k (number of eigenvectors) and iter (maximum iterations)
+        * Sets parameters.
+        * @param {module:analytics~PCAParam} param - The constructor parameters.
         * @example
         * // import analytics module
         * var analytics = require('qminer').analytics;
@@ -1512,11 +1573,12 @@ module.exports = exports = function (pathQmBinary) {
             iter = param.iter == undefined ? iter : param.iter;
             k = param.k == undefined ? k : param.k;
             initParam = { iter: iter, k: k };
+            return this;
         }
 
         /**
-        * Gets parameters
-        * @returns Object whose keys are: k (number of eigenvectors) and iter (maximum iterations)
+        * Gets parameters.
+        * @returns {moduel:analytics~PCAParam} The constructor parameters.
         * @example <caption>Using default constructor</caption>
         * // import analytics module
         * var analytics = require('qminer').analytics;
@@ -1524,6 +1586,7 @@ module.exports = exports = function (pathQmBinary) {
         * var pca = new analytics.PCA();
         * // check the constructor parameters
         * var paramvalue = pca.getParams();
+        *
         * @example <caption>Using custom constructor</caption>
         * // import analytics module
         * var analytics = require('qminer').analytics;
@@ -1571,14 +1634,16 @@ module.exports = exports = function (pathQmBinary) {
             this.P = res.U;
             this.lambda = res.s;
             this.mu = mu;
+
+            return this;
         }
 
         /**
-        * Projects the example(s) and expresses them as coefficients in the eigenvector basis this.P.
-        * Recovering the data in the original space: (this.P).multiply(p), where p's rows are the coefficients
+        * Projects the example(s) and expresses them as coefficients in the eigenvector basis `this.P`.
+        * Recovering the data in the original space: `(this.P).multiply(p)`, where `p`'s rows are the coefficients
         * in the eigenvector basis.
-        * @param {(module:la.Vector | module:la.Matrix)} x - Test vector or matrix with column examples
-        * @returns {(module:la.Vector | module:la.Matrix)} Returns projected vector or matrix
+        * @param {(module:la.Vector | module:la.Matrix)} x - Test vector or matrix with column examples.
+        * @returns {(module:la.Vector | module:la.Matrix)} Returns projected vector or matrix.
         * @example <caption>Transforming the matrix</caption>
         * // import analytics module
         * var analytics = require('qminer').analytics;
@@ -1591,6 +1656,7 @@ module.exports = exports = function (pathQmBinary) {
         * var model = pca.getModel();
         * // transform matrix
         * var transform = pca.transform(matrix);
+        *
         * @example <caption>Transforming the vector</caption>
         * // import analytics module
         * var analytics = require('qminer').analytics;
@@ -1618,9 +1684,9 @@ module.exports = exports = function (pathQmBinary) {
         }
 
         /**
-        * Reconstructs the vector in the original space, reverses centering
-        * @param {(module:la.Vector | module:la.Matrix)} x - Test vector or matrix with column examples, in the PCA space
-        * @returns {(module:la.Vector | module:la.Matrix)} Returns the reconstruction
+        * Reconstructs the vector in the original space, reverses centering.
+        * @param {(module:la.Vector | module:la.Matrix)} x - Test vector or matrix with column examples, in the PCA space.
+        * @returns {(module:la.Vector | module:la.Matrix)} Returns the reconstruction.
         * @example <caption>Inverse transform of matrix</caption>
         * // import analytics module
         * var analytics = require('qminer').analytics;
@@ -1633,6 +1699,7 @@ module.exports = exports = function (pathQmBinary) {
         * var model = pca.getModel();
         * // use inverseTransform on matrix
         * var invTransform = pca.inverseTransform(matrix);
+        *
         * @example <caption>Inverse transform of vector</caption>
         * // import analytics module
         * var analytics = require('qminer').analytics;
@@ -1662,8 +1729,8 @@ module.exports = exports = function (pathQmBinary) {
    
 
     /**
-     * @typedef KMeansExplanation
-     * @type {Object}
+     * @typedef {Object} KMeansExplanation
+     * The examplanation returned by {@link module:analytics.KMeans#explain}.
      * @property {number} medoidID - The ID of the nearest medoids.
      * @property {module:la.IntVector} featureIDs - The IDs of features, sorted by contribution.
      * @property {module:la.Vector} featureContributions - Weights of each feature contribution (sum to 1.0).
@@ -1672,7 +1739,7 @@ module.exports = exports = function (pathQmBinary) {
     /**
      * Returns the IDs of the nearest medoid for each example.
      * @param {(module:la.Matrix | module:la.SparseMatrix)} X - Matrix whose columns correspond to examples.
-     * @returns {Array.<KMeansExplanation>} Array containing the KMeans explanantions.
+     * @returns {Array.<module:analytics~KMeansExplanation>} Array containing the KMeans explanantions.
      * @example
      * // import analytics module
      * var analytics = require('qminer').analytics;

--- a/src/nodejs/scripts/analytics.js
+++ b/src/nodejs/scripts/analytics.js
@@ -88,46 +88,40 @@ module.exports = exports = function (pathQmBinary) {
 
     // Exports preprocessing namespace
     exports.preprocessing = preprocessing;
-
-    /**
-    * SVM model.
-    * @typedef {Object} svmModel
-    * @property  {module:la.Vector} [svmModel.weigths] - SVM normal vector.
-    */
+    
+    // SVM 
     /**
 	* Get the model.
-	* @returns {module:analytics~svmModel} The current SVM model.
+	* @returns {Object} The `svmModel` object containing the property:
+    * <br> 1. `svmModel.weights` - The SVM normal vector, type {@link module:la.Vector}.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
     * // create a SVC model
     * var SVC = new analytics.SVC();
     * // get the properties of the model
-    * var model = SVC.getModel(); // returns { weight: new require('qminer').la.Vector(); }
+    * var model = SVC.getModel();
 	*/
     exports.SVC.prototype.getModel = function() { return { weights: this.weights }; }
     /**
 	* Get the model.
-	* @returns {module:analytics~svmModel} Get current SVM model
+	* @returns {Object} The `svmModel` object containing the property:
+    * <br> 1. `svmModel.weights` - The SVM normal vector, type {@link module:la.Vector}.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
     * // create a SVR model
     * var SVR = new analytics.SVR();
     * // get the properties of the model
-    * var model = SVR.getModel(); // returns { weights: new require('qminer').la.Vector(); }
+    * var model = SVR.getModel();
 	*/
     exports.SVR.prototype.getModel = function() { return { weights: this.weights }; }
 
     // Ridge Regression
     /**
-    * @typedef {Object} ridgeRegModel
-    * @property {module:la.Vector} [ridgeRegModel.weights] - The Ridge Regression model vector.
-    */
-
-    /**
     * Gets the model.
-    * @returns {module:analytics~ridgeRegModel} Get current model.
+    * @returns {Object} The `ridgeRegModel` object containing the property:
+    * <br> 1. `ridgeRegModel.weights` - The Ridge Regression model vector, type {@link module:la.Vector}.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
@@ -140,12 +134,9 @@ module.exports = exports = function (pathQmBinary) {
 
     // Recursive Linear Regression
     /**
-    * @typedef {Object} recLinRegModel
-    * @property {module:la.Vector} [recLinRegModel.weights] - Recursive Linear Regression model vector.
-    */
-    /**
-    * Gets Recursive Linear Regression model
-    * @returns {module:analytics~recLnRegModel} The current model.
+    * Gets the model.
+    * @returns {Object} The `recLinRegModel` object containing the property:
+    * <br> 1. `recLinRegModel.weights` - The Recursive Linear Regression model vector, type {@link module:la.Vector}.
     * @example
     * // import analytics module
     * var analytics = require('qminer').analytics;
@@ -1673,15 +1664,15 @@ module.exports = exports = function (pathQmBinary) {
     /**
      * @typedef KMeansExplanation
      * @type {Object}
-     * @property {number} medoidID - The ID of the nearest medoids
-     * @property {module:la.IntVector} featureIDs - The IDs of features, sorted by contribution
-     * @property {module:la.Vector} featureContributions - Weights of each feature contribution (sum to 1.0)
+     * @property {number} medoidID - The ID of the nearest medoids.
+     * @property {module:la.IntVector} featureIDs - The IDs of features, sorted by contribution.
+     * @property {module:la.Vector} featureContributions - Weights of each feature contribution (sum to 1.0).
      */
 
     /**
      * Returns the IDs of the nearest medoid for each example.
      * @param {(module:la.Matrix | module:la.SparseMatrix)} X - Matrix whose columns correspond to examples.
-     * @returns {Array.<KMeansExplanation>} Object containing the vector of medoid IDs.
+     * @returns {Array.<KMeansExplanation>} Array containing the KMeans explanantions.
      * @example
      * // import analytics module
      * var analytics = require('qminer').analytics;
@@ -1743,15 +1734,11 @@ module.exports = exports = function (pathQmBinary) {
     }
 
     /**
-     * @typedef {Object} KMeansModel
-     * @property {(module:la.Matrix | module:la.SparseMatrix)} C - Matrix containing the centroids.
-     * @property module:la.IntVector} medoids - The cluster medoids of the training data.
-     * @property {module:la.IntVector} idxv - The cluster ids of the training data.
-     */
-
-    /**
     * Returns the model
-    * @returns {module:analytics~KMeansModel} The model.
+    * @returns {Object} The `KMeansModel` object containing the properites:
+    * <br> 1. `KMeansModel.C` - The {@link module:la.Matrix} or {@link module:la.SparseMatrix} containing the centroids,
+    * <br> 2. `KMeansModel.medoids` - The {@link module:la.IntVector} of cluster medoids of the training data,
+    * <br> 3. `KMeansModel.idxv` - The {@link module:la.IntVector} of cluster IDs of the training data.
     * @example
     * // import modules
     * var analytics = require('qminer').analytics;

--- a/src/nodejs/scripts/fs.js
+++ b/src/nodejs/scripts/fs.js
@@ -82,14 +82,17 @@ module.exports = exports = function (pathQmBinary) {
     /**
      * Reads a buffer, containing a CSV file, line by line and calls a callback for each line.
      * The callback function accepts an array with the values of the current line.
-     *
-     * @param {Buffer} buffer - the Node.js buffer
-     * @param {Object} opts - options parameter
-     * @param {function} opts.onLine - a callback that gets called on each line (for example: function (lineArr) {})
-     * @param {function} opts.onEnd - a callback that gets returned after all the lines have been read
-     * @param {String} opts.delimiter - the delimiter used when parsing
-     * @param {Number} opts.lineLimit - the maximum number of lines read
-     * @param {Number} opts.skipLines - the number of lines that should be skipped before first calling the callback
+     * @param {Buffer} buffer - The Node.js buffer.
+     * @param {Object} opts - Options parameter.
+     * @param {function} opts.onLine - A callback that gets called on each line (for example: `function (lineArr) {}`).
+     * @param {function} opts.onEnd - A callback that gets returned after all the lines have been read.
+     * @param {String} opts.delimiter - The delimiter used when parsing.
+     * @param {Number} opts.lineLimit - The maximum number of lines read.
+     * @param {Number} opts.skipLines - The number of lines that should be skipped before first calling the callback.
+     * @example
+     * // import fs module
+     * var fs = require('qminer').fs;
+     * // open a csv file and read the lines
      */
     exports.readCsvLines = function (fin, opts) {
     	exports.readLines(fin, processCsvLine(opts), opts.onEnd);
@@ -97,7 +100,11 @@ module.exports = exports = function (pathQmBinary) {
     
     /**
      * Reads json that was serialized using `fs.FOut.writeJson`.
-     * @returns {Object} Json object
+     * @returns {Object} Json object.
+     * @example
+     * // import fs module
+     * var fs = require('qminer').fs;
+     * // create and save a json and then read it using the readJson method
      */
     exports.FIn.prototype.readJson = function () {
     	var str = this.readString();
@@ -106,8 +113,12 @@ module.exports = exports = function (pathQmBinary) {
     
     /**
      * Saves json object, which can be read by `fs.FIn.readJson`.
-     * @returns {Object} obj - Json object to write
+     * @returns {Object} obj - Json object to write.
      * @returns {module:fs.FOut} Self.
+     * @example
+     * // import fs module
+     * var fs = require('qminer').fs;
+     * // create and save a json using the writeJson method
      */
     exports.FOut.prototype.writeJson = function (json) {
     	var str = JSON.stringify(json);

--- a/src/nodejs/scripts/la.js
+++ b/src/nodejs/scripts/la.js
@@ -15,7 +15,7 @@ module.exports = exports = function (pathQmBinary) {
     //!STARTJSDOC
 
     /**
-    * Caluclates the frobenious norm squared of the matrix.
+    * Calculates the frobenious norm squared of the matrix.
     * @returns {number} Frobenious norm squared.
     * @example
     * // import la module

--- a/src/nodejs/scripts/la.js
+++ b/src/nodejs/scripts/la.js
@@ -542,7 +542,7 @@ module.exports = exports = function (pathQmBinary) {
      * // create a vector
      * var vec = new la.Vector([1, 2, 3]);
      * // square the values of the vector
-     * returns the vector containing  the values 1, 4, 9
+     * // returns the vector containing  the values 1, 4, 9
      * var sqr = la.square(vec);
      */
     exports.square = function(x) {

--- a/src/nodejs/scripts/la.js
+++ b/src/nodejs/scripts/la.js
@@ -15,8 +15,15 @@ module.exports = exports = function (pathQmBinary) {
     //!STARTJSDOC
 
     /**
-    * Returns the frobenious norm squared
-    * @returns {number} Frobenious norm squared
+    * Caluclates the frobenious norm squared of the matrix.
+    * @returns {number} Frobenious norm squared.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a sparse matrix
+    * var spMat = new la.SparseMatrix([[[0, 1], [1, 5]], [[0, 2], [2, -3]]]);
+    * // get the forbenious norm squared of the sparse matrix
+    * var frob = spMat.frob2();
     */
     exports.SparseMatrix.prototype.frob2 = function () {
         return Math.pow(this.frob(), 2);
@@ -34,9 +41,18 @@ module.exports = exports = function (pathQmBinary) {
     * var text = mat.toString(); // returns 'rows: -1, cols: 2, nnz: 3'
     */
     exports.SparseMatrix.prototype.toString = function () { return "rows: " + this.rows + ", cols:" + this.cols + ", nnz: " + this.nnz(); }
+
     /**
     * Returns the number of non-zero elements of sparse matrix.
     * @returns {number} Number of non-zero elements.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a sparse matrix
+    * var spMat = new la.SparseMatrix([[[0, 1], [1, 5]], [[0, 2], [2, -3]]]);
+    * // get the number of non-zero elements
+    * // returns 4
+    * var nnz = spMat.nnz(); 
     */
     exports.SparseMatrix.prototype.nnz = function () {
         var nnz = 0;
@@ -113,7 +129,7 @@ module.exports = exports = function (pathQmBinary) {
 
 	/**
     * Copies the vector into a JavaScript array of numbers.
-    * @returns {Array<number>} A JavaScript array of numbers.
+    * @returns {Array.<number>} A JavaScript array of numbers.
     * @example
     * // import la module
     * var la = require('qminer').la;
@@ -126,19 +142,43 @@ module.exports = exports = function (pathQmBinary) {
         return vec2arr(this);
 	}
 	/**
-    * Copies the vector into a JavaScript array
+    * Copies the vector into a JavaScript array of numbers.
+    * @returns {Array.<number>} A JavaScript array of integers.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new integer vector
+    * var vec = new la.IntVector([1, 2, 3]);
+    * // create a JavaScript array out of vec
+    * var arr = vec.toArray(); // returns an array [1, 2, 3] 
     */
 	exports.IntVector.prototype.toArray = function () {
         return vec2arr(this);
 	}
 	/**
-    * Copies the vector into a JavaScript array
+    * Copies the vector into a JavaScript array of strings.
+    * @returns {Array.<string>} A JavaScript array of strings.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.StrVector(["one", "two", "three"]);
+    * // create a JavaScript array out of vec
+    * var arr = vec.toArray(); // returns an array ["one", "two", "three"]
     */
 	exports.StrVector.prototype.toArray = function () {
         return vec2arr(this);
 	}
 	/**
-    * Copies the vector into a JavaScript array
+    * Copies the vector into a JavaScript array of booleans.
+    * @returns {Array.<boolean>} A JavaScript array of booleans.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a new vector
+    * var vec = new la.BoolVector([true, false, true]);
+    * // create a JavaScript array out of vec
+    * var arr = vec.toArray(); // returns an array [true, false, true]
     */
 	exports.BoolVector.prototype.toArray = function () {
         return vec2arr(this);
@@ -409,7 +449,7 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Constructs a matrix by concatenating a double-nested array of matrices.
     * @param {Array<Array<module:la.Matrix>> } nestedArrMat - An array of block rows, where each block row is an array of matrices.
-    * For example: [[m_11, m_12], [m_21, m_22]] is used to construct a matrix where the (i,j)-th block submatrix is m_ij.
+    * For example: `[[m_11, m_12], [m_21, m_22]]` is used to construct a matrix where the (i,j)-th block submatrix is `m_ij`.
     * @returns {module:la.Matrix} Concatenated matrix.
     * @example
     * // import la module
@@ -420,12 +460,13 @@ module.exports = exports = function (pathQmBinary) {
     * var B = new la.Matrix([[5,6], [7,8]]);
     * var C = new la.Matrix([[9,10], [11,12]]);
     * var D = new la.Matrix([[13,14], [15,16]]);
-    * var mat = la.cat([[A,B], [C,D]]);
+    * // create a nested matrix
     * // returns the matrix:
     * // 1  2  5  6
     * // 3  4  7  8
     * // 9  10 13 14
     * // 11 12 15 16
+    * var mat = la.cat([[A,B], [C,D]]);
     */
     exports.cat = function (nestedArrMat) {
         var dimx = []; //cell row dimensions
@@ -517,7 +558,7 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
     * Returns a JS array of indices `idxArray` that correspond to the max elements in each column of dense matrix. The resulting array has one element for vector input.
-    * @param {(la.Matrix | la.Vector)} X - The matrix or vector.
+    * @param {(module:la.Matrix | module:la.Vector)} X - The matrix or vector.
     * @returns {Array<number>} Array of indexes where maximum is found, one for each column.
     * @example
     * // import la module
@@ -547,19 +588,20 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
     * Computes and returns the pairwise squared euclidean distances between columns of `X1` and `X2` (`mat3[i,j] = ||mat(:,i) - mat2(:,j)||^2`).
-    * @param {la.Matrix} X1 - First matrix
-    * @param {la.Matrix} X2 - Second matrix
-    * @returns {la.Matrix} Matrix with `X1.cols` rows and `X2.cols` columns containing squared euclidiean distances.
+    * @param {module:la.Matrix} X1 - First matrix.
+    * @param {module:la.Matrix} X2 - Second matrix.
+    * @returns {module:la.Matrix} Matrix with `X1.cols` rows and `X2.cols` columns containing squared euclidean distances.
     * @example
     * // import la module
     * var la = require('qminer').la;
     * // construct two input matrices
     * var X1 = new la.Matrix([[1,2], [2,0]]);
     * var X2 = new la.Matrix([[1,0.5,0],[0,-0.5,-1]]);
-    * la.pdist2(X1, X2)
+    * // get the pairwise squared distance between the matrices
     * // returns the matrix:
     * // 4 6.5 10
     * // 1 2.5 5
+    * la.pdist2(X1, X2)
     */
     exports.pdist2 = function (X1, X2) {
         var snorm1 = exports.square(X1.colNorms());
@@ -575,7 +617,14 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Calculates the inverse matrix with SVD.
     * @param {module:la.Matrix} mat - The matrix we want to inverse.
-    * @returns {module:la.Matrix} The inverse matrix of mat.
+    * @returns {module:la.Matrix} The inverse matrix of `mat`.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a random matrix
+    * var mat = new la.Matrix({ rows: 5, cols: 5, random: true });
+    * // get the inverse of mat
+    * var inv = la.inverseSVD(mat);
     */
     exports.inverseSVD = function (mat) {
         var k = Math.min(mat.rows, mat.cols);
@@ -607,15 +656,22 @@ module.exports = exports = function (pathQmBinary) {
         return B;
     }
 
-
-    //!- `la.conjgrad(mat,vec,vec2)` -- solves the psd symmetric system mat * vec2 = vec, where `mat` is a matrix and `vec` and `vec2` are dense vectors
-    //!- `la.conjgrad(spMat,vec,vec2)` -- solves the psd symmetric system spMat * vec2 = vec, where `spMat` is a matrix and `vec` and `vec2` are dense vectors
     /**
     * Solves the PSD symmetric system: A x = b, where A is a positive-definite symmetric matrix.
     * @param {(module:la.Matrix | module:la.SparseMatrix)} A - The matrix on the left-hand side of the system.
     * @param {module:la.Vector} b - The vector on the right-hand side of the system.
     * @param {module:la.Vector} [x] - Current solution. Default is a vector of zeros.
     * @returns {module:la.Vector} Solution to the system.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a positive-definite symmetric matrix
+    * var vecTemp = new la.Vector([1, 2, 3]);
+    * var mat = vecTemp.diag();
+    * // create the right-hand side vector 
+    * var vec = new la.Vector([0.5, 3, -2]);
+    * // solve the PSD symmetric system
+    * var x = la.conjgrad(mat, vec);
     */
     exports.conjgrad = function (A, b, x) {
     	x = x || new exports.Vector({vals: A.cols});

--- a/src/nodejs/scripts/la.js
+++ b/src/nodejs/scripts/la.js
@@ -76,7 +76,14 @@ module.exports = exports = function (pathQmBinary) {
 
 	/**
 	* Returns a copy of the matrix.
-	* @returns {module:la.Matrix} Copy
+	* @returns {module:la.Matrix} Matrix copy.
+    * @example 
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a random matrix
+    * var mat = new la.Matrix({ rows: 5, cols: 4, random: true });
+    * // create a copy of the matrix
+    * var copy = mat.toMat();
 	*/
 	exports.Matrix.prototype.toMat = function () { return new exports.Matrix(this); }
 
@@ -185,13 +192,22 @@ module.exports = exports = function (pathQmBinary) {
     ///////// RANDOM GENERATORS
 
     /**
-    * Returns an object with random numbers
+    * Returns an object with random numbers.
     * @param {number} [arg1] - Represents dimension of vector or number of rows in matrix. Must be an integer.
     * @param {number} [arg2] - Represents number of columns in matrix. Must be an integer.
     * @returns {(number | module:la.Vector | module:la.Matrix)}
     * <br>1. Number, if no parameters are given.
-    * <br>2. {@link module:la.Vector}, if parameter arg1 is given.
-    * <br>3. {@link module:la.Matrix}, if parameters arg1 and arg2 are given.
+    * <br>2. {@link module:la.Vector}, if parameter `arg1` is given.
+    * <br>3. {@link module:la.Matrix}, if parameters `arg1` and `arg2` are given.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // generate a random number
+    * var number = la.randn();
+    * // generate a random vector of length 7
+    * var vector = la.randn(7);
+    * // generate a random matrix with 7 rows and 10 columns
+    * var mat = la.randn(7, 10);
     */
     exports.randn = function (arg1, arg2) {
         //arguments.length
@@ -229,12 +245,19 @@ module.exports = exports = function (pathQmBinary) {
     };
 
     /**
-    * Returns a randomly selected integer from an array..
+    * Returns a randomly selected integer(s) from an array.
     * @param {number} num - The upper bound of the array. Must be an integer.
-    * @param {number} [len] - The number of integers. Must be an integer.
+    * @param {number} [len] - The number of selected integers. Must be an integer.
     * @returns {(number | la.IntVector)}
-    * <br>1. Randomly selected integer from the array [0, ..., num-1], if no parameters are given.
-    * <br>2. {@link module:la.Vector}, if parameter len is given. The vector contains random integers from the array [0, ..., num-1] (with repetition)
+    * <br>1. Randomly selected integer from the array `[0,...,num-1]`, if no parameters are given.
+    * <br>2. {@link module:la.IntVector}, if parameter `len` is given. The vector contains random integers from the array `[0,...,num-1]` (with repetition).
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // generate a random integer between 0 and 10
+    * var number = la.randi(10);
+    * // generate an integer vector containing 5 random integers between 0 and 10
+    * var vec = la.randi(10, 5);
     */
     exports.randi = function () {
         var len = arguments.length;
@@ -259,9 +282,14 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
     * Returns a JavaScript array, which is a sample of integers from an array.
-    * @param {number} n - The upper bound of the array [0, ..., n-1]. Must be an integer.
-    * @param {number} k - Length of the sample. Must be smaller or equal to n.
-    * @returns {Array<number>} The sample of k numbers from [0, ..., n-1], sampled without replacement.
+    * @param {number} n - The upper bound of the generated array `[0,...,n-1]`. Must be an integer.
+    * @param {number} k - Length of the sample. Must be smaller or equal to `n`.
+    * @returns {Array<number>} The sample of `k` numbers from `[0,...,n-1]`, sampled without replacement.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create an array containing 5 integers between 0 and 15
+    * var arr = la.randVariation(15, 5);
     */
     exports.randVariation = function (n, k) {
         var n = arguments[0];
@@ -276,7 +304,12 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Returns a permutation of elements.
     * @param {number} k - Number of elements to permutate.
-    * @returns {Array<number>} A JavaScript array of integers. Represents a permutation of k elements.
+    * @returns {Array<number>} A JavaScript array of integers. Represents a permutation of `k` elements.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create an array/permutation of 5 elements
+    * var perm = la.randPerm(5);
     */
     exports.randPerm = function (k) {
         assert(isInt(k));
@@ -289,9 +322,14 @@ module.exports = exports = function (pathQmBinary) {
     ///////// COMMON MATRICES
 
     /**
-    * Returns an dense identity matrix
+    * Returns an dense identity matrix.
     * @param {number} dim - The dimension of the identity matrix. Must be a positive integer.
-    * @returns {module:la.Matrix} A dim-by-dim identity matrix.
+    * @returns {module:la.Matrix} A `dim`-by-`dim` identity matrix.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // generate a dense identity matrix of dimension 5
+    * var id = la.eye(5);
     */
     exports.eye = function(dim) {
         var identity = new exports.Matrix({ "rows": dim, "cols": dim });
@@ -305,6 +343,11 @@ module.exports = exports = function (pathQmBinary) {
     * Returns a sparse identity matrix
     * @param {number} dim - The dimension of the identity matrix. Must be a positive integer.
     * @returns {module:la.SparseMatrix} A dim-by-dim identity matrix.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // generate a sparse identity matrix of dimension 5
+    * var spId = la.speye(5);
     */
     exports.speye = function (dim) {
         var vec = exports.ones(dim);
@@ -314,8 +357,13 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Returns a sparse zero matrix.
     * @param {number} rows - Number of rows of the sparse matrix.
-    * @param {number} cols - Number of columns of the sparse matrix.
-    * @returns {module:la.SparseMatrix} A rows-by-cols sparse zero matrix.
+    * @param {number} [cols = rows] - Number of columns of the sparse matrix.
+    * @returns {module:la.SparseMatrix} A `rows`-by-`cols` sparse zero matrix.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a sparse zero matrix with 5 rows and columns
+    * var spMat = la.sparse(5);
     */
     exports.sparse = function (rows, cols) {
         cols = typeof cols == 'undefined' ? rows : cols;
@@ -326,8 +374,13 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Returns a dense zero matrix.
     * @param {number} rows - Number of rows of the matrix.
-    * @param {number} cols - Number of columns of the matrix.
-    * @returns {module:la.Matrix} A rows-by-cols dense zero matrix.
+    * @param {number} [cols = rows] - Number of columns of the matrix.
+    * @returns {module:la.Matrix} A `rows`-by-`cols` dense zero matrix.
+    * @example
+    * // import la module
+    * var la = require('qminer').la;
+    * // create a sparse zero matrix with 5 rows and 3 columns
+    * var mat = la.zeros(5, 3);
     */
     exports.zeros = function (rows, cols) {
         cols = typeof cols == 'undefined' ? rows : cols;
@@ -338,7 +391,7 @@ module.exports = exports = function (pathQmBinary) {
     /**
     * Returns a vector with all entries set to 1.0.
     * @param {number} dim - Dimension of the vector.
-    * @returns {module:la.Vector} A dim-dimensional vector whose entries are set to 1.0.
+    * @returns {module:la.Vector} A `dim`-dimensional vector whose entries are set to 1.0.
     * @example
     * // import la module
     * var la = require('qminer').la;
@@ -354,10 +407,10 @@ module.exports = exports = function (pathQmBinary) {
     };
 
     /**
-    * Constructs a matrix by concatenating a doubly-nested array of matrices.
-    * @param {Array<Array<module:la.Matrix>> } matrixDoubleArr - An array of block rows, where each block row is an array of matrices.
-    * For example: [[m11, m12], [m21, m22]] is used to construct a matrix where the (i,j)-th block submatrix is mij.
-    * @returns {module:la.Matrix} Concatenated matrix
+    * Constructs a matrix by concatenating a double-nested array of matrices.
+    * @param {Array<Array<module:la.Matrix>> } nestedArrMat - An array of block rows, where each block row is an array of matrices.
+    * For example: [[m_11, m_12], [m_21, m_22]] is used to construct a matrix where the (i,j)-th block submatrix is m_ij.
+    * @returns {module:la.Matrix} Concatenated matrix.
     * @example
     * // import la module
     * var la = require('qminer').la;
@@ -374,7 +427,6 @@ module.exports = exports = function (pathQmBinary) {
     * // 9  10 13 14
     * // 11 12 15 16
     */
-    //# exports.cat = function(matrixDoubleArr) {}
     exports.cat = function (nestedArrMat) {
         var dimx = []; //cell row dimensions
         var dimy = []; //cell col dimensions
@@ -416,18 +468,16 @@ module.exports = exports = function (pathQmBinary) {
     }
 
     /**
-    * Generates an integer vector given range
-    * @param {number} min - Start value (should be an integer)
-    * @param {number} max - End value (should be an integer)
-    * @returns {module:la.IntVector} Integer range vector
+    * Generates an integer vector given range.
+    * @param {number} min - Start value. Should be an integer.
+    * @param {number} max - End value. Should be an integer.
+    * @returns {module:la.IntVector} Integer range vector.
     * @example
     * // import la module
     * var la = require('qminer').la;
+    * // create a range vector containing 1, 2, 3
     * var vec = la.rangeVec(1, 3);
-    * // returns the vector:
-    * // 1  2  3
     */
-    //# exports.rangeVec = function(min, max) {}
     exports.rangeVec = function (min, max) {
         var len = max - min + 1;
         var rangeV = new exports.IntVector({ "vals": len });
@@ -439,6 +489,21 @@ module.exports = exports = function (pathQmBinary) {
 
 	//////// METHODS
 
+    /**
+     * Squares the values in vector.
+     * @param {number | module:la.Vector} x - The value/vector.
+     * @returns {number | module:la.Vector}
+     * <br> 1. If `x` is a number, returns square of `x`.
+     * <br> 2. If `x` is a {@link module:la.Vector}, returns a {@link module:la.Vector}, where the i-th value of the vector is the square of `x[i]`.
+     * @example
+     * // import la module
+     * var la = require('qminer').la;
+     * // create a vector
+     * var vec = new la.Vector([1, 2, 3]);
+     * // square the values of the vector
+     * returns the vector containing  the values 1, 4, 9
+     * var sqr = la.square(vec);
+     */
     exports.square = function(x) {
         if (typeof x.length == "undefined") {
             return x * x;
@@ -451,19 +516,19 @@ module.exports = exports = function (pathQmBinary) {
     };
 
     /**
-    * returns a JS array of indices `idxArray` that correspond to the max elements in each column of dense matrix. The resulting array has one element for vector input.
-    * @param {(la.Matrix | la.Vector)} X - A matrix or a vector
-    * @returns {Array<number>} Array of indexes where maximum is found, one for each column
+    * Returns a JS array of indices `idxArray` that correspond to the max elements in each column of dense matrix. The resulting array has one element for vector input.
+    * @param {(la.Matrix | la.Vector)} X - The matrix or vector.
+    * @returns {Array<number>} Array of indexes where maximum is found, one for each column.
     * @example
     * // import la module
     * var la = require('qminer').la;
     * // create a dense matrix
     * var mat = new la.Matrix([[1, 2], [2, 0]]);
-    * la.findMaxIdx(mat)
+    * // get the indices of the maximum elements in each column of mat
     * // returns the array:
     * // [1, 0]
+    * la.findMaxIdx(mat);
     */
-    //# exports.findMaxIdx = function(X) {}
     exports.findMaxIdx = function (X) {
         var idxv = new Array();
         // X is a dense matrix
@@ -481,7 +546,7 @@ module.exports = exports = function (pathQmBinary) {
     };
 
     /**
-    * computes and returns the pairwise squared euclidean distances between columns of `X1` and `X2` (`mat3[i,j] = ||mat(:,i) - mat2(:,j)||^2`).
+    * Computes and returns the pairwise squared euclidean distances between columns of `X1` and `X2` (`mat3[i,j] = ||mat(:,i) - mat2(:,j)||^2`).
     * @param {la.Matrix} X1 - First matrix
     * @param {la.Matrix} X2 - Second matrix
     * @returns {la.Matrix} Matrix with `X1.cols` rows and `X2.cols` columns containing squared euclidiean distances.
@@ -496,7 +561,6 @@ module.exports = exports = function (pathQmBinary) {
     * // 4 6.5 10
     * // 1 2.5 5
     */
-    // exports.pdist2 = function (X1, X2) {}
     exports.pdist2 = function (X1, X2) {
         var snorm1 = exports.square(X1.colNorms());
         var snorm2 = exports.square(X2.colNorms());

--- a/src/nodejs/scripts/qm.js
+++ b/src/nodejs/scripts/qm.js
@@ -20,18 +20,18 @@ module.exports = exports = function (pathQmBinary) {
     //==================================================================
 
     /**
-    * The parameter given to {@link module:qm.Base#loadCSV}.
     * @typedef {object} BaseLoadCSVParam
-    * @property {string} BaseLoadCSVParam.file - The name of the input file.
-    * @property {string} BaseLoadCSVParam.store - Name of the store which will be created.
-    * @property {module:qm.Base} BaseLoadCSVParam.base - QMiner base object that creates the store.
-    * @property {string} [BaseLoadCSVParam.delimiter = ','] - Optional delimiter.
-    * @property {string} [BaseLoadCSVParam.quote = '"'] - Optional character to escape values that contain a delimiter.
+    * The parameter given to {@link module:qm.Base#loadCSV}.
+    * @property {string} file - The name of the input file.
+    * @property {string} store - Name of the store which will be created.
+    * @property {module:qm.Base} base - QMiner base object that creates the store.
+    * @property {string} [delimiter = ','] - Optional delimiter.
+    * @property {string} [quote = '"'] - Optional character to escape values that contain a delimiter.
     */
 
     /**
      * Loads the store from a CSV file.
-     * @param {module:qm~baseLoadCSVParam} opts - Options object.
+     * @param {module:qm~BaseLoadCSVParam} opts - Options object.
      * @param {function} [callback] - Callback function, called on errors and when the procedure finishes.
      */
     exports.Base.prototype.loadCSV = function (opts, callback) {
@@ -219,16 +219,15 @@ module.exports = exports = function (pathQmBinary) {
     	}
     };
 
-    /**
-     * Loads the store from a CSV file.
-     * @param {module:qm~baseLoadCSVParam} opts - Options object.
-     * @param {function} [callback] - Callback function, called on errors and when the procedure finishes.
-     */
-
     //==================================================================
     // STORE
     //==================================================================
 
+    /**
+     * Adds a stream aggregate to a store.
+     * @param {function} trigger - The trigger containing the method {@link module:qm.StreamAggr#onAdd} and optional
+     * {@link module:qm.StreamAggr#onUpdate} and {@link module:qm.StreamAggr#onDelete}.
+     */
     exports.Store.prototype.addTrigger = function (trigger) {
         // name is automatically generated
         // saveJson isn't needed
@@ -241,10 +240,21 @@ module.exports = exports = function (pathQmBinary) {
         var streamAggr = new exports.StreamAggr(this.base, Callbacks, this.name);
     }
 
+    /**
+     * Adds a stream aggregate to the store. For use example see {@link module:qm.StreamAggr} constructor example.
+     * @param {(module:qm~StreamAggregator | function)} arg - Constructor arguments. There are two argument types:
+     * <br>1. Using the {@link module:qm~StreamAggregator} object,
+     * <br>2. using a function/JavaScript class. The function has defined The object containing the schema of the stream aggregate or the function object defining the operations of the stream aggregate.
+     */ 
     exports.Store.prototype.addStreamAggr = function (params) {
         return new exports.StreamAggr(this.base, params, this.name);
     }
 
+    /**
+     * Inspects the stores.
+     * @param {number} depth - The depth of inspection. How many times to recurse while formatting the store object.
+     * @returns {string} String representation of the store.
+     */
     exports.Store.prototype.inspect = function (depth) {
         var d = (depth == null) ? 0 : depth;
         return util.inspect(this, { depth: d, 'customInspect': false });
@@ -252,9 +262,9 @@ module.exports = exports = function (pathQmBinary) {
 
     /**
      * Load given file line by line, parse each line to JSON and push it to the store.
-     *
-     * @param {String} file - Name of the json line file
-     * @param {Number} [limit] - Maximal number of records to load from file
+     * @param {String} file - Name of the JSON line file.
+     * @param {Number} [limit] - Maximal number of records to load from file.
+     * @returns {number} Number of records loaded from file.
      */
     exports.Store.prototype.loadJson = function (file, limit) {
         var fin = fs.openRead(file);
@@ -282,11 +292,13 @@ module.exports = exports = function (pathQmBinary) {
     /**
      * Stores the record set as a CSV file.
      *
-     * @param {Object} opts - arguments
-     * @property {String} opts.fname - name of the output file
-     * @property {Boolean} [opts.includeHeaders] - indicates wether to include the header in the first line
-     * @property {String} [opts.timestampType] - If set to 'ISO', datetime fields will be printed as ISO dates, otherwise as timestamps. Defaults to 'timestamp'.
-     * @property {String} [opts.escapeChar] - character which escapes quotes
+     * @param {Object} opts - Arguments.
+     * @property {String} opts.fname - Name of the output file.
+     * @property {Boolean} [opts.includeHeaders = true] - Indicates wether to include the header in the first line.
+     * @property {String} [opts.timestampType = 'timestamp'] - Date format. Possible options: 
+     * <br>1. `'ISO'` - Datetime fields will be printed as ISO dates,
+     * <br>2. `'timestamp'` - Datetime fields will be printed as timestamps.
+     * @property {String} [opts.escapeChar = "] - Character which escapes quotes.
      */
     exports.RecSet.prototype.saveCsv = function (opts) {
     	if (opts == null || opts.fname == null) throw new Error('Missing parameter fname!');
@@ -372,13 +384,17 @@ module.exports = exports = function (pathQmBinary) {
     * are removed from the buffer and new records are stored in their place. For
     * adding and deleting a callback is called. Records are stored by their IDs.
     * @class
-    * @param {Object} [param] - Constructor parameters
+    * @param {Object} [params] - Constructor parameters.
     * @param {module:qm.Store} param.store - Store for the records in the buffer.
     * @param {number} param.size - Size of the buffer (number of records).
     * @param {function} [param.onAdd] - Callback executed when new record is
-    * added to the buffer. Callback is give two parameters: record and instance of CircularRecordBuffer.
+    * added to the buffer. Callback is give two parameters: 
+    * <br>`rec` - The record. Type {@link module:qm.Record}.
+    * <br>`circRecBuff` - The circular record buffer instance. Type {@link module:qm.CircularRecordBuffer}.
     * @param {function} [param.onDelete] - Callback executed when record is removed
-    * from the buffer. Callback is give two parameters: record and instance of CircularRecordBuffer.
+    * from the buffer. Callback is give two parameters:
+    * <br>`rec` - The record. Type {@link module:qm.Record}.
+    * <br>`circRecBuff` - The circular record buffer instance. Type {@link module:qm.CircularRecordBuffer}.
     * @example
 	* // TODO
     */
@@ -400,7 +416,9 @@ module.exports = exports = function (pathQmBinary) {
         /**
         * Load circular buffer from input stream. Assumes store, onAdd and onDelete
         * were already initialized in constructor.
-        * @param {module:fs.FIn} fin - input stream
+        * @param {module:fs.FIn} fin - input stream.
+        * @example 
+        * // TODO
         */
         this.load = function (fin) {
             var finParam = fin.readJson();
@@ -412,8 +430,10 @@ module.exports = exports = function (pathQmBinary) {
         /**
         * Saves circular buffer to the output stream. Does not save store, onAdd
         * and onDelete callbacks.
-        * @param {module:fs.FOut} fout - output stream
-        * @returns {module:fs.FOut} output stream
+        * @param {module:fs.FOut} fout - Output stream.
+        * @returns {module:fs.FOut} The output stream `fout`.
+        * @example
+        * // TODO
         */
         this.save = function (fout) {
             fout.writeJson({

--- a/src/nodejs/scripts/statistics.js
+++ b/src/nodejs/scripts/statistics.js
@@ -13,11 +13,19 @@ module.exports = exports = function (pathQmBinary) {
     /**
 	 * Calculates the z-score for a point sampled from a Gaussian distribution. The z-score indicates
 	 * how many standard deviations an element is from the meam and can be calculated using
-	 * the following formula: z = (x - mu) / sigma
-	 *
-	 * @param {Number} x - the sampled point
-	 * @param {Number} mu - mean of the distribution
-	 * @param {Number} sigma - variance of the distribution
+	 * the following formula: z = (x - mu) / sigma.
+	 * @param {Number} x - The sampled point.
+	 * @param {Number} mu - Mean of the distribution.
+	 * @param {Number} sigma - Variance of the distribution.
+     * @returns {number} The z-score of the sampled point.
+     * @example
+     * // import modules
+     * var stat = require('qminer').statistics;
+     * // calculate the z-score of the sampled point
+     * var point = 10;
+     * var mu    = 5;
+     * var sigma = 5;
+     * var zScore = stat.getZScore(point, mu, sigma); // returns 1
 	 */
     exports.getZScore = function (x, mu, sigma) {
     	return (x - mu) / sigma;

--- a/src/nodejs/scripts/statistics.js
+++ b/src/nodejs/scripts/statistics.js
@@ -15,7 +15,7 @@ module.exports = exports = function (pathQmBinary) {
     /**
 	 * Calculates the z-score for a point sampled from a Gaussian distribution. The z-score indicates
 	 * how many standard deviations an element is from the meam and can be calculated using
-	 * the following formula: z = (x - mu) / sigma.
+	 * the following formula: `z = (x - mu) / sigma`.
 	 * @param {Number} x - The sampled point.
 	 * @param {Number} mu - Mean of the distribution.
 	 * @param {Number} sigma - Variance of the distribution.

--- a/src/nodejs/scripts/statistics.js
+++ b/src/nodejs/scripts/statistics.js
@@ -10,6 +10,8 @@ module.exports = exports = function (pathQmBinary) {
     var qm = require(pathQmBinary); // This loads only c++ functions of qm
     exports = qm.statistics;
 
+    //!STARTJSDOC
+
     /**
 	 * Calculates the z-score for a point sampled from a Gaussian distribution. The z-score indicates
 	 * how many standard deviations an element is from the meam and can be calculated using
@@ -31,5 +33,7 @@ module.exports = exports = function (pathQmBinary) {
     	return (x - mu) / sigma;
     }
     
+    //!ENDJSDOC
+
     return exports;
 }

--- a/src/nodejs/statistics/stat_nodejs.h
+++ b/src/nodejs/statistics/stat_nodejs.h
@@ -34,6 +34,16 @@ public:
 	* @returns {(number | module:la.Vector)}
 	* <br>1. If input is {@link module:la.Vector}, returns the mean of the vector.
     * <br>2. If input is {@link module:la.Matrix}, returns a vector of where the i-th value is the mean of i-th column.
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var la = qm.la;
+    * var statistics = qm.statistics;
+    * // create a matrix
+    * var mat = new la.Matrix([[1, 2, 1], [-1, 2, -1], [3, 2, 3]]);
+    * // calculate the mean of the matrix columns
+    * // vector contains the elements [1, 2, 1]
+    * var mean = statistics.mean(mat);
 	*/
 	//# exports.mean = function (input) { return input instanceof Object.create(require('qminer').la.Vector) ? 0.0 : Object.create(require('qminer').la.Vector); }
 	JsDeclareFunction(mean);
@@ -43,10 +53,19 @@ public:
 	* @param {(module:la.Vector | module:la.Matrix)} X - The input the method is used on.
 	* @param {number} [flag=0] - If set to to 0, it normalizes X by n-1; If set to 1 to, it normalizes by n.
 	* @param {number} [dim=1] - Computes the standard deviations along the dimension of X specified by parameter `dim`. 
-    * If set to 1, calculates the column standard deviation. If set to 2, calculates therow standard deviation.
+    * If set to 1, calculates the column standard deviation. If set to 2, calculates the row standard deviation.
 	* @returns {(number | module:la.Vector)}
 	* <br>1. If X is {@link module:la.Vector}, returns standard deviation of the vector.
     * <br>2. If X is {@link module:la.Matrix}, returns a vector where the i-th value is the standard deviation of the i-th column(row).
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var la = qm.la;
+    * var statistics = qm.statistics;
+    * // create a matrix
+    * var mat = new la.Matrix([[1, 2, 1], [-1, 2, -1], [3, 2, 3]]);
+    * // calculate the standard deviation of the matrix columns
+    * var mean = statistics.std(mat); 
 	*/
 	//# exports.std = function (X, flag, dim) { return input instanceof Object.create(require('qminer').la.Vector) ? 0.0 : Object.create(require('qminer').la.Vector); }
 	JsDeclareFunction(std);
@@ -61,6 +80,15 @@ public:
 	* <br>zscoreResult.sigma - Vector of standard deviations of mat used to compute the z-scores.
 	* <br>zscoreResult.mu - Vector of mean values of mat used to compute the z-scores.
 	* <br>zscoreResult.Z - A matrix of z-scores that has mean 0 and variance 1.
+    * @example
+    * // import modules
+    * var qm = require('qminer');
+    * var la = qm.la;
+    * var statistics = qm.statistics;
+    * // create a matrix
+    * var mat = new la.Matrix([[1, 2, 1], [-1, 2, -1], [3, 2, 3]]);
+    * // calculate the standard deviation of the matrix columns
+    * var mean = statistics.zscore(mat);
 	*/
 	//# exports.zscore = function (mat, flag, dim) { return {sigma: Object.create(require('qminer').la.Vector), mu: Object.create(require('qminer').la.Vector), Z: Object.create(require('qminer').la.Matrix)}; }
 	JsDeclareFunction(zscore);
@@ -78,7 +106,6 @@ public:
 	* @param {number} df - Degrees of freedom for the sample (if your sample is n big then degrees of freedom is n-1)
 	* @returns {Alpha}
 	*/
-    //# exports.studentCdf = function (val, df, mean, std) { return 0.0; }
 	JsDeclareFunction(studentCdf);
 };
 

--- a/src/nodejs/statistics/stat_nodejs.h
+++ b/src/nodejs/statistics/stat_nodejs.h
@@ -45,7 +45,7 @@ public:
     * // vector contains the elements [1, 2, 1]
     * var mean = statistics.mean(mat);
 	*/
-	//# exports.mean = function (input) { return input instanceof Object.create(require('qminer').la.Vector) ? 0.0 : Object.create(require('qminer').la.Vector); }
+	//# exports.mean = function (input) { return input instanceof Object.create(require('qminer').la.Vector) ? 0.0 : Object.create(require('qminer').la.Vector.prototype); }
 	JsDeclareFunction(mean);
 	
 	/**
@@ -67,7 +67,7 @@ public:
     * // calculate the standard deviation of the matrix columns
     * var mean = statistics.std(mat); 
 	*/
-	//# exports.std = function (X, flag, dim) { return input instanceof Object.create(require('qminer').la.Vector) ? 0.0 : Object.create(require('qminer').la.Vector); }
+	//# exports.std = function (X, flag, dim) { return input instanceof Object.create(require('qminer').la.Vector) ? 0.0 : Object.create(require('qminer').la.Vector.prototype); }
 	JsDeclareFunction(std);
 
 	/**
@@ -76,10 +76,10 @@ public:
 	* @param {number} [flag=0] - If set to 0, it normalizes mat by n-1; if set to 1, it normalizes by n.
 	* @param {number} [dim=1] - Computes the standard deviations along the dimension of mat specified by parameter `dim`. 
     * If set to 1, calculates the column standard deviation. If set to 2, calculates the row standard deviation.
-	* @returns {Object} The object 'zscoreResult' containing:
-	* <br>zscoreResult.sigma - Vector of standard deviations of mat used to compute the z-scores.
-	* <br>zscoreResult.mu - Vector of mean values of mat used to compute the z-scores.
-	* <br>zscoreResult.Z - A matrix of z-scores that has mean 0 and variance 1.
+	* @returns {Object} The object `zscoreResult` containing:
+	* <br>`zscoreResult.sigma` - {@link module:la.Vector} of standard deviations of mat used to compute the z-scores.
+	* <br>`zscoreResult.mu` - {@link module:la.Vector} of mean values of mat used to compute the z-scores.
+	* <br>`zscoreResult.Z` - {@link module:la.Matrix} of z-scores that has mean 0 and variance 1.
     * @example
     * // import modules
     * var qm = require('qminer');
@@ -90,7 +90,7 @@ public:
     * // calculate the standard deviation of the matrix columns
     * var mean = statistics.zscore(mat);
 	*/
-	//# exports.zscore = function (mat, flag, dim) { return {sigma: Object.create(require('qminer').la.Vector), mu: Object.create(require('qminer').la.Vector), Z: Object.create(require('qminer').la.Matrix)}; }
+	//# exports.zscore = function (mat, flag, dim) { return {sigma: Object.create(require('qminer').la.Vector.prototype), mu: Object.create(require('qminer').la.Vector.prototype), Z: Object.create(require('qminer').la.Matrix.prototype)}; }
 	JsDeclareFunction(zscore);
 
 	/**

--- a/src/nodejs/statistics/stat_nodejs.h
+++ b/src/nodejs/statistics/stat_nodejs.h
@@ -15,75 +15,70 @@
 * Statistics module.
 * @module statistics
 * @example
-* // TODO
+* // import the modules
+* var qm = require('qminer');
+* var statistics = require('qminer');
+* // create a vector
+* var vec = new qm.la.Vector([0, 1, 2, -1, -2]);
+* // calculate the mean value of the vector
+* var mean = statistics.mean(vec); // returns 0
 */
 class TNodeJsStat : public node::ObjectWrap {
 public:
 	static void Init(v8::Handle<v8::Object> exports);
 
 public:
-    // 
-	// **Functions and properties:**
-	// 
-	// - `num = la.mean(vec)` - returns mean `num` of vector `vec`.
-	// - `vec = la.mean(mat)` - returns `vec` containing the mean of each column from matrix `mat`. 1 is col mean, 2 is row mean.
-	
 	/**
-	* returns mean of vector.
-	* @param {(module:la.Vector | module:la.Matrix)} input - input can be vector or a matrix.
+	* Calculates the mean value(s).
+	* @param {(module:la.Vector | module:la.Matrix)} input - The input the method is used on.
 	* @returns {(number | module:la.Vector)}
-	* <br>1. Number, if input parameters is {@link module:la.Vector}.
-    * <br>2. {@link module:la.Vector}, if parameter is {@link module:la.Matrix}.
+	* <br>1. If input is {@link module:la.Vector}, returns the mean of the vector.
+    * <br>2. If input is {@link module:la.Matrix}, returns a vector of where the i-th value is the mean of i-th column.
 	*/
 	//# exports.mean = function (input) { return input instanceof Object.create(require('qminer').la.Vector) ? 0.0 : Object.create(require('qminer').la.Vector); }
 	JsDeclareFunction(mean);
 	
-	// - `vec = la.std(mat)` - returns `vec` containing the standard deviation of each column from matrix `mat`.
-	// - `vec = la.std(mat, flag)` - set `flag` to 0 to normalize Y by n-1; set flag to 1 to normalize by n.
-	// - `vec = la.std(mat, flag, dim)` - computes the standard deviations along the dimension of `mat` specified by parameter `dim`. 1 is col std, 2 is row std.
-	
 	/**
-	* returns vector containing the standard deviation of each column from input matrix.
-	* @param {(module:la.Vector | module:la.Matrix)} input - input can be vector or a matrix.
-	* @param {number} [flag=0] - Set `flag` to 0 to normalize Y by n-1; set flag to 1 to normalize by n.
-	* @param {number} [dim=1] - Computes the standard deviations along the dimension of `mat` specified by parameter `dim`. 1 is col std, 2 is row std.
+	* Calculates the standard deviation(s).
+	* @param {(module:la.Vector | module:la.Matrix)} X - The input the method is used on.
+	* @param {number} [flag=0] - If set to to 0, it normalizes X by n-1; If set to 1 to, it normalizes by n.
+	* @param {number} [dim=1] - Computes the standard deviations along the dimension of X specified by parameter `dim`. 
+    * If set to 1, calculates the column standard deviation. If set to 2, calculates therow standard deviation.
 	* @returns {(number | module:la.Vector)}
-	* <br>1. Number, if input parameters is {@link module:la.Vector}.
-    * <br>2. {@link module:la.Vector}, if parameter is {@link module:la.Matrix}.
+	* <br>1. If X is {@link module:la.Vector}, returns standard deviation of the vector.
+    * <br>2. If X is {@link module:la.Matrix}, returns a vector where the i-th value is the standard deviation of the i-th column(row).
 	*/
-	//# exports.std = function (input, flag, dim) { return input instanceof Object.create(require('qminer').la.Vector) ? 0.0 : Object.create(require('qminer').la.Vector); }
+	//# exports.std = function (X, flag, dim) { return input instanceof Object.create(require('qminer').la.Vector) ? 0.0 : Object.create(require('qminer').la.Vector); }
 	JsDeclareFunction(std);
 
-	// # - `zscoreResult = la.zscore(mat)` - returns `zscoreResult` containing the standard deviation `zscoreResult.sigma` of each column from matrix `mat`, mean vector `zscoreResult.mu` and z-score matrix `zscoreResult.Z`.
-	// # - `zscoreResult = la.zscore(mat, flag)` - returns `zscoreResult` containing the standard deviation `zscoreResult.sigma` of each column from matrix `mat`, mean vector `zscoreResult.mu` and z-score matrix `zscoreResult.Z`. Set `flag` to 0 to normalize Y by n-1; set flag to 1 to normalize by n.
-	// # - `zscoreResult = la.zscore(mat, flag, dim)` -  Computes the standard deviations along the dimension of X specified by parameter `dim`. Returns `zscoreResult` containing the standard deviation `zscoreResult.sigma` of each column from matrix `mat`, mean vector `zscoreResult.mu` and z-score matrix `zscoreResult.Z`. Set `flag` to 0 to normalize Y by n-1; set flag to 1 to normalize by n.
-	
 	/**
-	* returns `zscoreResult` containing the standard deviation `zscoreResult.sigma` of each column from matrix `mat`, mean vector `zscoreResult.mu` and z-score matrix `zscoreResult.Z`.
-	* @param {module:la.Matrix} input - Matrix
-	* @param {number} [flag=0] - Set `flag` to 0 to normalize Y by n-1; set flag to 1 to normalize by n.
-	* @param {number} [dim=1] - Computes the standard deviations along the dimension of `mat` specified by parameter `dim`. 1 is col std, 2 is row std.
-	* @returns {zscoreResult}
-	* <br>zscoreResult.sigma - Standard deviation of input used to compute the z-scores.
-	* <br>zscoreResult.mu - Mean of input used to compute the z-scores.
-	* <br>zscoreResult.Z - A vector of z-scores has mean 0 and variance 1.
+	* Returns an object containing the standard deviation of each column of matrix, mean vector and z-score matrix.
+	* @param {module:la.Matrix} mat - The matrix.
+	* @param {number} [flag=0] - If set to 0, it normalizes mat by n-1; if set to 1, it normalizes by n.
+	* @param {number} [dim=1] - Computes the standard deviations along the dimension of mat specified by parameter `dim`. 
+    * If set to 1, calculates the column standard deviation. If set to 2, calculates the row standard deviation.
+	* @returns {Object} The object 'zscoreResult' containing:
+	* <br>zscoreResult.sigma - Vector of standard deviations of mat used to compute the z-scores.
+	* <br>zscoreResult.mu - Vector of mean values of mat used to compute the z-scores.
+	* <br>zscoreResult.Z - A matrix of z-scores that has mean 0 and variance 1.
 	*/
-	//# exports.zscoreResult = function (mat, flag, dim) { return {sigma:'', mu:'', Z:''}; }
+	//# exports.zscore = function (mat, flag, dim) { return {sigma: Object.create(require('qminer').la.Vector), mu: Object.create(require('qminer').la.Vector), Z: Object.create(require('qminer').la.Matrix)}; }
 	JsDeclareFunction(zscore);
 
 	/**
 	* function studentCdf calculates Student's t cumulative distribution function (PDF integral from -inf to t)
 	* function studentCdf returns 'Alpha' as in the p-value of a Student t-test
 	* If you already have a t-value than the studentCdf function has 2 inputs: t-value and degrees of freedom
-	* @param {number} TVal - The t-value value of the sample you want to calculate the p-value for
-	* @param {number} Df - Degrees of freedom for the sample (if your sample is big n than degrees of freedom in n-1)
+	* @param {number} val - The t-value value of the sample you want to calculate the p-value for
+	* @param {number} df - Degrees of freedom for the sample (if your sample is big n than degrees of freedom in n-1)
 	* If you don't have the t-value than studentCdf function has 4 inputs: Value, Mean, Standard deviation and degrees of freedom
-	* @param {number} Val - The average value of the sample you want to calculate the p-value for
-	* @param {number} Mean - The mean value of the sample you want to calculate the p-value for
-	* @param {number} Std - The sample standard deviation of the sample you want to calculate the p-value for
-	* @param {number} Df - Degrees of freedom for the sample (if your sample is n big then degrees of freedom is n-1)
+	* @param {number} val - The average value of the sample you want to calculate the p-value for
+	* @param {number} mean - The mean value of the sample you want to calculate the p-value for
+	* @param {number} std - The sample standard deviation of the sample you want to calculate the p-value for
+	* @param {number} df - Degrees of freedom for the sample (if your sample is n big then degrees of freedom is n-1)
 	* @returns {Alpha}
 	*/
+    //# exports.studentCdf = function (val, df, mean, std) { return 0.0; }
 	JsDeclareFunction(studentCdf);
 };
 

--- a/src/nodejs/statistics/stat_nodejs.h
+++ b/src/nodejs/statistics/stat_nodejs.h
@@ -17,7 +17,7 @@
 * @example
 * // import the modules
 * var qm = require('qminer');
-* var statistics = require('qminer');
+* var statistics = qm.statistics;
 * // create a vector
 * var vec = new qm.la.Vector([0, 1, 2, -1, -2]);
 * // calculate the mean value of the vector

--- a/tools/genNodeDoc.bat
+++ b/tools/genNodeDoc.bat
@@ -3,11 +3,9 @@ node makedoc.js ../src/nodejs/ht/ht_nodejs.h ../src/nodejs/scripts/ht.js ../node
 node makedoc.js ../src/nodejs/fs/fs_nodejs.h ../src/nodejs/scripts/fs.js ../nodedoc/fsdoc.js
 node makedoc.js ../src/nodejs/analytics/analytics.h ../src/nodejs/scripts/analytics.js ../nodedoc/analyticsdoc.js
 
-
 node makedoc.js ../src/nodejs/la/la_nodejs.h "" ../nodedoc/ladoc_module.js 
 node makedoc.js ../src/nodejs/la/la_structures_nodejs.h ../src/nodejs/scripts/la.js ../nodedoc/ladoc_structures.js ../nodedoc/ladoc_module.js 
 node makedoc.js ../src/nodejs/la/la_vector_nodejs.h "" ../nodedoc/ladoc.js ../nodedoc/ladoc_structures.js ../src/nodejs/la/VectorDocData.js ../src/nodejs/la/StrVectorDocData.js ../src/nodejs/la/IntVectorDocData.js ../src/nodejs/la/BoolVectorDocData.js
-
 
 node makedoc.js ../src/nodejs/qm/qm_nodejs.h ../src/nodejs/scripts/qm.js ../nodedoc/qminerdoc.js
 node makedoc.js ../src/nodejs/qm/qm_nodejs_streamaggr.h "" ../nodedoc/qminer_aggrdoc.js

--- a/tools/genNodeDoc.bat
+++ b/tools/genNodeDoc.bat
@@ -12,7 +12,7 @@ node makedoc.js ../src/nodejs/la/la_vector_nodejs.h "" ../nodedoc/ladoc.js ../no
 node makedoc.js ../src/nodejs/qm/qm_nodejs.h ../src/nodejs/scripts/qm.js ../nodedoc/qminerdoc.js
 node makedoc.js ../src/nodejs/qm/qm_nodejs_streamaggr.h "" ../nodedoc/qminer_aggrdoc.js
 
-node makedoc.js ../src/nodejs/statistics/stat_nodejs.h "" ../nodedoc/statdoc.js
+node makedoc.js ../src/nodejs/statistics/stat_nodejs.h ../src/nodejs/scripts/statistics.js ../nodedoc/statdoc.js
 
 node appendIntellisense ../nodedoc/fsdoc.js ../src/nodejs/intellisense/fs_intellisense.js "exports = {}; require.modules.qminer_fs = exports;"
 node appendIntellisense ../nodedoc/ladoc.js ../src/nodejs/intellisense/la_intellisense.js "exports = {}; require.modules.qminer_la = exports;"

--- a/tools/genNodeDoc.sh
+++ b/tools/genNodeDoc.sh
@@ -10,7 +10,7 @@ node makedoc.js ../src/nodejs/la/la_vector_nodejs.h "" ../nodedoc/ladoc.js ../no
 node makedoc.js ../src/nodejs/qm/qm_nodejs.h ../src/nodejs/scripts/qm.js ../nodedoc/qminerdoc.js
 node makedoc.js ../src/nodejs/qm/qm_nodejs_streamaggr.h "" ../nodedoc/qminer_aggrdoc.js
 
-node makedoc.js ../src/nodejs/statistics/stat_nodejs.h "" ../nodedoc/statdoc.js
+node makedoc.js ../src/nodejs/statistics/stat_nodejs.h ../src/nodejs/scripts/statistics.js ../nodedoc/statdoc.js
 
 node appendIntellisense ../nodedoc/fsdoc.js ../src/nodejs/intellisense/fs_intellisense.js "exports = {}; require.modules.qminer_fs = exports;"
 node appendIntellisense ../nodedoc/ladoc.js ../src/nodejs/intellisense/la_intellisense.js "exports = {}; require.modules.qminer_la = exports;"


### PR DESCRIPTION
### Documentation update. 
Added missing types, descriptions, links and methods. The parameters now have a more detailed descriptions (if it was possible). Tried to reduce the number of clicks to get to a specific information, e.g. if it was possible and reasonable to put the possible options in the descriptions, it was done.  

### Tokenizer now uses the default value `'unicode'` at construction.
Tokenizer now uses a default constructor value. An example to show the change:
```Javascript
var analytics = require('qminer').analytics;
// default constructor uses type: "unicode"
var defaultTokenizer = new analytics.Tokenizer();
// if given an empty object, constructor uses type: "unicode"
var emptyTokenizer = new analytics.Tokenizer({});
// if given an object with the "type" key, uses that type
var customTokenizer = new analytics.Tokenizer({ type: 'html' });
```