### PR TITLE
Bugfix for TNodeJsRecSet::getVector and corresponding unit tests.

### DIFF
--- a/src/nodejs/qm/qm_nodejs.cpp
+++ b/src/nodejs/qm/qm_nodejs.cpp
@@ -3230,88 +3230,120 @@ void TNodeJsRecSet::getVector(const v8::FunctionCallbackInfo<v8::Value>& Args) {
         }
         Args.GetReturnValue().Set(TNodeJsVec<TInt, TAuxIntV>::New(ColV));
         return;
-    }
-    else if (Desc.IsInt16()) {
-        TIntV ColV(Recs);
+    } else if (Desc.IsInt16()) {
+        TIntV ColV(Recs, 0);
         for (int RecN = 0; RecN < Recs; RecN++) {
-            ColV[RecN] = Store->GetFieldInt16(RecSet()->GetRecId(RecN), FieldId);
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                ColV.Add(Store->GetFieldInt16(RecId, FieldId));
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TInt, TAuxIntV>::New(ColV));
         return;
     } else if (Desc.IsInt64()) {
-        TFltV ColV(Recs);
+        TFltV ColV(Recs, 0);
         for (int RecN = 0; RecN < Recs; RecN++) {
-            ColV[RecN] = (double)Store->GetFieldInt64(RecSet()->GetRecId(RecN), FieldId);
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                ColV.Add((double)Store->GetFieldInt64(RecId, FieldId));
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TFlt, TAuxFltV>::New(ColV));
         return;
     } else if (Desc.IsByte()) {
-        TIntV ColV(Recs);
+        TIntV ColV(Recs, 0);
         for (int RecN = 0; RecN < Recs; RecN++) {
-            ColV[RecN] = Store->GetFieldByte(RecSet()->GetRecId(RecN), FieldId);
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                ColV.Add(Store->GetFieldByte(RecId, FieldId));
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TInt, TAuxIntV>::New(ColV));
         return;
     } else if (Desc.IsUInt()) {
-        TFltV ColV(Recs);
+        TFltV ColV(Recs, 0);
         for (int RecN = 0; RecN < Recs; RecN++) {
-            ColV[RecN] = (double)Store->GetFieldUInt(RecSet()->GetRecId(RecN), FieldId);
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                ColV.Add((double)Store->GetFieldUInt(RecId, FieldId));
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TFlt, TAuxFltV>::New(ColV));
         return;
     } else if (Desc.IsUInt16()) {
-        TFltV ColV(Recs);
+        TFltV ColV(Recs, 0);
         for (int RecN = 0; RecN < Recs; RecN++) {
-            ColV[RecN] = (double)Store->GetFieldUInt16(RecSet()->GetRecId(RecN), FieldId);
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                ColV.Add((double)Store->GetFieldUInt16(RecId, FieldId));
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TFlt, TAuxFltV>::New(ColV));
         return;
     } else if (Desc.IsUInt64()) {
-        TFltV ColV(Recs);
+        TFltV ColV(Recs, 0);
         for (int RecN = 0; RecN < Recs; RecN++) {
-            ColV[RecN] = (double)Store->GetFieldUInt64(RecSet()->GetRecId(RecN), FieldId);
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                ColV.Add((double)Store->GetFieldUInt64(RecId, FieldId));
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TFlt, TAuxFltV>::New(ColV));
         return;
     }
     else if (Desc.IsStr()) {
-        TStrV ColV(Recs);
+        TStrV ColV(Recs, 0);
         for (int RecN = 0; RecN < Recs; RecN++) {
-            ColV[RecN] = Store->GetFieldStr(RecSet()->GetRecId(RecN), FieldId);
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                ColV.Add(Store->GetFieldStr(RecId, FieldId));
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TStr, TAuxStrV>::New(ColV));
         return;
     }
     else if (Desc.IsBool()) {
-        TIntV ColV(Recs);
+        TIntV ColV(Recs, 0);
         for (int RecN = 0; RecN < Recs; RecN++) {
-            ColV[RecN] = (int)Store->GetFieldBool(RecSet()->GetRecId(RecN), FieldId);
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                ColV.Add((int)Store->GetFieldBool(RecId, FieldId));
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TInt, TAuxIntV>::New(ColV));
         return;
     }
     else if (Desc.IsFlt()) {
-        TFltV ColV(Recs);
+        TFltV ColV(Recs, 0);
         for (int RecN = 0; RecN < Recs; RecN++) {
-            ColV[RecN] = Store->GetFieldFlt(RecSet()->GetRecId(RecN), FieldId);
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                ColV.Add(Store->GetFieldFlt(RecId, FieldId));
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TFlt, TAuxFltV>::New(ColV));
         return;
     }
     else if (Desc.IsSFlt()) {
-        TFltV ColV(Recs);
+        TFltV ColV(Recs, 0);
         for (int RecN = 0; RecN < Recs; RecN++) {
-            ColV[RecN] = Store->GetFieldSFlt(RecSet()->GetRecId(RecN), FieldId);
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                ColV.Add(Store->GetFieldSFlt(RecId, FieldId));
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TFlt, TAuxFltV>::New(ColV));
         return;
     }
     else if (Desc.IsTm()) {
-        TFltV ColV(Recs);
+        TFltV ColV(Recs, 0);
         TTm Tm;
         for (int RecN = 0; RecN < Recs; RecN++) {
-            Store->GetFieldTm(RecSet()->GetRecId(RecN), FieldId, Tm);
-            ColV[RecN] = (double)TTm::GetMSecsFromTm(Tm);   // TODO is this correct?? Shouldn't it be UNIX timestamp???
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                Store->GetFieldTm(RecSet()->GetRecId(RecN), FieldId, Tm);
+                ColV.Add((double)TTm::GetMSecsFromTm(Tm)); // TODO is this correct?? Shouldn't it be UNIX timestamp???
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TFlt, TAuxFltV>::New(ColV));
         return;

--- a/src/nodejs/qm/qm_nodejs.cpp
+++ b/src/nodejs/qm/qm_nodejs.cpp
@@ -3221,9 +3221,12 @@ void TNodeJsRecSet::getVector(const v8::FunctionCallbackInfo<v8::Value>& Args) {
     const TQm::TFieldDesc& Desc = Store->GetFieldDesc(FieldId);
 
     if (Desc.IsInt()) {
-        TIntV ColV(Recs);
+        TIntV ColV(Recs, 0);
         for (int RecN = 0; RecN < Recs; RecN++) {
-            ColV[RecN] = Store->GetFieldInt(RecSet()->GetRecId(RecN), FieldId);
+            const uint64 RecId = RecSet()->GetRecId(RecN);
+            if (!Store->IsFieldNull(RecId, FieldId)) {
+                ColV.Add(Store->GetFieldInt(RecId, FieldId));
+            }
         }
         Args.GetReturnValue().Set(TNodeJsVec<TInt, TAuxIntV>::New(ColV));
         return;

--- a/test/nodejs/recordset.js
+++ b/test/nodejs/recordset.js
@@ -61,7 +61,18 @@ function TStore() {
         "fields": [
             { "name": "Name", "type": "string", "primary": true },
             { "name": "Tm", "type": "datetime" },
-            { "name": "Id", "type": "int", "null": true }
+            { "name": "Id1", "type": "int", "null": true },
+            { "name": "Id2", "type": "int16", "null": true },
+            { "name": "Id3", "type": "int64", "null": true },
+            { "name": "Id4", "type": "byte", "null": true },
+            { "name": "Id5", "type": "uint", "null": true },
+            { "name": "Id6", "type": "uint16", "null": true },
+            { "name": "Id7", "type": "uint64", "null": true },
+            { "name": "Id8", "type": "string", "null": true },
+            { "name": "Id9", "type": "bool", "null": true },
+            { "name": "Id10", "type": "float", "null": true },
+            { "name": "Id11", "type": "sfloat", "null": true },
+            { "name": "Id12", "type": "datetime", "null": true }
         ]
     }]);
     // adding two persons
@@ -86,7 +97,7 @@ function TStore() {
     this.base.store("TestStore").push({ "Name": "Goran Dragic", "Tm": "2015-06-01T00:00:00" });
 	this.base.store("TestStore").push({ "Name": "Michael Jordan", "Tm": "2015-06-01T00:00:01" });
 	this.base.store("TestStore").push({ "Name": "Marko Milic", "Tm": "2015-06-01T00:00:05" });
-    this.base.store("TestStore").push({ "Name": "Marko Aznur", "Tm": "2015-06-01T00:00:05", "Id": 5 });
+    this.base.store("TestStore").push({ "Name": "Marko Aznur", "Tm": "2015-06-01T00:00:05", "Id1": 5, "Id2": 5, "Id3": 5, "Id4": 5, "Id5": 5, "Id6": 5, "Id7": 5, "Id8": "5", "Id9": true, "Id10": 5, "Id11": 5, "Id12": 1503696242914});
 
     this.close = function () {
         this.base.close();
@@ -699,9 +710,10 @@ describe('Record Set Tests', function () {
             assert.equal(arr[1], 2006);
         })
         it('should return the vector with only non-null elements', function () {
-            var arr = recSet5.getVector("Id");
-            assert.equal(arr.length, 1);
-            assert.equal(arr[0], 5);
+            for (let i = 1; i < 13; i++) {
+                var arr = recSet5.getVector("Id" + i);
+                assert.equal(arr.length, 1);
+            }
         })
         it('should throw an exception, if parameter is not a legit field', function () {
             assert.throws(function () {

--- a/test/nodejs/recordset.js
+++ b/test/nodejs/recordset.js
@@ -60,7 +60,8 @@ function TStore() {
         "name": "TestStore",
         "fields": [
             { "name": "Name", "type": "string", "primary": true },
-            { "name": "Tm", "type": "datetime" }
+            { "name": "Tm", "type": "datetime" },
+            { "name": "Id", "type": "int", "null": true }
         ]
     }]);
     // adding two persons
@@ -85,6 +86,7 @@ function TStore() {
     this.base.store("TestStore").push({ "Name": "Goran Dragic", "Tm": "2015-06-01T00:00:00" });
 	this.base.store("TestStore").push({ "Name": "Michael Jordan", "Tm": "2015-06-01T00:00:01" });
 	this.base.store("TestStore").push({ "Name": "Marko Milic", "Tm": "2015-06-01T00:00:05" });
+    this.base.store("TestStore").push({ "Name": "Marko Aznur", "Tm": "2015-06-01T00:00:05", "Id": 5 });
 
     this.close = function () {
         this.base.close();
@@ -439,11 +441,11 @@ describe('Record Set Tests', function () {
         })
         it('should handle request if the second parameter is missing - datetime', function () {
             recSet5.filterByField("Tm", "2015-06-01T00:00:01");
-            assert.equal(recSet5.length, 2);
+            assert.equal(recSet5.length, 3);
         })
         it('should handle request if the second parameter is null - datetime', function () {
             recSet5.filterByField("Tm", "2015-06-01T00:00:01", null);
-            assert.equal(recSet5.length, 2);
+            assert.equal(recSet5.length, 3);
         })
         it('should handle request if the first parameter is null - datetime', function () {
             recSet5.filterByField("Tm", null, "2015-06-01T00:00:01");
@@ -695,6 +697,11 @@ describe('Record Set Tests', function () {
             assert.equal(arr.length, 2);
             assert.equal(arr[0], 2010);
             assert.equal(arr[1], 2006);
+        })
+        it('should return the vector with only non-null elements', function () {
+            var arr = recSet5.getVector("Id");
+            assert.equal(arr.length, 1);
+            assert.equal(arr[0], 5);
         })
         it('should throw an exception, if parameter is not a legit field', function () {
             assert.throws(function () {

--- a/test/nodejs/recordset.js
+++ b/test/nodejs/recordset.js
@@ -710,7 +710,7 @@ describe('Record Set Tests', function () {
             assert.equal(arr[1], 2006);
         })
         it('should return the vector with only non-null elements', function () {
-            for (let i = 1; i < 13; i++) {
+            for (var i = 1; i < 13; i++) {
                 var arr = recSet5.getVector("Id" + i);
                 assert.equal(arr.length, 1);
             }


### PR DESCRIPTION
For stores that allow null fields in their schema, calling getVector on a rec set crashed qminer because it was trying to retrieve null elements. Now we first check through RecId and FieldId if the element is null and add it otherwise.