### PR TITLE
stream aggregates memory footprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ nbproject
 # Vim
 .vimrc
 .ycm_extra_conf.py
+/tags
+/cscope.out
+/cscope.po.out
+/cscope.in.out
 
 # build results
 build

--- a/src/glib/base/bd.h
+++ b/src/glib/base/bd.h
@@ -468,6 +468,7 @@ public:
   void UnRef(){Assert(Refs>0); Refs--;}
   bool NoRef() const {return Refs==0;}
   int GetRefs() const {return Refs;}
+  uint64 GetMemUsed() const { return sizeof(TCRef); }
 };
 
 /////////////////////////////////////////////////
@@ -654,6 +655,22 @@ public:
     RQ -= 0x7fffffffU;
     return (RQ == 0x7fffffffU) ? 0 : (int) RQ; }
 };
+
+/////////////////////////////////////////////////
+// Functions which returns the part of the memory footprint of
+// an object which ignored by the sizeof operator
+template <class TClass>
+uint64 GetExtraMemberSize(const TClass& Inst) {
+    return Inst.GetMemUsed() - sizeof(TClass);
+}
+
+/////////////////////////////////////////////////
+// Functions which returns the part of the memory footprint of
+// an object which ignored by the sizeof operator
+template <class TClass>
+uint64 GetDeepExtraMemberSize(const TClass& Inst) {
+    return Inst.GetMemUsedDeep() - sizeof(TClass);
+}
 
 // Depending on the platform and compiler settings choose the faster implementation (of the same hash function)
 #if (defined(GLib_64Bit)) && ! (defined(DEBUG) || defined(_DEBUG))

--- a/src/glib/base/bd.h
+++ b/src/glib/base/bd.h
@@ -658,69 +658,63 @@ public:
 
 #ifdef GLib_CPP11
 /// cpp type traits, helper to check if type is a container
-template <typename TClass>
-struct IsContainer : std::false_type{};
-#endif
+template <typename TClass> struct IsContainer : std::false_type{};
 
+#endif
 
 namespace TMemUtils {
 #ifdef GLib_CPP11
 
-/* #define ENABLE_MEMBER_IF(T, Cond)\ */
-/*     template <typename _T = T, typename std::enable_if<Cond<_T>{},bool>::type = true> */
-/* #define ENABLE_MEMBER_IF(T, Cond1, CondRest...) \ */
-/*     ENABLE_MEMBER_IF(T, Cond1<_T>{} && CondRest) */
+  /// fundamental types (int, float, ...)
+  template <typename T, typename std::enable_if<std::is_fundamental<T>::value,bool>::type = true>
+  uint64 GetMemUsed(const T& Val) {
+    return sizeof(T);
+  }
 
-    /// fundamental types (int, float, ...)
-    template <typename T, typename std::enable_if<std::is_fundamental<T>::value,bool>::type = true>
-    uint64 GetMemUsed(const T& Val) {
-        return sizeof(T);
-    }
+  /// pointers
+  template <typename T, typename std::enable_if<std::is_pointer<T>::value,bool>::type = true>
+  uint64 GetMemUsed(const T Val) {
+    if (Val == nullptr) { return sizeof(T); }
+    return sizeof(T) + Val->GetMemUsed();
+  }
 
-    /// pointers
-    template <typename T, typename std::enable_if<std::is_pointer<T>::value,bool>::type = true>
-    uint64 GetMemUsed(const T Val) {
-        if (Val == nullptr) { return sizeof(T); }
-        return sizeof(T) + Val->GetMemUsed();
-    }
+  /// get memory usabe for "normal" glib classes
+  template <typename T, typename std::enable_if<std::is_class<T>::value && !IsContainer<T>::value,bool>::type = true>
+  uint64 GetMemUsed(const T& Val) {
+    return Val.GetMemUsed();
+  }
 
-    /// get memory usabe for "normal" glib classes
-    template <typename T, typename std::enable_if<std::is_class<T>::value && !IsContainer<T>::value,bool>::type = true>
-    uint64 GetMemUsed(const T& Val) {
-        return Val.GetMemUsed();
-    }
+  /// glib structures
+  template <typename T, typename std::enable_if<IsContainer<T>::value,bool>::type = true>
+  uint64 GetMemUsed(const T& Val) {
+    return Val.GetMemUsed(true);   // deep
+  }
 
-    /// glib structures
-    template <typename T, typename std::enable_if<IsContainer<T>::value,bool>::type = true>
-    uint64 GetMemUsed(const T& Val) {
-        return Val.GetMemUsed(true);   // deep
-    }
-
-    /// get memory usabe for non-classes
-    template <typename T, typename std::enable_if<
-        !std::is_class<T>::value &&
-        !std::is_pointer<T>::value &&
-        !std::is_fundamental<T>::value &&
-        !IsContainer<T>::value
-    , bool>::type = true>
-    uint64 GetMemUsed(const T& Val) {
-        return sizeof(T);
-    }
+  /// get memory usabe for non-classes
+  template <typename T, typename std::enable_if<
+    !std::is_class<T>::value &&
+    !std::is_pointer<T>::value &&
+    !std::is_fundamental<T>::value &&
+    !IsContainer<T>::value
+  , bool>::type = true>
+  uint64 GetMemUsed(const T& Val) {
+    return sizeof(T);
+  }
 
 #else
-    template <class T>
-    uint64 GetMemUsed(const T& Val) {
-        return Val.GetMemUsed();
-    }
+  template <class T>
+  uint64 GetMemUsed(const T& Val) {
+    return Val.GetMemUsed();
+  }
 #endif
 
-    /////////////////////////////////////////////////
-    // Functions which returns the part of the memory footprint of
-    // an object which ignored by the sizeof operator
-    template <class TClass>
-    uint64 GetExtraMemberSize(const TClass& Inst) {
-        return TMemUtils::GetMemUsed(Inst) - sizeof(TClass);
-    }
+  /////////////////////////////////////////////////
+  // Functions which returns the part of the memory footprint of
+  // an object which ignored by the sizeof operator
+  template <class TClass>
+  uint64 GetExtraMemberSize(const TClass& Inst) {
+    return TMemUtils::GetMemUsed(Inst) - sizeof(TClass);
+  }
 }
 
 /* ///////////////////////////////////////////////// */

--- a/src/glib/base/cache.h
+++ b/src/glib/base/cache.h
@@ -507,7 +507,7 @@ private:
         // need to report size, for keeping up used-up space in cache
         int64 GetMemUsed() const {
             int64 MemUsed = (int64)sizeof(TVec<TVal>);
-            return MemUsed + ValV.GetMemUsed(false);
+            return MemUsed + ValV.GetMemUsed(true);
             /* for (int ValN = 0; ValN < ValV.Len(); ValN++) { */
             /*     MemUsed += (int64)ValV[ValN].GetMemUsed(); } */
             /* return MemUsed; */

--- a/src/glib/base/cache.h
+++ b/src/glib/base/cache.h
@@ -507,9 +507,10 @@ private:
         // need to report size, for keeping up used-up space in cache
         int64 GetMemUsed() const {
             int64 MemUsed = (int64)sizeof(TVec<TVal>);
-            for (int ValN = 0; ValN < ValV.Len(); ValN++) {
-                MemUsed += (int64)ValV[ValN].GetMemUsed(); }
-            return MemUsed;
+            return MemUsed + ValV.GetMemUsed(false);
+            /* for (int ValN = 0; ValN < ValV.Len(); ValN++) { */
+            /*     MemUsed += (int64)ValV[ValN].GetMemUsed(); } */
+            /* return MemUsed; */
         }
         // store this data - on delete-from cache or on demand
         bool OnDelFromCache(const TInt& BlockId, void* WndBlockCache) {

--- a/src/glib/base/ds.h
+++ b/src/glib/base/ds.h
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2015, Jozef Stefan Institute, Quintelligence d.o.o. and contributors
  * All rights reserved.
- * 
+ *
  * This source code is licensed under the FreeBSD license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -56,13 +56,17 @@ public:
   TPair& operator=(const TPair& Pair){
     if (this!=&Pair){Val1=Pair.Val1; Val2=Pair.Val2;} return *this;}
   TPair& operator=(TPair&& Pair) {
-	  if (this != &Pair) {std::swap(Val1, Pair.Val1); std::swap(Val2, Pair.Val2);} return *this;}
+      if (this != &Pair) {std::swap(Val1, Pair.Val1); std::swap(Val2, Pair.Val2);} return *this;}
   bool operator==(const TPair& Pair) const {
     return (Val1==Pair.Val1)&&(Val2==Pair.Val2);}
   bool operator<(const TPair& Pair) const {
     return (Val1<Pair.Val1)||((Val1==Pair.Val1)&&(Val2<Pair.Val2));}
 
+#ifdef GLib_CPP11
+  uint64 GetMemUsed() const { return TMemUtils::GetMemUsed<TVal1>(Val1) + TMemUtils::GetMemUsed<TVal2>(Val2); }
+#else
   uint64 GetMemUsed() const {return Val1.GetMemUsed()+Val2.GetMemUsed();}
+#endif
 
   int GetPrimHashCd() const {return TPairHashImpl::GetHashCd(Val1.GetPrimHashCd(), Val2.GetPrimHashCd()); }
   int GetSecHashCd() const {return TPairHashImpl::GetHashCd(Val2.GetSecHashCd(), Val1.GetSecHashCd()); }
@@ -154,7 +158,7 @@ public:
   TTriple(const TTriple& Triple):
     Val1(Triple.Val1), Val2(Triple.Val2), Val3(Triple.Val3){}
   TTriple(TTriple&& Triple):
-  	Val1(std::move(Triple.Val1)), Val2(std::move(Triple.Val2)), Val3(std::move(Triple.Val3)) {}
+    Val1(std::move(Triple.Val1)), Val2(std::move(Triple.Val2)), Val3(std::move(Triple.Val3)) {}
   TTriple(const TVal1& _Val1, const TVal2& _Val2, const TVal3& _Val3):
     Val1(_Val1), Val2(_Val2), Val3(_Val3){}
   explicit TTriple(TSIn& SIn): Val1(SIn), Val2(SIn), Val3(SIn){}
@@ -168,12 +172,12 @@ public:
     if (this!=&Triple){Val1=Triple.Val1; Val2=Triple.Val2; Val3=Triple.Val3;}
     return *this;}
   TTriple& operator=(TTriple&& Triple) {
-	  if (this != &Triple) {
-		std::swap(Val1, Triple.Val1);
-		std::swap(Val2, Triple.Val2);
-		std::swap(Val3, Triple.Val3);
-	  }
-	  return *this;
+      if (this != &Triple) {
+        std::swap(Val1, Triple.Val1);
+        std::swap(Val2, Triple.Val2);
+        std::swap(Val3, Triple.Val3);
+      }
+      return *this;
   }
   bool operator==(const TTriple& Triple) const {
     return (Val1==Triple.Val1)&&(Val2==Triple.Val2)&&(Val3==Triple.Val3);}
