### PR TITLE
Documentation Header and Tokenizer Fix

### DIFF
--- a/src/nodejs/analytics/analytics.cpp
+++ b/src/nodejs/analytics/analytics.cpp
@@ -1915,7 +1915,7 @@ TNodeJsTokenizer* TNodeJsTokenizer::NewFromArgs(const v8::FunctionCallbackInfo<v
     } else if (TNodeJsUtil::IsArgObj(Args, 0)) {
         PJsonVal ParamVal = TNodeJsUtil::GetArgJson(Args, 0);
         const TStr TypeNm = ParamVal->GetObjStr("type", "unicode");
-        ParamVal->AddToObj("type", TypeNm.CStr());
+        ParamVal->AddToObj("type", TypeNm);
         // create tokenizer
         PTokenizer Tokenizer = TTokenizer::New(TypeNm, ParamVal);
         return new TNodeJsTokenizer(Tokenizer);

--- a/tools/changeDocHeader.js
+++ b/tools/changeDocHeader.js
@@ -22,7 +22,7 @@ for (var i = 0; i < htmlFiles.length; i++) {
     // read the file
     var fin = fs.readFileSync(hfile + htmlFiles[i], 'ascii');
     var pattern = /<a href=\"index.html\" class=\"jsdoc-navbar-package-name\">Home<\/a>/g;
-    var changed = "<a href=\"index.html\" class=\"jsdoc-navbar-package-name\">QMiner JavaScript API " + qm.version + "<\/a>";
+    var changed = "<a href=\"index.html\" class=\"jsdoc-navbar-package-name\">QMiner JavaScript API v" + qm.version + "<\/a>";
     fin = fin.replace(pattern, changed);
 
     // create a write stream

--- a/tools/changeDocHeader.js
+++ b/tools/changeDocHeader.js
@@ -1,0 +1,31 @@
+// replaces the doc header with QMiner JavaScript API v*
+
+var hfile = process.argv[2]; // the path to the files (e.g. ./qminer/nodedoc/)
+
+var fs = require('fs');
+var qm = require('qminer'); // needed only for version
+
+// get the .html files from the file array
+var fileNames;
+if (hfile !== 0) {
+    fileNames = fs.readdirSync(hfile);
+}
+var htmlFiles = [];
+for (var i = 0; i < fileNames.length; i++) {
+    if (fileNames[i].indexOf(".js") === -1 && fileNames[i].indexOf(".html") !== -1) {
+        htmlFiles.push(fileNames[i]);
+    }
+}
+
+var fout = null;
+for (var i = 0; i < htmlFiles.length; i++) {
+    // read the file
+    var fin = fs.readFileSync(hfile + htmlFiles[i], 'ascii');
+    var pattern = /<a href=\"index.html\" class=\"jsdoc-navbar-package-name\">Home<\/a>/g;
+    var changed = "<a href=\"index.html\" class=\"jsdoc-navbar-package-name\">QMiner JavaScript API " + qm.version + "<\/a>";
+    fin = fin.replace(pattern, changed);
+
+    // create a write stream
+    fout = fs.createWriteStream(hfile + htmlFiles[i]);
+    fout.write(fin);
+}

--- a/tools/genNodeDoc.bat
+++ b/tools/genNodeDoc.bat
@@ -3,8 +3,8 @@ node makedoc.js ../src/nodejs/ht/ht_nodejs.h ../src/nodejs/scripts/ht.js ../node
 node makedoc.js ../src/nodejs/fs/fs_nodejs.h ../src/nodejs/scripts/fs.js ../nodedoc/fsdoc.js
 node makedoc.js ../src/nodejs/analytics/analytics.h ../src/nodejs/scripts/analytics.js ../nodedoc/analyticsdoc.js
 
-node makedoc.js ../src/nodejs/la/la_nodejs.h "" ../nodedoc/ladoc_module.js 
-node makedoc.js ../src/nodejs/la/la_structures_nodejs.h ../src/nodejs/scripts/la.js ../nodedoc/ladoc_structures.js ../nodedoc/ladoc_module.js 
+node makedoc.js ../src/nodejs/la/la_nodejs.h "" ../nodedoc/ladoc_module.js
+node makedoc.js ../src/nodejs/la/la_structures_nodejs.h ../src/nodejs/scripts/la.js ../nodedoc/ladoc_structures.js ../nodedoc/ladoc_module.js
 node makedoc.js ../src/nodejs/la/la_vector_nodejs.h "" ../nodedoc/ladoc.js ../nodedoc/ladoc_structures.js ../src/nodejs/la/VectorDocData.js ../src/nodejs/la/StrVectorDocData.js ../src/nodejs/la/IntVectorDocData.js ../src/nodejs/la/BoolVectorDocData.js
 
 node makedoc.js ../src/nodejs/qm/qm_nodejs.h ../src/nodejs/scripts/qm.js ../nodedoc/qminerdoc.js
@@ -19,7 +19,7 @@ node appendIntellisense ../nodedoc/statdoc.js ../src/nodejs/intellisense/statist
 node appendIntellisense ../nodedoc/analyticsdoc.js ../src/nodejs/intellisense/analytics_intellisense.js "exports = {}; require.modules.qminer_analytics = exports;"
 node appendIntellisense ../nodedoc/qminerdoc.js ../src/nodejs/intellisense/qminer_intellisense.js "// this file mimicks the qminer module index.js file\nexports = {}; require.modules.qminer = exports;\nexports.la = require('qminer_la');\nexports.fs = require('qminer_fs');\nexports.analytics = require('qminer_analytics');\nexports.ht= require('qminer_ht');\nexports.statistics= require('qminer_stat');"
 
-call jsdoc --template ../node_modules/jsdoc-baseline ../nodedoc/htdoc.js ../nodedoc/fsdoc.js ../nodedoc/analyticsdoc.js  ../nodedoc/ladoc.js ../nodedoc/qminerdoc.js ../nodedoc/statdoc.js ../nodedoc/qminer_aggrdoc.js -d ../nodedoc 
+call jsdoc --template ../node_modules/jsdoc-baseline ../nodedoc/htdoc.js ../nodedoc/fsdoc.js ../nodedoc/analyticsdoc.js  ../nodedoc/ladoc.js ../nodedoc/qminerdoc.js ../nodedoc/statdoc.js ../nodedoc/qminer_aggrdoc.js -d ../nodedoc
 
 node factorydoc.js ../nodedoc/module-qm.html
 node factorydoc.js ../nodedoc/module-qm.Iterator.html
@@ -30,5 +30,7 @@ node factorydoc.js ../nodedoc/module-qm.Store.html
 node removeTimestamp.js ../nodedoc
 
 xcopy "pictures" "..\nodedoc\pictures\" /S/E/Y
+
+node changeDocHeader.js ../nodedoc/
 
 node createExampleTests.js ../nodedoc/ ../test/nodejs/

--- a/tools/genNodeDoc.sh
+++ b/tools/genNodeDoc.sh
@@ -3,8 +3,8 @@ node makedoc.js ../src/nodejs/ht/ht_nodejs.h ../src/nodejs/scripts/ht.js ../node
 node makedoc.js ../src/nodejs/fs/fs_nodejs.h ../src/nodejs/scripts/fs.js ../nodedoc/fsdoc.js
 node makedoc.js ../src/nodejs/analytics/analytics.h ../src/nodejs/scripts/analytics.js ../nodedoc/analyticsdoc.js
 
-node makedoc.js ../src/nodejs/la/la_nodejs.h "" ../nodedoc/ladoc_module.js 
-node makedoc.js ../src/nodejs/la/la_structures_nodejs.h ../src/nodejs/scripts/la.js ../nodedoc/ladoc_structures.js ../nodedoc/ladoc_module.js 
+node makedoc.js ../src/nodejs/la/la_nodejs.h "" ../nodedoc/ladoc_module.js
+node makedoc.js ../src/nodejs/la/la_structures_nodejs.h ../src/nodejs/scripts/la.js ../nodedoc/ladoc_structures.js ../nodedoc/ladoc_module.js
 node makedoc.js ../src/nodejs/la/la_vector_nodejs.h "" ../nodedoc/ladoc.js ../nodedoc/ladoc_structures.js ../src/nodejs/la/VectorDocData.js ../src/nodejs/la/StrVectorDocData.js ../src/nodejs/la/IntVectorDocData.js ../src/nodejs/la/BoolVectorDocData.js
 
 node makedoc.js ../src/nodejs/qm/qm_nodejs.h ../src/nodejs/scripts/qm.js ../nodedoc/qminerdoc.js
@@ -30,5 +30,7 @@ node factorydoc.js ../nodedoc/module-qm.Store.html
 node removeTimestamp.js ../nodedoc
 
 cp -r pictures/ ../nodedoc/pictures/
+
+node changeDocHeader.js ../nodedoc/
 
 node createExampleTests.js ../nodedoc/ ../test/nodejs/


### PR DESCRIPTION
### Documentation Header
Documentation now has a custom `QMiner JavaScript API v<% require('qminer').version %>` header, which marks for which version the documentation is valid.

### Tokenizer 
Made the code consistent in the constructor. Basically code cleanup.