### PR TITLE
Bug fix.

### DIFF
--- a/src/glib/mine/signalproc.cpp
+++ b/src/glib/mine/signalproc.cpp
@@ -1458,7 +1458,6 @@ void TOnlineHistogram::Print() const {
 }
 
 PJsonVal TOnlineHistogram::SaveJson() const {
-    EAssertR(IsInit(), "TOnlineHistogram::SaveJson: online histogram is not initialized yet!");
     PJsonVal Result = TJsonVal::NewObj();
     PJsonVal BoundsArr = TJsonVal::NewArr();
     PJsonVal CountsArr = TJsonVal::NewArr();
@@ -1467,9 +1466,10 @@ PJsonVal TOnlineHistogram::SaveJson() const {
         CountsArr->AddToArr(CountLeftInf);
     }
     for (int ElN = 0; ElN < Counts.Len(); ElN++) {
-        BoundsArr->AddToArr(Bounds[ElN]);
         CountsArr->AddToArr(Counts[ElN]);
-    }if (Bounds.Len() > 0) {
+        if (Bounds.Len() > ElN) { BoundsArr->AddToArr(Bounds[ElN]); }
+    }
+    if (Bounds.Len() > 0) {
         BoundsArr->AddToArr(Bounds.Last());
     }
     if (AddPosInf) {


### PR DESCRIPTION
When calling saveJson() on uninitalized TOnlineHistrogram, an exception was created. Now it serializes the current state.