@@ -216,7 +220,7 @@ typedef TTriple<TStr, TInt, TInt> TStrIntIntTr;
 typedef TTriple<TStr, TFlt, TFlt> TStrFltFltTr;
 typedef TTriple<TStr, TStr, TInt> TStrStrIntTr;
 typedef TTriple<TStr, TInt, TStrV> TStrIntStrVTr;
-    
+
 /// Compares the triple by the second value.
 template <class TVal1, class TVal2, class TVal3>
 class TCmpTripleByVal2 {
@@ -228,7 +232,7 @@ public:
     if (IsAsc) { return T1.Val2 < T2.Val2; } else { return T2.Val2 < T1.Val2; }
   }
 };
-    
+
 /// Compares the triple by the third value.
 template <class TVal1, class TVal2, class TVal3>
 class TCmpTripleByVal3 {
@@ -328,7 +332,7 @@ public:
     for (int i = 1; i < NVals; i++) { hc = TPairHashImpl::GetHashCd(hc, ValV[i].GetSecHashCd()); }
     if (NVals > 0) { hc = TPairHashImpl::GetHashCd(hc, ValV[0].GetSecHashCd()); }
     return hc; }
-  
+
   TStr GetStr() const { TChA ValsStr;
     for (int i=0; i<Len(); i++) { ValsStr+=" "+ValV[i].GetStr(); }
     return TStr::Fmt("Tuple(%d):", Len())+ValsStr; }
@@ -440,13 +444,6 @@ class TVec{
 public:
   typedef TVal* TIter;  //!< Random access iterator to \c TVal.
 protected:
-#ifdef GLib_CPP11
-  /// cpp type traits, helper to check if type is TVec
-  template <typename T>
-  struct IsTVec : std::false_type{};
-  template <class TVal1, class TSizeTy1>
-  struct IsTVec<TVec<TVal1, TSizeTy1>> : std::true_type{};
-#endif
 
   TSizeTy MxVals; //!< Vector capacity. Capacity is the size of allocated storage. If <tt>MxVals==-1</tt>, then \c ValT is not owned by the vector, and it won't free it at destruction.
   TSizeTy Vals;   //!< Vector length. Length is the number of elements stored in the vector.
@@ -482,7 +479,7 @@ public:
   void Load(TSIn& SIn);
   // optimized deserialization from stream, uses memcpy
   void LoadMemCpy(TMIn& SIn);
-  void Save(TSOut& SOut) const;  
+  void Save(TSOut& SOut) const;
   // optimized serialization to stream, uses memcpy
   void SaveMemCpy(TMOut& SOut) const;
 
@@ -511,22 +508,16 @@ public:
   TVal& operator[](const TSizeTy& ValN){
     AssertR((0<=ValN)&&(ValN<Vals), GetXOutOfBoundsErrMsg(ValN));
     return ValT[ValN];}
-  /// Returns the memory footprint (the number of bytes) of the vector.
-  uint64 GetMemUsed() const {
-	  return TSizeTy(2 * sizeof(TSizeTy) + sizeof(TVal*) + sizeof(TVal)*(MxVals != -1 ? MxVals : 0));
-  }
-  /// Returns the memory footprint (the number of bytes) of the vector, including all its elements.
-  uint64 GetMemUsedDeep() const;
-  /// Returns the memory size (the number of bytes) of a binary representation.
-  TSizeTy GetMemSize(bool flat = true) const {
-	  return TSizeTy(2 * sizeof(TVal) + sizeof(TVal)*Vals);
-  }
-  
+
+  /// Get the memory usage of this vector. DeepP indicates whether the usage of 
+  /// each individual element should be included in the calculation
+  uint64 GetMemUsed(const bool& DeepP = false) const { return GetVecMemUsed(DeepP); }
+
   /// Returns primary hash code of the vector. Used by \c THash.
   int GetPrimHashCd() const;
   /// Returns secondary hash code of the vector. Used by \c THash.
   int GetSecHashCd() const;
-  
+
   /// Constructs a vector (an array) of \c _Vals elements.
   void Gen(const TSizeTy& _Vals){ IAssert(0<=_Vals);
     if (ValT!=NULL && MxVals!=-1){delete[] ValT;} MxVals=Vals=_Vals;
@@ -555,7 +546,7 @@ public:
   void MoveFrom(TVec<TVal, TSizeTy>& Vec);
   /// Swaps the contents of the vector with \c Vec.
   void Swap(TVec<TVal, TSizeTy>& Vec);
-  
+
   /// Tests whether the vector is empty. ##TVec::Empty
   bool Empty() const {return Vals==0;}
   /// Returns the number of elements in the vector. ##TVec::Len
@@ -572,7 +563,7 @@ public:
   const TVal& LastLast() const { AssertR(1<Vals, GetXOutOfBoundsErrMsg(Vals-2)); return ValT[Vals-2];}
   /// Returns a reference to the one before last element of the vector.
   TVal& LastLast(){ AssertR(1<Vals, GetXOutOfBoundsErrMsg(Vals-2)); return ValT[Vals-2];}
-  
+
   /// Returns an iterator pointing to the first element in the vector.
   TIter BegI() const {return ValT;}
   /// Returns an iterator pointing to the first element in the vector (used by C++11)
@@ -583,7 +574,7 @@ public:
   TIter end() const {return ValT+Vals;}
   /// Returns an iterator an element at position \c ValN.
   TIter GetI(const TSizeTy& ValN) const {return ValT+ValN;}
-  
+
   /// Adds a new element at the end of the vector, after its current last element. ##TVec::Add
   TSizeTy Add(){ AssertR(MxVals!=-1, "This vector was obtained from TVecPool. Such a vector cannot change its size!");
     if (Vals==MxVals){Resize();} return Vals++;}
@@ -646,17 +637,17 @@ public:
     ValT[ToValN] = std::move(ValT[FromValN]); } // C++11
     //ValT[ValN2] = ValT[ValN1]; } // C++98
   /// Swaps elements at positions \c ValN1 and \c ValN2.
-  void Swap(const TSizeTy& ValN1, const TSizeTy& ValN2){ 
-    Assert(0 <= ValN1 && ValN1 < Len() && 0 <= ValN2 && ValN2 < Len());	std::swap(ValT[ValN1], ValT[ValN2]); } // C++11
+  void Swap(const TSizeTy& ValN1, const TSizeTy& ValN2){
+    Assert(0 <= ValN1 && ValN1 < Len() && 0 <= ValN2 && ValN2 < Len()); std::swap(ValT[ValN1], ValT[ValN2]); } // C++11
     // const TVal Val=ValT[ValN1]; ValT[ValN1]=ValT[ValN2]; ValT[ValN2]=Val;} // C++98
   /// Swaps the elements that iterators \c LVal and \c RVal point to.
   static void SwapI(TIter LVal, TIter RVal){ const TVal Val=*LVal; *LVal=*RVal; *RVal=Val;}
-  
+
   /// Generates next permutation of the elements in the vector. ##TVec::NextPerm
   bool NextPerm();
   /// Generates previous permutation of the elements in the vector. ##TVec::PrevPerm
   bool PrevPerm();
-  
+
   // Sorting functions
   /// Picks three random elements at positions <tt>LValN...RValN</tt> and returns the middle one.
   TSizeTy GetPivotValN(const TSizeTy& LValN, const TSizeTy& RValN, TRnd& Rnd) const;
@@ -685,7 +676,7 @@ public:
   void Merge();
 
   TStr GetStr() const { return TStr("<Vector>");}
-  
+
   /// Picks three random elements at positions <tt>BI...EI</tt> and returns the middle one under the comparator \c Cmp.
   template <class TCmp>
   static TIter GetPivotValNCmp(const TIter& BI, const TIter& EI, const TCmp& Cmp) {
@@ -736,7 +727,7 @@ public:
     if (EndI() == BegI()) return true;
     for (TIter i = BegI(); i != EndI()-1; ++i) {
       if (Cmp(*(i+1), *i)){return false;} } return true; }
-  
+
   /// Result is the intersection of \c this vector with \c ValV. ##TVec::Intrs
   void Intrs(const TVec<TVal, TSizeTy>& ValV);
   /// Result is the union of \c this vector with \c ValV. ##TVec::Union
@@ -791,7 +782,7 @@ public:
   const TVal& GetMxVal() const {return GetVal(GetMxValN());}
   /// Returns the smallest element in the vector \c Val. ###TVec::GetMnVal
   const TVal& GetMnVal() const { return GetVal(GetMnValN()); }
-  
+
   /// Returns a vector on element \c Val1.
   static TVec<TVal, TSizeTy> GetV(const TVal& Val1){
     TVec<TVal, TSizeTy> V(1, 0); V.Add(Val1); return V;}
@@ -820,42 +811,64 @@ public:
   static TVec<TVal, TSizeTy> GetV(const TVal& Val1, const TVal& Val2, const TVal& Val3, const TVal& Val4, const TVal& Val5, const TVal& Val6, const TVal& Val7, const TVal& Val8, const TVal& Val9){
     TVec<TVal, TSizeTy> V(9, 0); V.Add(Val1); V.Add(Val2); V.Add(Val3); V.Add(Val4); V.Add(Val5); V.Add(Val6); V.Add(Val7); V.Add(Val8); V.Add(Val9); return V;}
 
-#ifdef GLib_CPP11
 private:
-    uint64 GetMemUsedDeep(std::true_type) const;
-    uint64 GetMemUsedDeep(std::false_type) const;
+  //////////////////////////////////
+  /// MEMORY USAGE optimized using C++11 type traits
+  uint64 GetMemUsedDeep() const;
+  uint64 GetMemUsedShallow() const;
+#ifdef GLib_CPP11
+  /// get memory usage for simple types, such that we don't need to call
+  /// GetMemUsed on each element
+  template <class T = TVal, typename std::enable_if<std::is_standard_layout<T>::value, bool>::type = true>
+  uint64 GetVecMemUsed(const bool& = false) const { return GetMemUsedShallow(); }
+  /// get memory usage for complex types, where we have to call GetMemUsed
+  /// on each element
+  template <class T = TVal, typename std::enable_if<!std::is_standard_layout<T>::value, bool>::type = true>
+  uint64 GetVecMemUsed(const bool& DeepP = false) const { return DeepP ? GetMemUsedDeep() : GetMemUsedShallow(); }
+#else
+  /// get memory usage - pre-cpp11 implementation
+  // FIXME: deep doesn't work when TVal == TVec
+  uint64 GetVecMemUsed(const bool& DeepP = false) const { return DeepP ? GetMemUsedDeep() : GetMemUsedShallow(); }
 #endif
 };
