### PR TITLE
Fixed #550: no frequency for tiny joins

### DIFF
--- a/src/qminer/qminer_core.cpp
+++ b/src/qminer/qminer_core.cpp
@@ -5599,19 +5599,18 @@ bool TIndex::DoQuerySmall(const TPt<TQmGixExpItemSmall>& ExpItem, TVec<TQmGixIte
     for (const TQmGixItemSmall& SmallRecIdFq : SmallRecIdFqV) {
         RecIdFqV.Add(TQmGixItemFull((uint64)SmallRecIdFq.Key, (int)SmallRecIdFq.Dat));
     }
+    // make sure we are sorted
+    Assert(RecIdFqV.IsSorted());
     // pass forward return result
     return Not;
 }
 
 bool TIndex::DoQueryTiny(const TPt<TQmGixExpItemTiny>& ExpItem, TVec<TQmGixItemFull>& RecIdFqV) const {
-    // execute query
-    TVec<TQmGixItemTiny> TinyRecIdV;
-    const bool Not = ExpItem->Eval(GixTiny, TinyRecIdV, MergerTiny);
-    // upgrade to full
-    RecIdFqV.Gen(TinyRecIdV.Len(), 0);
-    for (const TQmGixItemTiny& TinyRecId : TinyRecIdV) {
-        RecIdFqV.Add(TQmGixItemFull((uint64)TinyRecId, 1));
-    }
+    // clean if there is anything on the input
+    RecIdFqV.Clr();
+    const bool Not = ExpItem->Eval(GixTiny, RecIdFqV, MergerTiny);
+    // make sure we are sorted
+    Assert(RecIdFqV.IsSorted());
     // pass forward return result
     return Not;
 }
@@ -5700,21 +5699,25 @@ TIndex::TIndex(const TStr& _IndexFPath, const TFAccess& _Access, const PIndexVoc
     IndexFPath = _IndexFPath;
     Access = _Access;
     // initialize full invered index
-    SumMergerFull = new TQmGixSumMerger<TQmGixItemFull>;
+    SumItemHandlerFull = new TQmGixSumItemHandler<TQmGixItemFull>;
     GixFull = TGix<TQmGixKey, TQmGixItemFull>::New("Index.GixFull",
-        IndexFPath, Access, SumMergerFull, CacheSizeFull, SplitLen);
+        IndexFPath, Access, SumItemHandlerFull, CacheSizeFull, SplitLen);
+    SumMergerFull = new TQmGixSumWithFqMerger<TQmGixItemFull>;
     // initialize small inverted index
-    SumMergerSmall = new TQmGixSumMerger<TQmGixItemSmall>;
+    SumItemHandlerSmall = new TQmGixSumItemHandler<TQmGixItemSmall>;
     GixSmall = TGix<TQmGixKey, TQmGixItemSmall>::New("Index.GixSmall",
-        IndexFPath, Access, SumMergerSmall, CacheSizeSmall, SplitLen);
+        IndexFPath, Access, SumItemHandlerSmall, CacheSizeSmall, SplitLen);
+    SumMergerSmall = new TQmGixSumWithFqMerger<TQmGixItemSmall>;
     // initialize tiny inverted index
-    MergerTiny = new TGixDefMerger<TQmGixKey, TQmGixItemTiny>;
+    ItemHandlerTiny = new TGixDefItemHandler<TQmGixKey, TQmGixItemTiny>;
     GixTiny = TGix<TQmGixKey, TQmGixItemTiny>::New("Index.GixTiny",
-        IndexFPath, Access, MergerTiny, CacheSizeTiny, SplitLen);
+        IndexFPath, Access, ItemHandlerTiny, CacheSizeTiny, SplitLen);
+    MergerTiny = new TQmGixSumWithoutFqMerger<TQmGixItemTiny, TQmGixItemFull>;
     // initialize position inverted index
