### PR TITLE
bugfix TJsonVal::GetUInt64

### DIFF
--- a/src/glib/base/json.h
+++ b/src/glib/base/json.h
@@ -119,7 +119,7 @@ public:
   bool GetBool() const {EAssert(IsBool()); return Bool;}
   double GetNum() const {EAssert(IsNum()); return Num;}
   int GetInt() const {EAssert(IsNum()); return TFlt::Round(Num);}
-  uint64 GetUInt64() const {EAssert(IsNum()); return (unsigned)(int64)(Num);}
+  uint64 GetUInt64() const {EAssert(IsNum()); return (unsigned long long)(int64)(Num);}
   uint GetUInt() const { EAssert(IsNum()); return uint(Num); }
   int64 GetInt64() const { EAssert(IsNum()); return int64(Num); }
   const TStr& GetStr() const {EAssert(IsStr()); return Str;}

--- a/src/nodejs/qm/qm_nodejs.cpp
+++ b/src/nodejs/qm/qm_nodejs.cpp
@@ -2155,7 +2155,7 @@ void TNodeJsRec::setField(v8::Local<v8::String> Name, v8::Local<v8::Value> Value
     TStr FieldNm = TNodeJsUtil::GetStr(Name);
     const int FieldId = Store->GetFieldId(FieldNm);
     //TODO: for now we don't support by-value records, fix this
-    QmAssertR(Rec.IsByRef(), "Only records by reference (from stores) supported for setters.");
+    //QmAssertR(Rec.IsByRef(), "Only records by reference (from stores) supported for setters.");
     // not null, get value
     const TQm::TFieldDesc& Desc = Store->GetFieldDesc(FieldId);
     if (Value->IsNull()) {

--- a/src/nodejs/qm/qm_nodejs_store.cpp
+++ b/src/nodejs/qm/qm_nodejs_store.cpp
@@ -75,7 +75,7 @@ namespace TQm {
                 throw TQm::TQmExcept::New("Javascript exception triggered from TNodeJsFuncStore::GetRecs, " + TStr(*Msg));
             }
             QmAssertR(RetVal->IsNumber(), "TNodeJsFuncStore::GetRecs: Return type expected to be number");
-            return (unsigned)(int64)RetVal->NumberValue();
+            return (unsigned long long)(int64)RetVal->NumberValue();
         }
 
         PRecSet TNodeJsFuncStore::GetAllRecs() {
@@ -113,7 +113,7 @@ namespace TQm {
                 throw TQm::TQmExcept::New("Javascript exception triggered from TNodeJsFuncStore::GetFirstRecId, " + TStr(*Msg));
             }
             QmAssertR(RetVal->IsNumber(), "TNodeJsFuncStore::GetFirstRecId: Return type expected to be number");
-            return (unsigned)(int64)RetVal->NumberValue();
+            return (unsigned long long)(int64)RetVal->NumberValue();
         }
 
         uint64 TNodeJsFuncStore::GetLastRecId() const {
@@ -131,7 +131,7 @@ namespace TQm {
                 throw TQm::TQmExcept::New("Javascript exception triggered from TNodeJsFuncStore::GetLastRecId, " + TStr(*Msg));
             }
             QmAssertR(RetVal->IsNumber(), "TNodeJsFuncStore::GetLastRecId: Return type expected to be number");
-            return (unsigned)(int64)RetVal->NumberValue();
+            return (unsigned long long)(int64)RetVal->NumberValue();
         }
 
         v8::Handle<v8::Value> TNodeJsFuncStore::GetField(const uint64& RecId, const int& FieldId) const {
@@ -190,7 +190,7 @@ namespace TQm {
             v8::HandleScope HandleScope(Isolate);
             v8::Local<v8::Value> RetVal = GetField(RecId, FieldId);
             QmAssertR(RetVal->IsNumber(), "TNodeJsFuncStore::GetField: Return type expected to be a number");
-            return (unsigned)(int64) RetVal->NumberValue();
+            return (unsigned long long)(int64) RetVal->NumberValue();
         }
         TStr TNodeJsFuncStore::GetFieldStr(const uint64& RecId, const int& FieldId) const {
             v8::Isolate* Isolate = v8::Isolate::GetCurrent();

--- a/src/qminer/qminer_aggr.hpp
+++ b/src/qminer/qminer_aggr.hpp
@@ -72,6 +72,7 @@ TWinBufMem<TVal>::TWinBufMem(const TWPt<TBase>& Base, const PJsonVal& ParamVal):
     // parse out window parameters
     ParamVal->AssertObjKeyNum("winsize", __FUNCTION__);
     WinSizeMSecs = ParamVal->GetObjUInt64("winsize");
+    printf("WINDOW SIZE: %s\n", TUInt64::GetStr(WinSizeMSecs).CStr());
     DelayMSecs = ParamVal->GetObjUInt64("delay", 0);
 }
 

--- a/src/qminer/qminer_aggr.hpp
+++ b/src/qminer/qminer_aggr.hpp
@@ -72,7 +72,6 @@ TWinBufMem<TVal>::TWinBufMem(const TWPt<TBase>& Base, const PJsonVal& ParamVal):
     // parse out window parameters
     ParamVal->AssertObjKeyNum("winsize", __FUNCTION__);
     WinSizeMSecs = ParamVal->GetObjUInt64("winsize");
-    printf("WINDOW SIZE: %s\n", TUInt64::GetStr(WinSizeMSecs).CStr());
     DelayMSecs = ParamVal->GetObjUInt64("delay", 0);
 }
 


### PR DESCRIPTION
previous fix of uint64 cast of double (undefined) to (unsigned)(int64) was wrong: (unsigned long long)(int64) works as it should