+
+/*
+ * TYPE TRAITS: tell the compiler that TVec is a container
+ */
+#ifdef GLib_CPP11
+template <class TVal1, class TSizeTy1>
+struct IsContainer<TVec<TVal1, TSizeTy1>> : std::true_type{};
+#endif
 
 //#//////////////////////////////////////////////
 /// TSIter is a stride iterator. ##TVec
 template <class TVal, class TSizeTy = int>
 class TSIter{
 protected:
-	TVec<TVal, TSizeTy>* Vector;
-	TSizeTy start;
-	TSizeTy stride;
+    TVec<TVal, TSizeTy>* Vector;
+    TSizeTy start;
+    TSizeTy stride;
 public:
-	TSIter<TVal, TSizeTy>(){
-		Vector = NULL;
-		start = 0;
-		stride = 1;
-	}
-	TSIter<TVal, TSizeTy>(TVec<TVal, TSizeTy>* Vec, TSizeTy _start = 0, TSizeTy _stride = 1){
-		Vector = Vec;
-		start = _start;
-		stride = _stride;
-	}
-	const TVal& operator[](const TSizeTy& El) const {
-		TSizeTy index = start + El*stride;
-		AssertR((0 <= index) && (index < Vector->Vals), GetXOutOfBoundsErrMsg(index));
-		return (*Vector)[index];
-	}
-	TVal& operator[](const TSizeTy& El){
-		TSizeTy index = start + El*stride;
-		AssertR((0 <= index) && (index < Vector->Vals), GetXOutOfBoundsErrMsg(index));
-		return (*Vector)[index];
-	}
+    TSIter<TVal, TSizeTy>(){
+        Vector = NULL;
+        start = 0;
+        stride = 1;
+    }
+    TSIter<TVal, TSizeTy>(TVec<TVal, TSizeTy>* Vec, TSizeTy _start = 0, TSizeTy _stride = 1){
+        Vector = Vec;
+        start = _start;
+        stride = _stride;
+    }
+    const TVal& operator[](const TSizeTy& El) const {
+        TSizeTy index = start + El*stride;
+        AssertR((0 <= index) && (index < Vector->Vals), GetXOutOfBoundsErrMsg(index));
+        return (*Vector)[index];
+    }
+    TVal& operator[](const TSizeTy& El){
+        TSizeTy index = start + El*stride;
+        AssertR((0 <= index) && (index < Vector->Vals), GetXOutOfBoundsErrMsg(index));
+        return (*Vector)[index];
+    }
 };
 
 
@@ -969,7 +982,7 @@ public:
   static PVecPool Load(const TStr& FNm) { TFIn FIn(FNm); return Load(FIn); }
   void Save(TSOut& SOut) const;
   TVecPool& operator = (const TVecPool& Pool);
-  
+
   /// Returns the total number of vectors stored in the vector pool.
   int GetVecs() const { return IdToOffV.Len(); }
   /// Returns the total number of values stored in the vector pool.
@@ -987,7 +1000,7 @@ public:
   /// Returns the total memory footprint (in bytes) of the pool.
   uint64 GetMemUsed() const {
     return sizeof(TCRef)+sizeof(TBool)+3*sizeof(TSize)+sizeof(TVal*)+MxVals*sizeof(TVal);}
-  
+
   /// Adds vector \c ValV to the pool and returns its id.
   int AddV(const TValV& ValV);
   /// Adds a vector of length \c ValVLen to the pool and returns its id. ##TVecPool::AddEmptyV
@@ -1015,7 +1028,7 @@ public:
   /// Shuffles the order of all elements in the pool. ##TVecPool::ShuffleAll
   void ShuffleAll(TRnd& Rnd);
   void ShuffleAll() { TRnd Rnd; ShuffleAll(Rnd); }