-    MergerPos = new TGixDefMerger<TQmGixKey, TQmGixItemPos>;
+    ItemHandlerPos = new TGixDefItemHandler<TQmGixKey, TQmGixItemPos>;
     GixPos = TGix<TQmGixKey, TQmGixItemPos>::New("Index.GixPos",
-        IndexFPath, Access, MergerPos, CacheSizePos, SplitLen);
+        IndexFPath, Access, ItemHandlerPos, CacheSizePos, SplitLen);
+    MergerPos = new TGixDefMerger<TQmGixKey, TQmGixItemPos, TQmGixItemPos>;
     // initialize location index
     TStr SphereFNm = IndexFPath + "Index.Geo";
     if (TFile::Exists(SphereFNm) && Access != faCreate) {
@@ -5752,15 +5755,19 @@ TIndex::~TIndex() {
         {
             TEnv::Logger->OnStatus("Saving and closing inverted index - full");
             GixFull.Clr();
+            delete SumItemHandlerFull;
             delete SumMergerFull;
             TEnv::Logger->OnStatus("Saving and closing inverted index - small");
             GixSmall.Clr();
+            delete SumItemHandlerSmall;
             delete SumMergerSmall;
             TEnv::Logger->OnStatus("Saving and closing inverted index - tiny");
             GixTiny.Clr();
+            delete ItemHandlerTiny;
             delete MergerTiny;
             TEnv::Logger->OnStatus("Saving and closing inverted index - position");
             GixPos.Clr();
+            delete ItemHandlerPos;
             delete MergerPos;
         }
         {
@@ -5784,6 +5791,15 @@ TIndex::~TIndex() {
         TEnv::Logger->OnStatus("Index closed");
     } else {
         TEnv::Logger->OnStatus("Index opened in read-only mode, no saving needed");
+        // we still need to delete all item handlers and mergers
+        delete SumItemHandlerFull;
+        delete SumMergerFull;
+        delete SumItemHandlerSmall;
+        delete SumMergerSmall;
+        delete ItemHandlerTiny;
+        delete MergerTiny;
+        delete ItemHandlerPos;
+        delete MergerPos;
     }
 }
 
@@ -6265,17 +6281,6 @@ void TIndex::SearchGixJoin(const int& KeyId, const uint64& RecId, TUInt64IntKdV&
     }
 }
 
-PRecSet TIndex::SearchTextPos(const TWPt<TBase>& Base, const int& KeyId,
-        const TUInt64V& WordIdV, const int& MaxDiff) const {
-
-    // execute query
-    TUInt64IntKdV RecIdFqV; DoQueryPos(KeyId, WordIdV, MaxDiff, RecIdFqV);
-    // wrap as record set and return
-    const uint StoreId = IndexVoc->GetKey(KeyId).GetStoreId();
-    return TRecSet::New(Base->GetStoreByStoreId(StoreId), RecIdFqV);
-}
-
-
 void TIndex::SearchGixJoin(const int& KeyId, const TUInt64V& RecIdV, TUInt64IntKdV& JoinRecIdFqV) const {
     // prepare keys for gix
     TKeyWordV KeyWordV(RecIdV.Len(), 0);
@@ -6295,6 +6300,16 @@ void TIndex::SearchGixJoin(const int& KeyId, const TUInt64V& RecIdV, TUInt64IntK
     default:
         throw TQmExcept::New("[TIndex::SearchGixJoin] Unsupported gix type!");
     }
+}
+
+PRecSet TIndex::SearchTextPos(const TWPt<TBase>& Base, const int& KeyId,
+        const TUInt64V& WordIdV, const int& MaxDiff) const {
+
+    // execute query
+    TUInt64IntKdV RecIdFqV; DoQueryPos(KeyId, WordIdV, MaxDiff, RecIdFqV);
+    // wrap as record set and return
+    const uint StoreId = IndexVoc->GetKey(KeyId).GetStoreId();
+    return TRecSet::New(Base->GetStoreByStoreId(StoreId), RecIdFqV);
 }
 
 PRecSet TIndex::SearchGeoRange(const TWPt<TBase>& Base, const int& KeyId,
@@ -6973,7 +6988,7 @@ TBase::TBase(const TStr& _FPath, const int64& IndexCacheSize, const TStrUInt64H&
     TEnv::Logger->OnStatus("Opening in create mode");
     // prepare index
     IndexVoc = TIndexVoc::New();
-    Index = TIndex::New(FPath, FAccess, IndexVoc, 
+    Index = TIndex::New(FPath, FAccess, IndexVoc,
         IndexTypeCacheSizeH.GetDatOrDef("full", IndexCacheSize),
         IndexTypeCacheSizeH.GetDatOrDef("small", IndexCacheSize),
         IndexTypeCacheSizeH.GetDatOrDef("tiny", IndexCacheSize),
@@ -7007,11 +7022,11 @@ TBase::TBase(const TStr& _FPath, const TFAccess& _FAccess, const int64& IndexCac
 
     // load index
     IndexVoc = TIndexVoc::Load(IndexVocFIn);
-    Index = TIndex::New(FPath, FAccess, IndexVoc, 
+    Index = TIndex::New(FPath, FAccess, IndexVoc,
         IndexTypeCacheSizeH.GetDatOrDef("full", IndexCacheSize),
         IndexTypeCacheSizeH.GetDatOrDef("small", IndexCacheSize),
         IndexTypeCacheSizeH.GetDatOrDef("tiny", IndexCacheSize),
-        IndexTypeCacheSizeH.GetDatOrDef("pos", IndexCacheSize), 
+        IndexTypeCacheSizeH.GetDatOrDef("pos", IndexCacheSize),
         SplitLen);
     // load shared store blob base
     StoreBlobBs = TMBlobBs::New(FPath + "StoreBlob", FAccess);

--- a/src/qminer/qminer_core.h
+++ b/src/qminer/qminer_core.h
@@ -3057,7 +3057,7 @@ private:
     };
 
     /// Merger which sums up the frequencies of items.
-    /// Assumes TGixResItem is a TPair< , >.
+    /// Assumes TGixResItem is a TKeyDat< , >.
     template <class TQmGixItem, class TQmGixResItem>
     class TQmGixSumMerger : public TGixMerger<TQmGixKey, TQmGixItem, TQmGixResItem> {
     public:

--- a/src/qminer/qminer_core.h
+++ b/src/qminer/qminer_core.h
@@ -3039,23 +3039,12 @@ private:
     /// We are indexing by (KeyId, WordId) pairs
     typedef TKeyWord TQmGixKey;
 
-    /// Merger which sums up the frequencies of items
+    /// ItemHandler which sums up the frequencies of items
     template <class TQmGixItem>
-    class TQmGixSumMerger : public TGixMerger<TQmGixKey, TQmGixItem> {
+    class TQmGixSumItemHandler : public TGixItemHandler<TQmGixKey, TQmGixItem> {
     public:
-        /// Union sums up frequencies of overlapping items
-        void Union(TVec<TQmGixItem>& MainV, const TVec<TQmGixItem>& JoinV) const;
-        /// Intersection sums up frequencies of overlapping items
-        void Intrs(TVec<TQmGixItem>& MainV, const TVec<TQmGixItem>& JoinV) const;
-        /// Minus does not deal with frequencies
-        void Minus(const TVec<TQmGixItem>& MainV, const TVec<TQmGixItem>& JoinV, TVec<TQmGixItem>& ResV) const;
-
-        /// No initialization necessary
-        void Def(const TQmGixKey& Key, TVec<TQmGixItem>& MainV) const { }
-
         /// Merge given items when they have same record ID. Frequency is sumed together
         void Merge(TVec<TQmGixItem>& ItemV, const bool& IsLocal) const;
-
         /// Remove given item from the list
         void Delete(const TQmGixItem& Item, TVec<TQmGixItem>& MainV) const { return MainV.DelAll(Item); }
         /// < comparator between items
@@ -3064,23 +3053,58 @@ private:
         bool IsLtE(const TQmGixItem& Item1, const TQmGixItem& Item2) const { return Item1 <= Item2; }
 
         /// Memory footprint
-        uint64 GetMemUsed() const { return sizeof(TQmGixSumMerger<TQmGixItem>); }
+        uint64 GetMemUsed() const { return sizeof(TQmGixSumItemHandler<TQmGixItem>); }
+    };
+
+    /// Merger which sums up the frequencies of items.
+    /// Assumes TGixResItem is a TPair< , >.
+    template <class TQmGixItem, class TQmGixResItem>
+    class TQmGixSumMerger : public TGixMerger<TQmGixKey, TQmGixItem, TQmGixResItem> {
+    public:
+        /// Union sums up frequencies of overlapping items
+        void Union(TVec<TQmGixResItem>& MainV, const TVec<TQmGixResItem>& JoinV) const;
+        /// Intersection sums up frequencies of overlapping items
+        void Intrs(TVec<TQmGixResItem>& MainV, const TVec<TQmGixResItem>& JoinV) const;
+        /// Minus does not deal with frequencies
+        void Minus(const TVec<TQmGixResItem>& MainV, const TVec<TQmGixResItem>& JoinV, TVec<TQmGixResItem>& ResV) const;
+    };
+
+    /// Specialization for case when TQmGixItem == TQmGixResItem.
+    template <class TQmGixItem>
+    class TQmGixSumWithFqMerger : public TQmGixSumMerger<TQmGixItem, TQmGixItem> {
+    public:
+        /// Move MainV to ResV since no changes needed
+        void Def(const TQmGixKey& Key, TVec<TQmGixItem>& MainV, TVec<TQmGixItem>& ResV) const;
+
+        /// Memory footprint
+        uint64 GetMemUsed() const { return sizeof(TQmGixSumWithFqMerger<TQmGixItem>); }
+    };
+
+    /// Specialization for case when index has implied frequency of 1 (e.g. tiny)
+    template <class TQmGixItem, class TQmGixResItem>
+    class TQmGixSumWithoutFqMerger : public TQmGixSumMerger<TQmGixItem, TQmGixResItem> {
+    public:
+        /// Copy MainV to ResV and init frequency to 1
+        void Def(const TQmGixKey& Key, TVec<TQmGixItem>& MainV, TVec<TQmGixResItem>& ResV) const;
+
+        /// Memory footprint
+        uint64 GetMemUsed() const { return sizeof(TQmGixSumWithoutFqMerger<TQmGixItem, TQmGixResItem>); }
     };
 
     /// Normal version of inverted index contains full record ID and frequency count values
     typedef TKeyDat<TUInt64, TInt> TQmGixItemFull; // [RecId, Freq]
     /// Expression for executing gix queries for full records
-    typedef TGixExpItem<TQmGixKey, TQmGixItemFull> TQmGixExpItemFull;
+    typedef TGixExpItem<TQmGixKey, TQmGixItemFull, TQmGixItemFull> TQmGixExpItemFull;
 
     /// Small version of inverted index which works when we have less then 2^32 records
     typedef TKeyDat<TUInt, TSInt> TQmGixItemSmall; // [RecId, Freq]
     /// Expression for executing gix queries for small records
-    typedef TGixExpItem<TQmGixKey, TQmGixItemSmall > TQmGixExpItemSmall;
+    typedef TGixExpItem<TQmGixKey, TQmGixItemSmall, TQmGixItemSmall> TQmGixExpItemSmall;
 
     /// Tiny version of inverted index which works when we have less then 2^32 records
     typedef TUInt TQmGixItemTiny; // [RecId]
     /// Expression for executing gix queries for tiny records
-    typedef TGixExpItem<TQmGixKey, TQmGixItemTiny > TQmGixExpItemTiny;
+    typedef TGixExpItem<TQmGixKey, TQmGixItemTiny, TQmGixItemFull> TQmGixExpItemTiny;
 
     /// Giving pretty names to GIX keys when printing debug statistics
     class TQmGixKeyStr : public TGixKeyStr<TQmGixKey> {
@@ -3176,10 +3200,12 @@ private:
         uint64 GetMemUsed() const { return sizeof(TQmGixItemPos); }
     };
 
+    /// ItemHandler for combining position records
+    typedef TGixDefItemHandler<TQmGixKey, TQmGixItemPos> TQmGixItemHandlerPos;
     /// Merger for combining position records
-    typedef TGixDefMerger<TQmGixKey, TQmGixItemPos> TQmGixMergerPos;
+    typedef TGixDefMerger<TQmGixKey, TQmGixItemPos, TQmGixItemPos> TQmGixMergerPos;
     /// Expression for executing gix position queries
-    typedef TGixExpItem<TQmGixKey, TQmGixItemPos> TQmGixExpItemPos;
+    typedef TGixExpItem<TQmGixKey, TQmGixItemPos, TQmGixItemPos> TQmGixExpItemPos;
 
 private:
     // b-tree definitions
@@ -3233,14 +3259,24 @@ private:
 
     /// Index Vocabulary
     PIndexVoc IndexVoc;
+
+    /// Inverted Index Default ItemHandler Full
+    const TGixItemHandler<TQmGixKey, TQmGixItemFull>* SumItemHandlerFull;
+    /// Inverted Index Default ItemHandler Small
+    const TGixItemHandler<TQmGixKey, TQmGixItemSmall>* SumItemHandlerSmall;
+    /// Inverted Index Default ItemHandler Tiny
+    const TGixItemHandler<TQmGixKey, TQmGixItemTiny>* ItemHandlerTiny;
+    /// Inverted Index Default ItemHandler Position
+    const TGixItemHandler<TQmGixKey, TQmGixItemPos>* ItemHandlerPos;
+
     /// Inverted Index Default Merger Full
-    const TGixMerger<TQmGixKey, TQmGixItemFull>* SumMergerFull;
+    const TGixMerger<TQmGixKey, TQmGixItemFull, TQmGixItemFull>* SumMergerFull;
     /// Inverted Index Default Merger Small
-    const TGixMerger<TQmGixKey, TQmGixItemSmall>* SumMergerSmall;
+    const TGixMerger<TQmGixKey, TQmGixItemSmall, TQmGixItemSmall>* SumMergerSmall;
     /// Inverted Index Default Merger Tiny
-    const TGixMerger<TQmGixKey, TQmGixItemTiny>* MergerTiny;
+    const TGixMerger<TQmGixKey, TQmGixItemTiny, TQmGixItemFull>* MergerTiny;
     /// Inverted Index Default Merger Position
-    const TGixMerger<TQmGixKey, TQmGixItemPos>* MergerPos;
+    const TGixMerger<TQmGixKey, TQmGixItemPos, TQmGixItemPos>* MergerPos;
 
     /// Determines which Gix should be used for given KeyId
     TIndexKeyGixType GetGixType(const int& KeyId) const { return IndexVoc->GetKey(KeyId).GetGixType(); }
@@ -3281,7 +3317,7 @@ public:
     /// Get index vocabulary
     TWPt<TIndexVoc> GetIndexVoc() const { return IndexVoc; }
     /// Get sum merger of recID/FQ vectors
-    const TGixMerger<TQmGixKey, TQmGixItemFull>* GetSumMerger() const { return SumMergerFull; }
+    const TGixMerger<TQmGixKey, TQmGixItemFull, TQmGixItemFull>* GetSumMerger() const { return SumMergerFull; }
 
     /// Index RecId under (Key, Word). WordStr is sent through index vocabulary.
     void IndexValue(const int& KeyId, const TStr& WordStr, const uint64& RecId);
@@ -3816,12 +3852,12 @@ public:
     ~TBase();
 
     /// Create new base on the given folder
-    static TWPt<TBase> New(const TStr& FPath, const int64& IndexCacheSize, const TStrUInt64H& IndexTypeCacheSizeH, 
+    static TWPt<TBase> New(const TStr& FPath, const int64& IndexCacheSize, const TStrUInt64H& IndexTypeCacheSizeH,
         const int& SplitLen, const bool& StrictNmP) {
         return new TBase(FPath, IndexCacheSize, IndexTypeCacheSizeH, SplitLen, StrictNmP);
     }
     /// Open existing base from the given folder
-    static TWPt<TBase> Load(const TStr& FPath, const TFAccess& FAccess, const int64& IndexCacheSize, 
+    static TWPt<TBase> Load(const TStr& FPath, const TFAccess& FAccess, const int64& IndexCacheSize,
         const TStrUInt64H& IndexTypeCacheSizeH, const int& SplitLen) {
         return new TBase(FPath, FAccess, IndexCacheSize, IndexTypeCacheSizeH, SplitLen);
     }

--- a/src/qminer/qminer_core.hpp
+++ b/src/qminer/qminer_core.hpp
@@ -65,48 +65,9 @@ void TBTreeIndex<TVal>::SearchRange(const TPair<TVal, TVal>& RangeMinMax, TUInt6
 }
 
 ///////////////////////////////
-/// QMiner-Index-Default-Merger
+/// QMiner Index Frequency Summation Item Handler
 template <class TQmGixItem>
-void TIndex::TQmGixSumMerger<TQmGixItem>::Union(TVec<TQmGixItem>& MainV, const TVec<TQmGixItem>& JoinV) const {
-    TVec<TQmGixItem> ResV; int ValN1 = 0; int ValN2 = 0;
-    while ((ValN1 < MainV.Len()) && (ValN2 < JoinV.Len())) {
-        const TQmGixItem& Val1 = MainV.GetVal(ValN1);
-        const TQmGixItem& Val2 = JoinV.GetVal(ValN2);
-        if (Val1 < Val2) { ResV.Add(Val1); ValN1++; }
-        else if (Val1 > Val2) { ResV.Add(Val2); ValN2++; }
-        else { ResV.Add(TQmGixItem(Val1.Key, Val1.Dat + Val2.Dat)); ValN1++; ValN2++; }
-    }
-    for (int RestValN1 = ValN1; RestValN1 < MainV.Len(); RestValN1++) {
-        ResV.Add(MainV.GetVal(RestValN1));
-    }
-    for (int RestValN2 = ValN2; RestValN2 < JoinV.Len(); RestValN2++) {
-        ResV.Add(JoinV.GetVal(RestValN2));
-    }
-    MainV = ResV;
-}
-
-template <class TQmGixItem>
-void TIndex::TQmGixSumMerger<TQmGixItem>::Intrs(TVec<TQmGixItem>& MainV, const TVec<TQmGixItem>& JoinV) const {
-    TVec<TQmGixItem> ResV; int ValN1 = 0; int ValN2 = 0;
-    while ((ValN1 < MainV.Len()) && (ValN2 < JoinV.Len())) {
-        const TQmGixItem& Val1 = MainV.GetVal(ValN1);
-        const TQmGixItem& Val2 = JoinV.GetVal(ValN2);
-        if (Val1 < Val2) { ValN1++; }
-        else if (Val1 > Val2) { ValN2++; }
-        else { ResV.Add(TQmGixItem(Val1.Key, Val1.Dat + Val2.Dat)); ValN1++; ValN2++; }
-    }
-    MainV = ResV;
-}
-
-template <class TQmGixItem>
-void TIndex::TQmGixSumMerger<TQmGixItem>::Minus(const TVec<TQmGixItem>& MainV,
-        const TVec<TQmGixItem>& JoinV, TVec<TQmGixItem>& ResV) const {
-
-    MainV.Diff(JoinV, ResV);
-}
-
-template <class TQmGixItem>
-void TIndex::TQmGixSumMerger<TQmGixItem>::Merge(TVec<TQmGixItem>& ItemV, const bool& IsLocal) const {
+void TIndex::TQmGixSumItemHandler<TQmGixItem>::Merge(TVec<TQmGixItem>& ItemV, const bool& IsLocal) const {
     if (ItemV.Empty()) { return; } // nothing to do in this case
     if (!ItemV.IsSorted()) { ItemV.Sort(); } // sort if not yet sorted
     // merge counts
@@ -135,5 +96,71 @@ void TIndex::TQmGixSumMerger<TQmGixItem>::Merge(TVec<TQmGixItem>& ItemV, const b
         ItemV.Reserve(ItemV.Reserved(), LastIndN);
     } else {
         ItemV.Reserve(ItemV.Reserved(), LastItemN + 1);
+    }
+}
+
+///////////////////////////////
+/// QMiner Index Frequency Summation Merger
+template <class TQmGixItem, class TQmGixResItem>
+void TIndex::TQmGixSumMerger<TQmGixItem, TQmGixResItem>::Union(
+        TVec<TQmGixResItem>& MainV, const TVec<TQmGixResItem>& JoinV) const {
+
+    TVec<TQmGixResItem> ResV; int ValN1 = 0; int ValN2 = 0;
+    while ((ValN1 < MainV.Len()) && (ValN2 < JoinV.Len())) {
+        const TQmGixResItem& Val1 = MainV.GetVal(ValN1);
+        const TQmGixResItem& Val2 = JoinV.GetVal(ValN2);
+        if (Val1 < Val2) { ResV.Add(Val1); ValN1++; }
+        else if (Val1 > Val2) { ResV.Add(Val2); ValN2++; }
+        else { ResV.Add(TQmGixResItem(Val1.Key, Val1.Dat + Val2.Dat)); ValN1++; ValN2++; }
+    }
+    for (int RestValN1 = ValN1; RestValN1 < MainV.Len(); RestValN1++) {
+        ResV.Add(MainV.GetVal(RestValN1));
+    }
+    for (int RestValN2 = ValN2; RestValN2 < JoinV.Len(); RestValN2++) {
+        ResV.Add(JoinV.GetVal(RestValN2));
+    }
+    MainV = ResV;
+}
+
+template <class TQmGixItem, class TQmGixResItem>
+void TIndex::TQmGixSumMerger<TQmGixItem, TQmGixResItem>::Intrs(
+        TVec<TQmGixResItem>& MainV, const TVec<TQmGixResItem>& JoinV) const {
+
+    TVec<TQmGixResItem> ResV; int ValN1 = 0; int ValN2 = 0;
+    while ((ValN1 < MainV.Len()) && (ValN2 < JoinV.Len())) {
+        const TQmGixResItem& Val1 = MainV.GetVal(ValN1);
+        const TQmGixResItem& Val2 = JoinV.GetVal(ValN2);
+        if (Val1 < Val2) { ValN1++; }
+        else if (Val1 > Val2) { ValN2++; }
+        else { ResV.Add(TQmGixResItem(Val1.Key, Val1.Dat + Val2.Dat)); ValN1++; ValN2++; }
+    }
+    MainV = ResV;
+}
+
+template <class TQmGixItem, class TQmGixResItem>
+void TIndex::TQmGixSumMerger<TQmGixItem, TQmGixResItem>::Minus(const TVec<TQmGixResItem>& MainV,
+        const TVec<TQmGixResItem>& JoinV, TVec<TQmGixResItem>& ResV) const {
+
+    MainV.Diff(JoinV, ResV);
+}
+
+///////////////////////////////
+/// Specialization for case when TQmGixItem == TQmGixResItem
+template <class TQmGixItem>
+void TIndex::TQmGixSumWithFqMerger<TQmGixItem>::Def(const TQmGixKey& Key,
+        TVec<TQmGixItem>& MainV, TVec<TQmGixItem>& ResV) const {
+
+    ResV.MoveFrom(MainV);
+}
+
+///////////////////////////////
+/// Specialization for case when index has implied frequency of 1 (e.g. tiny)
+template <class TQmGixItem, class TQmGixResItem>
+void TIndex::TQmGixSumWithoutFqMerger<TQmGixItem, TQmGixResItem>::Def(const TQmGixKey& Key,
+        TVec<TQmGixItem>& MainV, TVec<TQmGixResItem>& ResV) const {
+
+    ResV.Gen(MainV.Len(), 0);
+    for (TQmGixItem& Item : MainV) {
+        ResV.Add(TQmGixResItem(Item.Val, 1));
     }
 }

--- a/test/nodejs/search.js
+++ b/test/nodejs/search.js
@@ -1051,7 +1051,7 @@ describe('Gix Tests', function () {
             store.push({ Value: "D", Count: 10 });
         }
 
-        function prepareJoinStore() {
+        function prepareJoinStore1() {
             base.createStore([{
                 name: 'TestStore1',
                 fields: [ { name: 'Value', type: 'string' } ],
@@ -1116,7 +1116,7 @@ describe('Gix Tests', function () {
                 }).length, 0);
             })
             it('should return correct number of records for join query', function () {
-                prepareJoinStore();
+                prepareJoinStore1();
                 assert.equal(base.store("TestStore1").length, 10);
                 assert.equal(base.store("TestStore2").length, 3);
                 // x < y < z
@@ -1153,7 +1153,9 @@ describe('Gix Tests', function () {
                 });
                 assert.equal(res3.length, 2);
                 assert.equal(res3[0].Value, "y");
+                assert.equal(res3[0].$fq, 1);
                 assert.equal(res3[1].Value, "z");
+                assert.equal(res3[1].$fq, 2);
                 //A => [x] => [A, D, D, D]
                 var res4 = base.search({
                     $join: {
@@ -1170,12 +1172,16 @@ describe('Gix Tests', function () {
                 });
                 assert.equal(res4.length, 4);
                 assert.equal(res4[0].Value, "A");
+                assert.equal(res4[0].$fq, 1);
                 assert.equal(res4[1].Value, "D");
+                assert.equal(res4[1].$fq, 1);
                 assert.equal(res4[2].Value, "D");
+                assert.equal(res4[2].$fq, 1);
                 assert.equal(res4[3].Value, "D");
+                assert.equal(res4[3].$fq, 1);
             })
             it('should return correct number of records for join query after delete', function () {
-                prepareJoinStore();
+                prepareJoinStore1();
                 // x => [D, D, D]
                 base.store("TestStore1").clear(1);
                 var res1 = base.search({
@@ -1190,7 +1196,7 @@ describe('Gix Tests', function () {
                 assert.equal(res1[2].Value, "D");
             })
             it('should return correct number of records for join query after delete', function () {
-                prepareJoinStore();
+                prepareJoinStore1();
                 // delete x
                 base.store("TestStore2").clear(1);
                 //C => [y, z]
@@ -1221,7 +1227,309 @@ describe('Gix Tests', function () {
     testGixSearch("full");
     testGixSearch("small");
     testGixSearch("tiny");
-});
+
+    function testGixFrequency1(gixType) {
+        function prepareJoinStore() {
+            base.createStore([{
+                name: 'TestStore1',
+                fields: [ { name: 'Value', type: 'string', primary: true } ],
+                joins: [ { name: 'Join', type: 'index', store: 'TestStore2', inverse: 'Join', storage: gixType } ],
+                keys: [ { field: 'Value', type: 'value', storage: gixType } ]
+            }, {
+                name: 'TestStore2',
+                fields: [ { name: 'Value', type: 'string', primary: true } ],
+                joins: [ { name: 'Join', type: 'index', store: 'TestStore1', inverse: 'Join', storage: gixType } ],
+                keys: [ { field: 'Value', type: 'value', storage: gixType } ]
+            }]);
+            var store1 = base.store("TestStore1");
+            store1.push({ Value: "A" });
+            store1.push({ Value: "B" });
+            store1.push({ Value: "C" });
+            store1.push({ Value: "D" });
+            var store2 = base.store("TestStore2");
+            store2.push({ Value: "x" });
+            store2.push({ Value: "y" });
+            store2.push({ Value: "z" });
+            store1[0].$addJoin("Join", store2[0], 1); // A->x:1
+            store1[0].$addJoin("Join", store2[1], 2); // A->y:2
+            store1[0].$addJoin("Join", store2[2], 4); // A->z:4
+            store1[1].$addJoin("Join", store2[0], 5); // B->x:5
+            store1[1].$addJoin("Join", store2[1], 6); // B->y:6
+            store1[2].$addJoin("Join", store2[2], 1); // C->z:1
+            store1[3].$addJoin("Join", store2[0], 2); // D->x:2
+        }
+        describe('Test explicit frequencies xfor gix type "' + gixType + '"', function () {
+            it('should return correct frequencies for records when doing direct join on record', function () {
+                prepareJoinStore()
+                // first direct joins, without search
+                var rec1 = base.store("TestStore1").recordByName("A");
+                assert.equal(rec1.Join.length, 3);
+                assert.equal(rec1.Join[0].Value, "x");
+                assert.equal(rec1.Join[0].$id, 0);
+                assert.equal(rec1.Join[0].$fq, 1);
+                assert.equal(rec1.Join[1].Value, "y");
+                assert.equal(rec1.Join[1].$id, 1);
+                assert.equal(rec1.Join[1].$fq, 2);
+                assert.equal(rec1.Join[2].Value, "z");
+                assert.equal(rec1.Join[2].$id, 2);
+                assert.equal(rec1.Join[2].$fq, 4);
+
+                var rec2 = base.store("TestStore1").recordByName("B");
+                assert.equal(rec2.Join.length, 2);
+                assert.equal(rec2.Join[0].Value, "x");
+                assert.equal(rec2.Join[0].$id, 0);
+                assert.equal(rec2.Join[0].$fq, 5);
+                assert.equal(rec2.Join[1].Value, "y");
+                assert.equal(rec2.Join[1].$id, 1);
+                assert.equal(rec2.Join[1].$fq, 6);
+
+                var rec3 = base.store("TestStore1").recordByName("C");
+                assert.equal(rec3.Join.length, 1);
+                assert.equal(rec3.Join[0].Value, "z");
+                assert.equal(rec3.Join[0].$id, 2);
+                assert.equal(rec3.Join[0].$fq, 1);
+
+                var rec4 = base.store("TestStore1").recordByName("D");
+                assert.equal(rec4.Join.length, 1);
+                assert.equal(rec4.Join[0].Value, "x");
+                assert.equal(rec4.Join[0].$id, 0);
+                assert.equal(rec4.Join[0].$fq, 2);
+
+                var rec5 = base.store("TestStore2").recordByName("x");
+                assert.equal(rec5.Join.length, 3);
+                assert.equal(rec5.Join[0].Value, "A");
+                assert.equal(rec5.Join[0].$id, 0);
+                assert.equal(rec5.Join[0].$fq, 1);
+                assert.equal(rec5.Join[1].Value, "B");
+                assert.equal(rec5.Join[1].$id, 1);
+                assert.equal(rec5.Join[1].$fq, 5);
+                assert.equal(rec5.Join[2].Value, "D");
+                assert.equal(rec5.Join[2].$id, 3);
+                assert.equal(rec5.Join[2].$fq, 2);
+
+                var rec6 = base.store("TestStore2").recordByName("y");
+                assert.equal(rec6.Join.length, 2);
+                assert.equal(rec6.Join[0].Value, "A");
+                assert.equal(rec6.Join[0].$id, 0);
+                assert.equal(rec6.Join[0].$fq, 2);
+                assert.equal(rec6.Join[1].Value, "B");
+                assert.equal(rec6.Join[1].$id, 1);
+                assert.equal(rec6.Join[1].$fq, 6);
+
+                var rec7 = base.store("TestStore2").recordByName("z");
+                assert.equal(rec7.Join.length, 2);
+                assert.equal(rec7.Join[0].Value, "A");
+                assert.equal(rec7.Join[0].$id, 0);
+                assert.equal(rec7.Join[0].$fq, 4);
+                assert.equal(rec7.Join[1].Value, "C");
+                assert.equal(rec7.Join[1].$id, 2);
+                assert.equal(rec7.Join[1].$fq, 1);
+            })
+            it('should return correct frequencies for records when doing direct join or recordset', function () {
+                prepareJoinStore()
+                // first direct joins, without search
+                var rec1 = base.search({ $from: "TestStore1", Value: "A" }).join("Join");
+                assert.equal(rec1.length, 3);
+                assert.equal(rec1[0].Value, "x");
+                assert.equal(rec1[0].$id, 0);
+                assert.equal(rec1[0].$fq, 1);
+                assert.equal(rec1[1].Value, "y");
+                assert.equal(rec1[1].$id, 1);
+                assert.equal(rec1[1].$fq, 2);
+                assert.equal(rec1[2].Value, "z");
+                assert.equal(rec1[2].$id, 2);
+                assert.equal(rec1[2].$fq, 4);
+
+                var rec2 = base.search({ $from: "TestStore1", Value: "B" }).join("Join");
+                assert.equal(rec2.length, 2);
+                assert.equal(rec2[0].Value, "x");
+                assert.equal(rec2[0].$id, 0);
+                assert.equal(rec2[0].$fq, 5);
+                assert.equal(rec2[1].Value, "y");
+                assert.equal(rec2[1].$id, 1);
+                assert.equal(rec2[1].$fq, 6);
+
+                var rec3 = base.search({ $from: "TestStore1", Value: "C" }).join("Join");
+                assert.equal(rec3.length, 1);
+                assert.equal(rec3[0].Value, "z");
+                assert.equal(rec3[0].$id, 2);
+                assert.equal(rec3[0].$fq, 1);
+
+                var rec4 = base.search({ $from: "TestStore1", Value: "D" }).join("Join");
+                assert.equal(rec4.length, 1);
+                assert.equal(rec4[0].Value, "x");
+                assert.equal(rec4[0].$id, 0);
+                assert.equal(rec4[0].$fq, 2);
+
+                var rec5 = base.search({ $from: "TestStore2", Value: "x" }).join("Join");
+                assert.equal(rec5.length, 3);
+                assert.equal(rec5[0].Value, "A");
+                assert.equal(rec5[0].$id, 0);
+                assert.equal(rec5[0].$fq, 1);
+                assert.equal(rec5[1].Value, "B");
+                assert.equal(rec5[1].$id, 1);
+                assert.equal(rec5[1].$fq, 5);
+                assert.equal(rec5[2].Value, "D");
+                assert.equal(rec5[2].$id, 3);
+                assert.equal(rec5[2].$fq, 2);
+
+                var rec6 = base.search({ $from: "TestStore2", Value: "y" }).join("Join");
+                assert.equal(rec6.length, 2);
+                assert.equal(rec6[0].Value, "A");
+                assert.equal(rec6[0].$id, 0);
+                assert.equal(rec6[0].$fq, 2);
+                assert.equal(rec6[1].Value, "B");
+                assert.equal(rec6[1].$id, 1);
+                assert.equal(rec6[1].$fq, 6);
+
+                var rec7 = base.search({ $from: "TestStore2", Value: "z" }).join("Join");
+                assert.equal(rec7.length, 2);
+                assert.equal(rec7[0].Value, "A");
+                assert.equal(rec7[0].$id, 0);
+                assert.equal(rec7[0].$fq, 4);
+                assert.equal(rec7[1].Value, "C");
+                assert.equal(rec7[1].$id, 2);
+                assert.equal(rec7[1].$fq, 1);
+            })
+            it('should return correct frequencies for records when doing search join', function () {
+                prepareJoinStore()
+                // first direct joins, without search
+                var rec1 = base.search({ $join: { $name: "Join", $query: { $from: "TestStore1", Value: "A" }}});
+                assert.equal(rec1.length, 3);
+                assert.equal(rec1[0].Value, "x");
+                assert.equal(rec1[0].$id, 0);
+                assert.equal(rec1[0].$fq, 1);
+                assert.equal(rec1[1].Value, "y");
+                assert.equal(rec1[1].$id, 1);
+                assert.equal(rec1[1].$fq, 2);
+                assert.equal(rec1[2].Value, "z");
+                assert.equal(rec1[2].$id, 2);
+                assert.equal(rec1[2].$fq, 4);
+
+                var rec2 = base.search({ $join: { $name: "Join", $query: { $from: "TestStore1", Value: "B" }}});
+                assert.equal(rec2.length, 2);
+                assert.equal(rec2[0].Value, "x");
+                assert.equal(rec2[0].$id, 0);
+                assert.equal(rec2[0].$fq, 5);
+                assert.equal(rec2[1].Value, "y");
+                assert.equal(rec2[1].$id, 1);
+                assert.equal(rec2[1].$fq, 6);
+
+                var rec3 = base.search({ $join: { $name: "Join", $query: { $from: "TestStore1", Value: "C" }}});
+                assert.equal(rec3.length, 1);
+                assert.equal(rec3[0].Value, "z");
+                assert.equal(rec3[0].$id, 2);
+                assert.equal(rec3[0].$fq, 1);
+
+                var rec4 = base.search({ $join: { $name: "Join", $query: { $from: "TestStore1", Value: "D" }}});
+                assert.equal(rec4.length, 1);
+                assert.equal(rec4[0].Value, "x");
+                assert.equal(rec4[0].$id, 0);
+                assert.equal(rec4[0].$fq, 2);
+
+                var rec5 = base.search({ $join: { $name: "Join", $query: { $from: "TestStore2", Value: "x" }}});
+                assert.equal(rec5.length, 3);
+                assert.equal(rec5[0].Value, "A");
+                assert.equal(rec5[0].$id, 0);
+                assert.equal(rec5[0].$fq, 1);
+                assert.equal(rec5[1].Value, "B");
+                assert.equal(rec5[1].$id, 1);
+                assert.equal(rec5[1].$fq, 5);
+                assert.equal(rec5[2].Value, "D");
+                assert.equal(rec5[2].$id, 3);
+                assert.equal(rec5[2].$fq, 2);
+
+                var rec6 = base.search({ $join: { $name: "Join", $query: { $from: "TestStore2", Value: "y" }}});
+                assert.equal(rec6.length, 2);
+                assert.equal(rec6[0].Value, "A");
+                assert.equal(rec6[0].$id, 0);
+                assert.equal(rec6[0].$fq, 2);
+                assert.equal(rec6[1].Value, "B");
+                assert.equal(rec6[1].$id, 1);
+                assert.equal(rec6[1].$fq, 6);
+
+                var rec7 = base.search({ $join: { $name: "Join", $query: { $from: "TestStore2", Value: "z" }}});
+                assert.equal(rec7.length, 2);
+                assert.equal(rec7[0].Value, "A");
+                assert.equal(rec7[0].$id, 0);
+                assert.equal(rec7[0].$fq, 4);
+                assert.equal(rec7[1].Value, "C");
+                assert.equal(rec7[1].$id, 2);
+                assert.equal(rec7[1].$fq, 1);
+            })
+        })
+    }
+    testGixFrequency1("full");
+    testGixFrequency1("small");
+
+    function testGixFrequency2(gixType) {
+        function prepareJoinStore() {
+            base.createStore([{
+                name: 'TestStore1',
+                fields: [ { name: 'Value', type: 'string', primary: true } ],
+                joins: [ { name: 'Join', type: 'index', store: 'TestStore2', inverse: 'Join', storage: gixType } ],
+                keys: [ { field: 'Value', type: 'value', storage: gixType } ]
+            }, {
+                name: 'TestStore2',
+                fields: [ { name: 'Value', type: 'string', primary: true } ],
+                joins: [ { name: 'Join', type: 'index', store: 'TestStore1', inverse: 'Join', storage: gixType } ],
+                keys: [ { field: 'Value', type: 'value', storage: gixType } ]
+            }]);
+            var store1 = base.store("TestStore1");
+            store1.push({ Value: "A" });
+            store1.push({ Value: "B" });
+            store1.push({ Value: "C" });
+            store1.push({ Value: "D" });
+            var store2 = base.store("TestStore2");
+            store2.push({ Value: "x" });
+            store2.push({ Value: "y" });
+            store2.push({ Value: "z" });
+            store1[0].$addJoin("Join", store2[0]); // A->x
+            store1[1].$addJoin("Join", store2[0]); // B->x
+            store1[2].$addJoin("Join", store2[0]); // C->x
+            store1[3].$addJoin("Join", store2[0]); // D->x
+            store1[0].$addJoin("Join", store2[1]); // A->y
+            store1[1].$addJoin("Join", store2[1]); // B->y
+            store1[2].$addJoin("Join", store2[1]); // C->y
+            store1[0].$addJoin("Join", store2[2]); // A->z
+            store1[1].$addJoin("Join", store2[2]); // B->z
+        }
+        describe('Test implicit frequencies for gix type "' + gixType + '"', function () {
+            it('should return correct frequencies for records when doing direct join on record', function () {
+                prepareJoinStore()
+                var rec1 = base.store("TestStore1").allRecords.join("Join");
+                assert.equal(rec1.length, 3);
+                assert.equal(rec1[0].Value, "x");
+                assert.equal(rec1[0].$id, 0);
+                assert.equal(rec1[0].$fq, 4);
+                assert.equal(rec1[1].Value, "y");
+                assert.equal(rec1[1].$id, 1);
+                assert.equal(rec1[1].$fq, 3);
+                assert.equal(rec1[2].Value, "z");
+                assert.equal(rec1[2].$id, 2);
+                assert.equal(rec1[2].$fq, 2);
+                var rec2 = base.store("TestStore2").allRecords.join("Join");
+                assert.equal(rec2.length, 4);
+                assert.equal(rec2[0].Value, "A");
+                assert.equal(rec2[0].$id, 0);
+                assert.equal(rec2[0].$fq, 3);
+                assert.equal(rec2[1].Value, "B");
+                assert.equal(rec2[1].$id, 1);
+                assert.equal(rec2[1].$fq, 3);
+                assert.equal(rec2[2].Value, "C");
+                assert.equal(rec2[2].$id, 2);
+                assert.equal(rec2[2].$fq, 2);
+                assert.equal(rec2[3].Value, "D");
+                assert.equal(rec2[3].$id, 3);
+                assert.equal(rec2[3].$fq, 1);
+
+            })
+        })
+    }
+    testGixFrequency2("full");
+    testGixFrequency2("small");
+    testGixFrequency2("tiny");
+})
 
 describe('Gix Position Tests', function () {
     var base = undefined;


### PR DESCRIPTION
Tiny joins now counted as having frequency 1 when doing joins with record sets