-  
+
   /// Clears the contents of the pool. ##TVecPool::Clr
   void Clr(bool DoDel = true) {
     IdToOffV.Clr(DoDel);  MxVals=0;  Vals=0;
@@ -1033,32 +1046,32 @@ public:
 template <class TVal, class TSizeTy = TUInt64>
 class TLinkedQueue {
 private:
-	class TNode {
-	public:
-		TNode* Next;
-		TVal Val;
+    class TNode {
+    public:
+        TNode* Next;
+        TVal Val;
 
-		TNode(TNode* Next, const TVal& Val);
-	};
+        TNode(TNode* Next, const TVal& Val);
+    };
 
-	TNode* First;
-	TNode* Last;
-	TSizeTy Size;
+    TNode* First;
+    TNode* Last;
+    TSizeTy Size;
 
 public:
-	TLinkedQueue();
-	TLinkedQueue(TSIn& SIn);
-	~TLinkedQueue();
+    TLinkedQueue();
+    TLinkedQueue(TSIn& SIn);
+    ~TLinkedQueue();
 
-	void Save(TSOut& SOut) const;
+    void Save(TSOut& SOut) const;
 
-	void Push(const TVal& Val);
-	TVal Pop();
-	TVal& Peek();
-	void DelFirst();
+    void Push(const TVal& Val);
+    TVal Pop();
+    TVal& Peek();
+    void DelFirst();
 
-	bool Empty() const { return Len() == 0; };
-	TSizeTy Len() const { return Size; };
+    bool Empty() const { return Len() == 0; };
+    TSizeTy Len() const { return Size; };
 };
 
 /////////////////////////////////////////////////
@@ -1358,71 +1371,71 @@ typedef TPt<TStrVP> PStrV;
 template <class TVal, class TSizeTy = int, bool colmajor = false>
 class TVVec{
 protected:
-	TSizeTy XDim, YDim;
-	TVec<TVal, TSizeTy> ValV;
-	TBool ColMajor;
-	//TSizeTy XStride, YStride;
+    TSizeTy XDim, YDim;
+    TVec<TVal, TSizeTy> ValV;
+    TBool ColMajor;
+    //TSizeTy XStride, YStride;
 public:
-	TVVec() : XDim(), YDim(), ValV(), ColMajor(){}
-	TVVec(const TVVec& Vec) :
-		XDim(Vec.XDim), YDim(Vec.YDim), ValV(Vec.ValV), ColMajor(Vec.ColMajor){}
-	TVVec(const TVec<TVal, TSizeTy>& Vec) :
-		XDim(colmajor ? Vec.Len() : 1), YDim(colmajor ? 1 : Vec.Len()), ValV(Vec), ColMajor(colmajor){}
-	TVVec(const TVec<TVal, TSizeTy> && Vec) :
-		XDim(colmajor ? Vec.Len() : 1), YDim(colmajor ? 1 : Vec.Len()), ValV(std::move(Vec)), ColMajor(colmajor){}
-	//-------------------------------------------------------------------------------------------
+    TVVec() : XDim(), YDim(), ValV(), ColMajor(){}
+    TVVec(const TVVec& Vec) :
+        XDim(Vec.XDim), YDim(Vec.YDim), ValV(Vec.ValV), ColMajor(Vec.ColMajor){}
+    TVVec(const TVec<TVal, TSizeTy>& Vec) :
+        XDim(colmajor ? Vec.Len() : 1), YDim(colmajor ? 1 : Vec.Len()), ValV(Vec), ColMajor(colmajor){}
+    TVVec(const TVec<TVal, TSizeTy> && Vec) :
+        XDim(colmajor ? Vec.Len() : 1), YDim(colmajor ? 1 : Vec.Len()), ValV(std::move(Vec)), ColMajor(colmajor){}
+    //-------------------------------------------------------------------------------------------
 #ifdef GLib_CPP11
-	TVVec(const TVVec&& Vec) :
-		XDim(std::move(Vec.XDim)), YDim(std::move(Vec.YDim)), ValV(std::move(Vec.ValV)), ColMajor(std::move(Vec.ColMajor)){ }
+    TVVec(const TVVec&& Vec) :
+        XDim(std::move(Vec.XDim)), YDim(std::move(Vec.YDim)), ValV(std::move(Vec.ValV)), ColMajor(std::move(Vec.ColMajor)){ }
 #endif
-	TVVec(const TSizeTy& _XDim, const TSizeTy& _YDim, const TBool& _ColMajor = false) :
-		XDim(), YDim(), ValV(), ColMajor(_ColMajor){
-		Gen(_XDim, _YDim);
-	}
-	explicit TVVec(const TVec<TVal, TSizeTy>& _ValV, const TSizeTy& _XDim, const TSizeTy& _YDim, const TBool& _ColMajor = false) :
-		XDim(_XDim), YDim(_YDim), ValV(_ValV), ColMajor(_ColMajor){
-		IAssert(ValV.Len() == XDim*YDim);
-	}
-	//Andrej beta specialize this only for row major, works only for row major
-	void GetExtRows(TVVec& VVec, const TSizeTy& RowStart, const TSizeTy& RowEnd){
-		//VVec.ValV.MxVals = -1;//I will not be resonsible for this memory!
-		VVec.ValV.GenExt(&ValV[RowStart*YDim], (RowEnd - RowStart + 1)*YDim);
-		VVec.XDim = (RowEnd - RowStart + 1);
-		VVec.YDim = YDim;
-	}
-	explicit TVVec(TSIn& SIn) { Load(SIn); }
-	void Load(TSIn& SIn){
-		SIn.Load(XDim);
-		SIn.Load(YDim);
-		ValV.Load(SIn);
-		if (colmajor){
-			ColMajor.Load(SIn);
-		}
-		else{
-			ColMajor = false;
-		}
-	}
-	void Save(TSOut& SOut) const {
-		SOut.Save(XDim);
-		SOut.Save(YDim);
-		ValV.Save(SOut);
-		/*Added by Andrej*/
-		if (colmajor){
-			ColMajor.Save(SOut);
-		}
-	}
+    TVVec(const TSizeTy& _XDim, const TSizeTy& _YDim, const TBool& _ColMajor = false) :
+        XDim(), YDim(), ValV(), ColMajor(_ColMajor){
+        Gen(_XDim, _YDim);
+    }
+    explicit TVVec(const TVec<TVal, TSizeTy>& _ValV, const TSizeTy& _XDim, const TSizeTy& _YDim, const TBool& _ColMajor = false) :
+        XDim(_XDim), YDim(_YDim), ValV(_ValV), ColMajor(_ColMajor){
+        IAssert(ValV.Len() == XDim*YDim);
+    }
+    //Andrej beta specialize this only for row major, works only for row major
+    void GetExtRows(TVVec& VVec, const TSizeTy& RowStart, const TSizeTy& RowEnd){
+        //VVec.ValV.MxVals = -1;//I will not be resonsible for this memory!
+        VVec.ValV.GenExt(&ValV[RowStart*YDim], (RowEnd - RowStart + 1)*YDim);
+        VVec.XDim = (RowEnd - RowStart + 1);
+        VVec.YDim = YDim;
+    }
+    explicit TVVec(TSIn& SIn) { Load(SIn); }
+    void Load(TSIn& SIn){
+        SIn.Load(XDim);
+        SIn.Load(YDim);
+        ValV.Load(SIn);
+        if (colmajor){
+            ColMajor.Load(SIn);
+        }
+        else{
+            ColMajor = false;
+        }
+    }
+    void Save(TSOut& SOut) const {
+        SOut.Save(XDim);
+        SOut.Save(YDim);
+        ValV.Save(SOut);
+        /*Added by Andrej*/
+        if (colmajor){
+            ColMajor.Save(SOut);
+        }
+    }
   TVVec<TVal, TSizeTy>& operator=(const TVVec<TVal, TSizeTy>& Vec){
-	  if (this != &Vec){ XDim = Vec.XDim; YDim = Vec.YDim;  ValV = Vec.ValV; ColMajor = Vec.ColMajor; } return *this;
+      if (this != &Vec){ XDim = Vec.XDim; YDim = Vec.YDim;  ValV = Vec.ValV; ColMajor = Vec.ColMajor; } return *this;
   }
   bool operator==(const TVVec& Vec) const {
-	  return (XDim == Vec.XDim) && (YDim == Vec.YDim) && (ValV == Vec.ValV) && (ColMajor == Vec.ColMajor);
+      return (XDim == Vec.XDim) && (YDim == Vec.YDim) && (ValV == Vec.ValV) && (ColMajor == Vec.ColMajor);
   }
 
   bool Empty() const {return ValV.Len()==0;}
   void Clr(){XDim=0; YDim=0; ValV.Clr();}
   void Gen(const TSizeTy& _XDim, const TSizeTy& _YDim){
-	  EAssert((_XDim >= 0) && (_YDim >= 0));
-	  XDim = _XDim; YDim = _YDim;  ValV.Gen(XDim*YDim); ColMajor = colmajor;
+      EAssert((_XDim >= 0) && (_YDim >= 0));
+      XDim = _XDim; YDim = _YDim;  ValV.Gen(XDim*YDim); ColMajor = colmajor;
   }
   TSizeTy GetXDim() const {return XDim;}
   TSizeTy GetYDim() const {return YDim;}
@@ -1431,12 +1444,12 @@ public:
   TVec<TVal, TSizeTy>& Get1DVec(){return ValV;}
 
   const TVal& At(const TSizeTy& X, const TSizeTy& Y) const {
-	  Assert((0 <= X) && (X<TSizeTy(XDim)) && (0 <= Y) && (Y<TSizeTy(YDim)));
-	  return colmajor ? ValV[Y*XDim + X] : ValV[X*YDim + Y];
+      Assert((0 <= X) && (X<TSizeTy(XDim)) && (0 <= Y) && (Y<TSizeTy(YDim)));
+      return colmajor ? ValV[Y*XDim + X] : ValV[X*YDim + Y];
   }
   TVal& At(const TSizeTy& X, const TSizeTy& Y){
-	  Assert((0 <= X) && (X<TSizeTy(XDim)) && (0 <= Y) && (Y<TSizeTy(YDim)));
-	  return colmajor ? ValV[Y*XDim + X] : ValV[X*YDim + Y];
+      Assert((0 <= X) && (X<TSizeTy(XDim)) && (0 <= Y) && (Y<TSizeTy(YDim)));
+      return colmajor ? ValV[Y*XDim + X] : ValV[X*YDim + Y];
   }
   TVal& operator()(const TSizeTy& X, const TSizeTy& Y){
     return At(X, Y);}
@@ -1450,8 +1463,8 @@ public:
   void PutY(const TSizeTy& Y, const TVal& Val){
     for (TSizeTy X=0; X<TSizeTy(XDim); X++){At(X, Y)=Val;}}
   TVal GetXY(const TSizeTy& X, const TSizeTy& Y) const {
-	  Assert((0 <= X) && (X<TSizeTy(XDim)) && (0 <= Y) && (Y<TSizeTy(YDim)));
-	  return colmajor ? ValV[Y*XDim + X] : ValV[X*YDim + Y];
+      Assert((0 <= X) && (X<TSizeTy(XDim)) && (0 <= Y) && (Y<TSizeTy(YDim)));
+      return colmajor ? ValV[Y*XDim + X] : ValV[X*YDim + Y];
   }
   void GetRow(const TSizeTy& RowN, TVec<TVal, TSizeTy>& Vec) const;
   // Get a pointer to the row (no copying in case of row major format)
@@ -1465,7 +1478,7 @@ public:
   void SetRow(const TSizeTy& RowN, const TVec<TVal, TSizeTy>& Vec);
   void SetCol(const TSizeTy& ColN, const TVec<TVal, TSizeTy>& Vec);
 
-  void AddCol(const TVec<TVal, TSizeTy>& Col) { AddYDim();	SetCol(GetCols()-1, Col); }
+  void AddCol(const TVec<TVal, TSizeTy>& Col) { AddYDim();  SetCol(GetCols()-1, Col); }
 
   void SwapX(const TSizeTy& X1, const TSizeTy& X2);
   void SwapY(const TSizeTy& Y1, const TSizeTy& Y2);
@@ -1483,38 +1496,38 @@ public:
   void DelCols(const TVec<TNum<TSizeTy>, TSizeTy>& ColIdV);
 #ifndef INTEL_TRANSPOSE
   void Transpose() {
-	  TVec<TVal, TSizeTy> ValV2 = ValV;
-	  int Counter = 0;
-	  for (int Y = 0; Y < YDim; Y++) {
-		  for (int X = 0; X < XDim; X++) {
-			  ValV2[Counter] = colmajor ? ValV[Y*XDim + Y] : ValV[X*YDim + Y];
-			  Counter++;
-		  }
-	  }
-	  std::swap(ValV, ValV2);
-	  TSizeTy temp2 = XDim;
-	  XDim = YDim;
-	  YDim = temp2;
+      TVec<TVal, TSizeTy> ValV2 = ValV;
+      int Counter = 0;
+      for (int Y = 0; Y < YDim; Y++) {
+          for (int X = 0; X < XDim; X++) {
+              ValV2[Counter] = colmajor ? ValV[Y*XDim + Y] : ValV[X*YDim + Y];
+              Counter++;
+          }
+      }
+      std::swap(ValV, ValV2);
+      TSizeTy temp2 = XDim;
+      XDim = YDim;
+      YDim = temp2;
   }
   void SwitchDim() {
-	  TSizeTy temp2 = XDim;
-	  XDim = YDim;
-	  YDim = temp2;
+      TSizeTy temp2 = XDim;
+      XDim = YDim;
+      YDim = temp2;
   }
 #else
   //INTEL MKL in place transpose needs to be fixed to support both row and column major format
   void Transpose() {
-	  //void mkl_dimatcopy(const char ordering, const char trans, size_t rows, size_t cols, const double alpha, double * AB, size_t lda, size_t ldb);
-	  char Format = colmajor ? 'C' : 'T';
-	  mkl_dimatcopy(Format, 'T', XDim, YDim, 1.0, &ValV[0].Val, YDim, XDim);
-	  TSizeTy temp2 = XDim;
-	  XDim = YDim;
-	  YDim = temp2;
+      //void mkl_dimatcopy(const char ordering, const char trans, size_t rows, size_t cols, const double alpha, double * AB, size_t lda, size_t ldb);
+      char Format = colmajor ? 'C' : 'T';
+      mkl_dimatcopy(Format, 'T', XDim, YDim, 1.0, &ValV[0].Val, YDim, XDim);
+      TSizeTy temp2 = XDim;
+      XDim = YDim;
+      YDim = temp2;
   }
   void SwitchDim() {
-	  TSizeTy temp2 = XDim;
-	  XDim = YDim;
-	  YDim = temp2;
+      TSizeTy temp2 = XDim;
+      XDim = YDim;
+      YDim = temp2;
   }
 #endif
 };
@@ -1614,10 +1627,10 @@ public:
     return NodeV.Add(TTriple<TInt, TIntV, TVal>(ParentNodeId, TIntV(), NodeVal));}
   int AddRoot(const TVal& NodeVal=TVal()){
     return AddNode(-1, NodeVal);}
- 
+
   int GetNodes() const {return NodeV.Len();}
   void GetNodeIdV(TIntV& NodeIdV, const int& NodeId=0);
-  int GetParentNodeId(const int& NodeId) const {return NodeV[NodeId].Val1;} 
+  int GetParentNodeId(const int& NodeId) const {return NodeV[NodeId].Val1;}
   int GetChildren(const int& NodeId) const {return NodeV[NodeId].Val2.Len();}
   int GetChildNodeId(const int& NodeId, const int& ChildN) const {return NodeV[NodeId].Val2[ChildN];}
   TVal& GetNodeVal(const int& NodeId){return NodeV[NodeId].Val3;}
@@ -1716,11 +1729,11 @@ public:
     if (this!=&Queue){MxLast=Queue.MxLast; MxLen=Queue.MxLen;
       Last=Queue.Last; Next=Queue.Next; ValV=Queue.ValV;}
       return *this;}
-  
+
   /// Index operator. Queue[0] corresponds to Back() and Queue[Queue.Len()-1] corresponts to Front()
   const TVal& operator[](const int& ValN) const {
-	Assert((0<=ValN)&&(ValN<Len()));
-    int Index = (Next + ValN) % ValV.Len();  
+    Assert((0<=ValN)&&(ValN<Len()));
+    int Index = (Next + ValN) % ValV.Len();
     return ValV[Index];}
 
   /// Deletes the queue
@@ -1744,7 +1757,7 @@ public:
 
   /// Number of elements in the queue
   int Len() const {
-    return Last >= Next ? Last - Next : ValV.Len() - (Next - Last);    
+    return Last >= Next ? Last - Next : ValV.Len() - (Next - Last);
   }
 
   /// Most recently added element, last one to go out
@@ -1836,6 +1849,11 @@ public:
   TLstNd* Next() const {Assert(this!=NULL); return NextNd;}
   TVal& GetVal(){Assert(this!=NULL); return Val;}
   const TVal& GetVal() const {Assert(this!=NULL); return Val;}
+  uint64 GetMemUsed() const {
+      return TMemUtils::GetMemUsed(PrevNd) +
+             TMemUtils::GetMemUsed(NextNd) +
+             TMemUtils::GetMemUsed(Val);
+  }
 };
 
 /////////////////////////////////////////////////
@@ -1883,7 +1901,7 @@ public:
   PLstNd SearchForw(const TVal& Val);
   PLstNd SearchBack(const TVal& Val);
   uint64 GetMemUsed() const {
-	  return uint64(sizeof(int) + 2 * sizeof(PLstNd) + Nds * sizeof(TLstNd<TVal>));
+      return uint64(sizeof(int) + 2 * sizeof(PLstNd) + Nds * sizeof(TLstNd<TVal>));
   }
   friend class TLstNd<TVal>;
 };

--- a/src/glib/base/ds.h
+++ b/src/glib/base/ds.h
@@ -439,6 +439,14 @@ class TVec{
 public:
   typedef TVal* TIter;  //!< Random access iterator to \c TVal.
 protected:
+#ifdef GLib_CPP11
+  /// cpp type traits, helper to check if type is TVec
+  template <typename T>
+  struct IsTVec : std::false_type{};
+  template <class TVal1, class TSizeTy1>
+  struct IsTVec<TVec<TVal1, TSizeTy1>> : std::true_type{};
+#endif
+
   TSizeTy MxVals; //!< Vector capacity. Capacity is the size of allocated storage. If <tt>MxVals==-1</tt>, then \c ValT is not owned by the vector, and it won't free it at destruction.
   TSizeTy Vals;   //!< Vector length. Length is the number of elements stored in the vector.
   TVal* ValT;     //!< Pointer to the memory where the elements of the vector are stored.
@@ -506,16 +514,8 @@ public:
   uint64 GetMemUsed() const {
 	  return TSizeTy(2 * sizeof(TSizeTy) + sizeof(TVal*) + sizeof(TVal)*(MxVals != -1 ? MxVals : 0));
   }
-  /// Returns the memory footprint (the number of bytes) of the vector.
-  uint64 GetMemUsedDeep() const {
-	  uint64 MemSize = 2 * sizeof(TSizeTy) + sizeof(TVal*);
-	  if (ValT != NULL && MxVals != -1){
-		  for (TSizeTy i = 0; i < MxVals; i++){
-			  MemSize += ValT[i].GetMemUsed();
-		  }
-	  }
-	  return MemSize;
-  }
+  /// Returns the memory footprint (the number of bytes) of the vector, including all its elements.
+  uint64 GetMemUsedDeep() const;
   /// Returns the memory size (the number of bytes) of a binary representation.
   TSizeTy GetMemSize(bool flat = true) const {
 	  return TSizeTy(2 * sizeof(TVal) + sizeof(TVal)*Vals);
@@ -818,6 +818,12 @@ public:
   /// Returns a vector on elements <tt>Val1...Val9</tt>.
   static TVec<TVal, TSizeTy> GetV(const TVal& Val1, const TVal& Val2, const TVal& Val3, const TVal& Val4, const TVal& Val5, const TVal& Val6, const TVal& Val7, const TVal& Val8, const TVal& Val9){
     TVec<TVal, TSizeTy> V(9, 0); V.Add(Val1); V.Add(Val2); V.Add(Val3); V.Add(Val4); V.Add(Val5); V.Add(Val6); V.Add(Val7); V.Add(Val8); V.Add(Val9); return V;}
+
+#ifdef GLib_CPP11
+private:
+    uint64 GetMemUsedDeep(std::true_type) const;
+    uint64 GetMemUsedDeep(std::false_type) const;
+#endif
 };
 
 //#//////////////////////////////////////////////

--- a/src/glib/base/ds.h
+++ b/src/glib/base/ds.h
@@ -202,6 +202,7 @@ typedef TTriple<TInt, TInt, TStr> TIntIntStrTr;
 typedef TTriple<TInt, TInt, TFlt> TIntIntFltTr;
 typedef TTriple<TInt, TFlt, TInt> TIntFltIntTr;
 typedef TTriple<TInt, TFlt, TFlt> TIntFltFltTr;
+typedef TTriple<TInt, TFlt, TUInt64> TIntFltUInt64Tr;
 typedef TTriple<TFlt, TInt, TFlt> TFltIntFltTr;
 typedef TTriple<TInt, TVec<TInt, int>, TInt> TIntIntVIntTr;
 typedef TTriple<TInt, TInt, TVec<TInt, int> > TIntIntIntVTr;

--- a/src/glib/base/dt.h
+++ b/src/glib/base/dt.h
@@ -1324,6 +1324,8 @@ public:
 
   TSInt& operator++() { ++Val; return *this; } // prefix
   TSInt& operator--() { --Val; return *this; } // prefix
+  /// Returns the memoty footprint
+  uint64 GetMemUsed() const { return sizeof(TSInt); }
 };
 typedef TSInt TInt16;
 
@@ -1397,7 +1399,7 @@ public:
   TNum operator++(int){ TNum oldVal = Val; Val++; return oldVal; } // postfix
   TNum operator--(int){ TNum oldVal = Val; Val--; return oldVal; } // postfix
 
-  int GetMemUsed() const {return sizeof(TNum);}
+  int GetMemUsed() const { return sizeof(TInt); }
 
   int GetPrimHashCd() const {return Val;}
   int GetSecHashCd() const {return Val/0x10;}

--- a/src/glib/base/dt.h
+++ b/src/glib/base/dt.h
@@ -1324,7 +1324,7 @@ public:
 
   TSInt& operator++() { ++Val; return *this; } // prefix
   TSInt& operator--() { --Val; return *this; } // prefix
-  /// Returns the memoty footprint
+  /// Returns the memory footprint
   uint64 GetMemUsed() const { return sizeof(TSInt); }
 };
 typedef TSInt TInt16;

--- a/src/glib/base/gix.h
+++ b/src/glib/base/gix.h
@@ -131,6 +131,15 @@ private:
             Len.Save(SOut);
             Pt.Save(SOut);
         }
+
+        uint64 GetMemUsed() const {
+            return TMemUtils::GetMemUsed(MinVal) +
+                   TMemUtils::GetMemUsed(MaxVal) +
+                   TMemUtils::GetMemUsed(Len) +
+                   TMemUtils::GetMemUsed(Pt) +
+                   TMemUtils::GetMemUsed(Loaded) +
+                   TMemUtils::GetMemUsed(Dirty);
+        }
     };
 
 private:
@@ -269,7 +278,7 @@ public:
         res += ItemV.GetMemUsed();
         res += ItemVDel.GetMemUsed();
         res += Children.GetMemUsed();
-        res += ChildrenData.GetMemUsedDeep();
+        res += ChildrenData.GetMemUsed(false);
         return res;
 
         /*return ItemSetKey.GetMemUsed() + ItemV.GetMemUsed() + ItemVDel.GetMemUsed()
@@ -936,7 +945,7 @@ public:
         res += sizeof(TGixStats);
         res += GixFNm.GetMemUsed();
         res += GixBlobFNm.GetMemUsed();
-        res += KeyIdH.GetMemUsed();
+        res += KeyIdH.GetMemUsed(true);
         res += ItemSetCache.GetMemUsed();
         return res;
         /*return

--- a/src/glib/base/gix.h
+++ b/src/glib/base/gix.h
@@ -236,11 +236,12 @@ private:
 
     /// Ask child vectors about their memory usage
     uint64 GetChildMemUsed() const {
-        uint64 mem = 0;
-        for (int i = 0; i < ChildrenData.Len(); i++) {
-            mem += ChildrenData[i].GetMemUsed();
-        }
-        return mem;
+        return ChildrenData.GetMemUsed(true);
+        /* uint64 mem = 0; */
+        /* for (int i = 0; i < ChildrenData.Len(); i++) { */
+        /*     mem += ChildrenData[i].GetMemUsed(); */
+        /* } */
+        /* return mem; */
     }
 
 public:
@@ -278,7 +279,7 @@ public:
         res += ItemV.GetMemUsed();
         res += ItemVDel.GetMemUsed();
         res += Children.GetMemUsed();
-        res += ChildrenData.GetMemUsed(false);
+        res += ChildrenData.GetMemUsed(true);
         return res;
 
         /*return ItemSetKey.GetMemUsed() + ItemV.GetMemUsed() + ItemVDel.GetMemUsed()

--- a/src/glib/base/json.cpp
+++ b/src/glib/base/json.cpp
@@ -319,11 +319,11 @@ void TJsonVal::AssertObjKeyBool(const TStr& Key, const TStr& Fun) {
 uint64 TJsonVal::GetMemUsed() const {
     return sizeof(TJsonVal) +
            // JsonValType is an enum and is already counted
-           GetExtraMemberSize(Bool) +
-           GetExtraMemberSize(Num) +
-           GetExtraMemberSize(Str) +
-           GetDeepExtraMemberSize(ValV) +
-           GetExtraMemberSize(KeyValH); // THash already does a deep calculation
+           TMemUtils::GetExtraMemberSize(Bool) +
+           TMemUtils::GetExtraMemberSize(Num) +
+           TMemUtils::GetExtraMemberSize(Str) +
+           TMemUtils::GetExtraMemberSize(ValV) +
+           TMemUtils::GetExtraMemberSize(KeyValH);
 }
 
 PJsonVal TJsonVal::GetValFromLx(TILx& Lx){

--- a/src/glib/base/json.cpp
+++ b/src/glib/base/json.cpp
@@ -316,6 +316,16 @@ void TJsonVal::AssertObjKeyBool(const TStr& Key, const TStr& Fun) {
     if (!GetObjKey(Key)->IsBool()) { throw TExcept::New("Exception in function `" + Fun + "`: JSON property:`" + Key + "` is not a boolean."); }
 }
 
+uint64 TJsonVal::GetMemUsed() const {
+    return sizeof(TJsonVal) +
+           // JsonValType is an enum and is already counted
+           GetExtraMemberSize(Bool) +
+           GetExtraMemberSize(Num) +
+           GetExtraMemberSize(Str) +
+           GetDeepExtraMemberSize(ValV) +
+           GetExtraMemberSize(KeyValH); // THash already does a deep calculation
+}
+
 PJsonVal TJsonVal::GetValFromLx(TILx& Lx){
   static TFSet ValExpect=TFSet()|syIdStr|syFlt|syQStr|syLBracket|syLBrace|syRBracket;
   PJsonVal Val=TJsonVal::New();

--- a/src/glib/base/json.h
+++ b/src/glib/base/json.h
@@ -187,6 +187,9 @@ public:
   void AssertObjKeyNum(const TStr& Key, const TStr& Fun);
   void AssertObjKeyBool(const TStr& Key, const TStr& Fun);
 
+  /// debugging
+  uint64 GetMemUsed() const;
+
   // (de)serialization
   static PJsonVal GetValFromLx(TILx& Lx);
   static PJsonVal GetValFromSIn(const PSIn& SIn, bool& Ok, TStr& MsgStr);

--- a/src/glib/base/tm.h
+++ b/src/glib/base/tm.h
@@ -534,6 +534,8 @@ public:
     double GetSec() const { return double(TimeSoFar) / double(CLOCKS_PER_SEC); }
     /// Get time in seconds
     int GetSecInt() const { return TFlt::Round(GetSec()); }
+    /// Get the memory footprint
+    uint64 GetMemUsed() const { return sizeof(TAggrExeTm); }
 };
 
 /////////////////////////////////////////////////

--- a/src/glib/mine/anomaly.cpp
+++ b/src/glib/mine/anomaly.cpp
@@ -197,4 +197,17 @@ PJsonVal TNearestNeighbor::Explain(const TIntFltKdV& Vec) const {
     return ResVal;
 }
 
+uint64 TNearestNeighbor::GetMemUsed() const {
+    return sizeof(TNearestNeighbor) +
+           GetDeepExtraMemberSize(RateV) +
+           GetExtraMemberSize(WindowSize) +
+           GetDeepExtraMemberSize(Mat) +
+           GetDeepExtraMemberSize(DistV) +
+           GetDeepExtraMemberSize(DistColV) +
+           GetDeepExtraMemberSize(ThresholdV) +
+           GetExtraMemberSize(InitVecs) +
+           GetExtraMemberSize(NextCol) +
+           GetDeepExtraMemberSize(DatV);
+}
+
 };

--- a/src/glib/mine/anomaly.cpp
+++ b/src/glib/mine/anomaly.cpp
@@ -199,15 +199,15 @@ PJsonVal TNearestNeighbor::Explain(const TIntFltKdV& Vec) const {
 
 uint64 TNearestNeighbor::GetMemUsed() const {
     return sizeof(TNearestNeighbor) +
-           GetDeepExtraMemberSize(RateV) +
-           GetExtraMemberSize(WindowSize) +
-           GetDeepExtraMemberSize(Mat) +
-           GetDeepExtraMemberSize(DistV) +
-           GetDeepExtraMemberSize(DistColV) +
-           GetDeepExtraMemberSize(ThresholdV) +
-           GetExtraMemberSize(InitVecs) +
-           GetExtraMemberSize(NextCol) +
-           GetDeepExtraMemberSize(DatV);
+           TMemUtils::GetExtraMemberSize(RateV) +
+           TMemUtils::GetExtraMemberSize(WindowSize) +
+           TMemUtils::GetExtraMemberSize(Mat) +
+           TMemUtils::GetExtraMemberSize(DistV) +
+           TMemUtils::GetExtraMemberSize(DistColV) +
+           TMemUtils::GetExtraMemberSize(ThresholdV) +
+           TMemUtils::GetExtraMemberSize(InitVecs) +
+           TMemUtils::GetExtraMemberSize(NextCol) +
+           TMemUtils::GetExtraMemberSize(DatV);
 }
 
 };

--- a/src/glib/mine/anomaly.h
+++ b/src/glib/mine/anomaly.h
@@ -68,6 +68,8 @@ public:
     double GetRate(const int& RateN) const { return RateV[RateN]; }
     double GetThreshold(const int& RateN) const { return IsInit() ? ThresholdV[RateN].Val : 0.0; }
     int GetWindowSize() const { return WindowSize; }
+    /// Returns the memory footprint of the object
+    uint64 GetMemUsed() const;
 };
 
 };

--- a/src/glib/mine/bowbs.h
+++ b/src/glib/mine/bowbs.h
@@ -707,7 +707,7 @@ public:
     TFOut SOut(FNm); Save(SOut);}
 
   int64 GetMemUsed() {
-	  return DocNmToDescStrH.GetMemUsed() + WordStrToDescH.GetMemUsed() + CatNmToFqH.GetMemUsed() + DocSpVV.GetMemUsed() + 
+	  return DocNmToDescStrH.GetMemUsed(true) + WordStrToDescH.GetMemUsed(true) + CatNmToFqH.GetMemUsed(true) + DocSpVV.GetMemUsed() + 
 		  DocStrV.GetMemUsed() + DocCIdVV.GetMemUsed() + TrainDIdV.GetMemUsed() + TestDIdV.GetMemUsed();
   }
   friend class TBowFl;

--- a/src/nodejs/qm/qm_nodejs.h
+++ b/src/nodejs/qm/qm_nodejs.h
@@ -3251,8 +3251,10 @@ public:
 * The feature extractor of type `'multinomial'`. Used for constructing {@link module:qm.FeatureSpace} objects.
 * @property {string} type - The type of the extractor. <b>Important</b>: It must be equal `'multinomial'`.
 * @property {boolean} [normalize = 'false'] - Normalize the resulting vector of the extractor to have L2 norm 1.0.
-* @property {boolean} [binary = false] - Do not compute frequencies, but only a binary indicator whether the category appears
-* @property {boolean} [log = false] - Output logarithm of the frequencies log(1+x). This flag is exclusive with flag 'binary'.
+* @property {string} [transform] - Transformation to apply to each dimension of the feature vector.
+* <br> Transformation include:
+* <br> - 'log' - Compute a logarithm of the frequencies using the following formula: log(1+x)
+* <br> - 'binary' - Do not compute frequencies, but only a binary indicator whether the category appears
 * @property {Array.<Object>} [values] - A fixed set of values, which form a fixed feature set, no dimensionality changes if new values are seen in the updates. Cannot be used the same time as datetime.
 * @property {number} [hashDimension] - A hashing code to set the fixed dimensionality. All values are hashed and divided modulo hashDimension to get the corresponding dimension.
 * @property {Object} [datetime = false] - Same as `'values'`, only with predefined values which are extracted from date and time (`month`, `day of month`, `day of week`, `time of day`, `hour`).

--- a/src/qminer/qminer_aggr.cpp
+++ b/src/qminer/qminer_aggr.cpp
@@ -2426,7 +2426,7 @@ TRecFilterAggr::TRecFilterAggr(const TWPt<TBase>& Base, const PJsonVal& ParamVal
 
 uint64 TRecFilterAggr::GetMemUsed() const {
     return (TStreamAggr::GetMemUsed() - sizeof(TStreamAggr) + sizeof(TRecFilterAggr)) +
-           (FilterV.GetMemUsed() - sizeof(TVec<PRecFilter>));
+           TMemUtils::GetExtraMemberSize(FilterV);
 }
 
 //////////////////////////////////////////////////////////////////////////////////

--- a/src/qminer/qminer_aggr.cpp
+++ b/src/qminer/qminer_aggr.cpp
@@ -2029,6 +2029,13 @@ void TNNAnomalyAggr::Reset() {
     Explanation = TJsonVal::NewObj();
 }
 
+uint64 TNNAnomalyAggr::GetMemUsed() const {
+    return sizeof(TNNAnomalyAggr) +
+           (TStreamAggr::GetMemUsed() - sizeof(TStreamAggr)) +
+           GetExtraMemberSize(Model) +
+           GetExtraMemberSize(Explanation);
+}
+
 /// Load from stream
 void TNNAnomalyAggr::LoadState(TSIn& SIn) {
     Model = TAnomalyDetection::TNearestNeighbor(SIn);
@@ -2414,6 +2421,12 @@ TRecFilterAggr::TRecFilterAggr(const TWPt<TBase>& Base, const PJsonVal& ParamVal
     }
     // parse out input aggregate
     Aggr = ParseAggr(ParamVal, "aggr");
+}
+
+
+uint64 TRecFilterAggr::GetMemUsed() const {
+    return (TStreamAggr::GetMemUsed() - sizeof(TStreamAggr) + sizeof(TRecFilterAggr)) +
+           (FilterV.GetMemUsed() - sizeof(TVec<PRecFilter>));
 }
 
 //////////////////////////////////////////////////////////////////////////////////

--- a/src/qminer/qminer_aggr.cpp
+++ b/src/qminer/qminer_aggr.cpp
@@ -2032,8 +2032,8 @@ void TNNAnomalyAggr::Reset() {
 uint64 TNNAnomalyAggr::GetMemUsed() const {
     return sizeof(TNNAnomalyAggr) +
            (TStreamAggr::GetMemUsed() - sizeof(TStreamAggr)) +
-           GetExtraMemberSize(Model) +
-           GetExtraMemberSize(Explanation);
+           TMemUtils::GetExtraMemberSize(Model) +
+           TMemUtils::GetExtraMemberSize(Explanation);
 }
 
 /// Load from stream

--- a/src/qminer/qminer_aggr.h
+++ b/src/qminer/qminer_aggr.h
@@ -1594,6 +1594,8 @@ public:
     int GetInt() const { return LastSeverity; }
     PJsonVal SaveJson(const int& Limit) const;
 
+    /// Returns the memory footprint of the object
+    uint64 GetMemUsed() const;
     /// Stream aggregator type name
     static TStr GetType() { return "nnAnomalyDetector"; }
     /// Stream aggregator type name
@@ -2003,6 +2005,8 @@ public:
     void Reset() { }
     /// JSON serialization
     PJsonVal SaveJson(const int& Limit) const { return TJsonVal::NewObj(); }
+    /// Returns the memory footprint
+    uint64 GetMemUsed() const;
     /// Stream aggregator type name
     static TStr GetType() { return "recordFilterAggr"; }
     /// Stream aggregator type name

--- a/src/qminer/qminer_core.cpp
+++ b/src/qminer/qminer_core.cpp
@@ -6636,6 +6636,16 @@ void TStreamAggr::SaveState(TSOut& SOut) const {
     throw TQmExcept::New("TStreamAggr::_Save not implemented:" + GetAggrNm());
 };
 
+uint64 TStreamAggr::GetMemUsed() const {
+    // sizeof(TStreamAggr) returns the size of this class including all its members and
+    // alignment, but discards the size of any pointers that the members hold which
+    // equals Member.GetMemUsed() - sizeof(TMemberClass) (calculated by GetExtraMemberSize)
+    return sizeof(TStreamAggr) +
+           GetExtraMemberSize(CRef) +
+           GetExtraMemberSize(AggrNm) +
+           GetExtraMemberSize(ExeTm);
+}
+
 ///////////////////////////////
 // QMiner-Stream-Aggregator-Set
 TStreamAggrSet::TStreamAggrSet(const TWPt<TBase>& _Base, const TStr& _AggrNm):

--- a/src/qminer/qminer_core.cpp
+++ b/src/qminer/qminer_core.cpp
@@ -6641,9 +6641,9 @@ uint64 TStreamAggr::GetMemUsed() const {
     // alignment, but discards the size of any pointers that the members hold which
     // equals Member.GetMemUsed() - sizeof(TMemberClass) (calculated by GetExtraMemberSize)
     return sizeof(TStreamAggr) +
-           GetExtraMemberSize(CRef) +
-           GetExtraMemberSize(AggrNm) +
-           GetExtraMemberSize(ExeTm);
+           TMemUtils::GetExtraMemberSize(CRef) +
+           TMemUtils::GetExtraMemberSize(AggrNm) +
+           TMemUtils::GetExtraMemberSize(ExeTm);
 }
 
 ///////////////////////////////

--- a/src/qminer/qminer_core.h
+++ b/src/qminer/qminer_core.h
@@ -1314,6 +1314,8 @@ public:
     /// Calls the filter, default keeps all records
     virtual bool Filter(const TRec& Rec) const { return true; }
 
+    /// Retuns the memory footprint
+    virtual uint64 GetMemUsed() const { return sizeof(TRecFilter); }
     /// Filter type name
     static TStr GetType() { return "trivial"; }
     /// Filter type name

--- a/src/qminer/qminer_core.h
+++ b/src/qminer/qminer_core.h
@@ -3505,6 +3505,8 @@ public:
     virtual void PrintStat() const { }
     /// Serialization current status to JSon
     virtual PJsonVal SaveJson(const int& Limit) const = 0;
+    /// Returns the memory footprint (the number of bytes) of the aggregate
+    virtual uint64 GetMemUsed() const;
     /// Get access to the timmer
     const TAggrExeTm& GetExeTm() const { return ExeTm; }
 

--- a/src/qminer/qminer_ftr.cpp
+++ b/src/qminer/qminer_ftr.cpp
@@ -993,8 +993,10 @@ TMultinomial::TMultinomial(const TWPt<TBase>& Base, const PJsonVal& ParamVal): T
     }
     // prase out feature generator parameters
     const bool NormalizeP = ParamVal->GetObjBool("normalize", false);
-    const bool BinaryP = ParamVal->GetObjBool("binary", false);
-    const bool LogP = ParamVal->GetObjBool("log", false);
+    const bool BinaryP =
+                         ParamVal->GetObjBool("binary", false) ||   // XXX binary: true is deprecated, should use transform: 'binary' instead
+                         ParamVal->GetObjStr("transform", "") == "binary";
+    const bool LogP = ParamVal->GetObjStr("transform", "") == "log";
     if (ParamVal->IsObjKey("values")) {
         // we have fixed values
         TStrV ValV; ParamVal->GetObjStrV("values", ValV);

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -42,7 +42,7 @@ endif
 CXXFLAGS += -std=c++11 -Wall -O3 -DNDEBUG
 CXXFLAGS += -I$(GLIB_DIR)base -I$(GLIB_DIR)mine -I$(SOLE_DIR) -I$(QMINER_DIR)
 
-# ling with gtest
+# link with gtest
 LIBS += -lgtest
 
 ## Main application file

--- a/test/cpp/Makefile
+++ b/test/cpp/Makefile
@@ -53,6 +53,7 @@ TEST_SRCS = test-TStr.cpp
 TEST_SRCS += test-THash.cpp 
 TEST_SRCS += test-TQQueue.cpp 
 TEST_SRCS += test-sizeof.cpp
+TEST_SRCS += test-traits.cpp
 
 # transform to list of object files
 TEST_OBJS = $(TEST_SRCS:.cpp=.o)

--- a/test/cpp/install_linux.sh
+++ b/test/cpp/install_linux.sh
@@ -1,13 +1,23 @@
-# download
-wget http://googletest.googlecode.com/files/gtest-1.7.0.zip
-unzip gtest-1.7.0.zip
+#!/bin/bash
 
-# build
-cd gtest-1.7.0
-./configure
+git clone git@github.com:google/googletest.git
+
+pushd . > /dev/null
+
+cd googletest/googletest
+
+# link the headers to the include directory
+pushd . > /dev/null
+cd include
+sudo ln -s `pwd`/gtest /usr/include/gtest
+popd > /dev/null
+
+# link the libraries
+pushd . > /dev/null
+cd make
 make
+ar -rv libgtest.a gtest-all.o
+sudo ln -s `pwd`/libgtest.a /usr/lib
+popd > /dev/null
 
-# install
-sudo cp -a include/gtest /usr/include
-sudo cp -a lib/.libs/* /usr/lib/
-sudo ldconfig -v | grep gtest
+popd > /dev/null

--- a/test/cpp/test-sizeof.cpp
+++ b/test/cpp/test-sizeof.cpp
@@ -52,11 +52,41 @@ TEST(sizeof, BasicStructures) {
 }
 
 TEST(sizeof, QMiner) {
-    ASSERT_EQ(sizeof(TQm::TRec), 216);
+    /* ASSERT_EQ(sizeof(TQm::TRec), 216); */ // TODO check on Mac and Windows
+    ASSERT_EQ(sizeof(TQm::TRec), 200);
     ASSERT_EQ(sizeof(TQm::TRecSet), 56);
     ASSERT_EQ(sizeof(TQm::TRecFilter), 24);
     ASSERT_EQ(sizeof(TQm::TAggr), 32);
-    ASSERT_EQ(sizeof(TQm::TStreamAggr), 32);
+    ASSERT_EQ(sizeof(TQm::TStreamAggr), 40);
     ASSERT_EQ(sizeof(TQm::TFtrExt), 80);
     ASSERT_EQ(sizeof(TQm::TFtrSpace), 72);
+}
+
+TEST(GetMemUsedDeep, TVec) {
+    const TStr TargetStr = "abcdefg";
+    const int NVecs = 4;
+    const int StrMemUsed = TargetStr.GetMemUsed();
+    const int VecMem = sizeof(TVec<TInt>) + NVecs*StrMemUsed;
+    const int VVecMem = sizeof(TVec<TIntV>) + NVecs*VecMem;
+    const int VVVecMem = sizeof(TVec<TVec<TIntV>>) + NVecs*VVecMem;
+
+    TStrV StrV(NVecs);
+    TVec<TStrV> StrVV(NVecs);
+    TVec<TVec<TStrV>> StrVVV(NVecs);
+
+    for (int i = 0; i < NVecs; i++) {
+        StrV[i] = TargetStr;
+    }
+
+    for (int i = 0; i < NVecs; i++) {
+        StrVV[i] = StrV;
+    }
+
+    for (int i = 0; i < NVecs; i++) {
+        StrVVV[i] = StrVV;
+    }
+
+    ASSERT_EQ(StrV.GetMemUsedDeep(), VecMem);
+    ASSERT_EQ(StrVV.GetMemUsedDeep(), VVecMem);
+    ASSERT_EQ(StrVVV.GetMemUsedDeep(), VVVecMem);
 }

--- a/test/cpp/test-sizeof.cpp
+++ b/test/cpp/test-sizeof.cpp
@@ -57,6 +57,7 @@ TEST(sizeof, QMiner) {
     ASSERT_EQ(sizeof(TQm::TRecSet), 56);
     ASSERT_EQ(sizeof(TQm::TRecFilter), 24);
     ASSERT_EQ(sizeof(TQm::TAggr), 32);
+    /* ASSERT_EQ(sizeof(TQm::TStreamAggr), 32); */
     ASSERT_EQ(sizeof(TQm::TStreamAggr), 40);
     ASSERT_EQ(sizeof(TQm::TFtrExt), 80);
     ASSERT_EQ(sizeof(TQm::TFtrSpace), 72);

--- a/test/cpp/test-traits.cpp
+++ b/test/cpp/test-traits.cpp
@@ -1,0 +1,46 @@
+/**
+* Copyright (c) 2015, Jozef Stefan Institute, Quintelligence d.o.o. and contributors
+* All rights reserved.
+*
+* This source code is licensed under the FreeBSD license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+#include <base.h>
+
+///////////////////////////////////////////////////////////////////////////////
+// Google Test
+#include "gtest/gtest.h"
+
+#ifdef WIN32
+#ifdef _DEBUG
+#define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
+#define new DEBUG_NEW
+#endif
+#endif
+
+#ifdef GLib_CPP11
+
+// test that glib numeric types have standard layouts
+TEST(is_standard_layout, TNum) {
+    // integers
+    ASSERT_TRUE(std::is_standard_layout<TInt>::value);
+    ASSERT_TRUE(std::is_standard_layout<TUInt>::value);
+    ASSERT_TRUE(std::is_standard_layout<TUSInt>::value);
+    ASSERT_TRUE(std::is_standard_layout<TUInt64>::value);
+    // real numbers
+    ASSERT_TRUE(std::is_standard_layout<TFlt>::value);
+}
+
+// characters
+TEST(is_standard_layout, TCh) {
+    ASSERT_TRUE(std::is_standard_layout<TCh>::value);
+    ASSERT_TRUE(std::is_standard_layout<TUCh>::value);
+}
+
+// boolean
+TEST(is_standard_layout, TBool) {
+    ASSERT_TRUE(std::is_standard_layout<TBool>::value);
+}
+
+#endif

--- a/test/nodejs/featurespace.js
+++ b/test/nodejs/featurespace.js
@@ -229,7 +229,7 @@ describe('Feature Space Tests', function () {
                 source: "FtrSpaceTest",
                 field: "Categories",
                 values: ["a", "b", "c", "q", "w", "e"],
-                log: true
+                transform: 'log'
             });
             var vec = ftr.extractVector(Store[0]);
 
@@ -239,18 +239,6 @@ describe('Feature Space Tests', function () {
             for (var i = 0; i < expected.length; i++) {
                 assert.equal(vec[i], Math.log(expected[i] + 1));
             }
-        })
-        it('should not allow exclusive binary and log transformations', function () {
-            assert.throws(function () {
-                var ftr = new qm.FeatureSpace(base, {
-                    type: "multinomial",
-                    source: "FtrSpaceTest",
-                    field: "Categories",
-                    values: ["a", "b", "c", "q", "w", "e"],
-                    log: true,
-                    binary: true
-                });
-            });
         })
         it('should return a vector for the first record in store: multinomial', function () {
             var ftr = new qm.FeatureSpace(base, { type: "multinomial", source: "FtrSpaceTest", field: "Categories", valueField: "Values", values: ["a", "b", "c", "q", "w", "e"] });


### PR DESCRIPTION
- calculation of the memory footprint for stream aggregates
- fixed GetMemUsedDeep in TVec (only for C++11)
- fixed cpp unit tests on linux
- deprecated 'binary: true' in multinomial feature extractor (should use 'transform: "binary"')
- added log transformation to multinomial feature extractor