### PR TITLE
Feature: support for keyword search operator NEAR/5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,23 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -24,8 +41,36 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "aws-sdk": {
+      "version": "2.0.31",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.31.tgz",
+      "integrity": "sha1-5yzx/caQFb2f0r3z07iMFlB9Jo4=",
+      "dev": true,
+      "requires": {
+        "xml2js": "0.2.6",
+        "xmlbuilder": "0.4.2"
       }
     },
     "balanced-match": {
@@ -38,8 +83,35 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "catharsis": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+      "dev": true,
+      "requires": {
+        "underscore-contrib": "~0.3.0"
+      }
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chownr": {
@@ -47,15 +119,52 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "config-chain": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
     },
     "console-control-strings": {
       "version": "1.1.0",
@@ -75,6 +184,13 @@
         "ms": "2.0.0"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
@@ -90,12 +206,30 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
+    "diff": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+      "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+      "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
+      "dev": true
+    },
     "fs-minipass": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "minipass": "2.3.1"
+        "minipass": "^2.2.1"
       }
     },
     "fs.realpath": {
@@ -108,28 +242,57 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
+    },
+    "graceful-fs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+      "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+      "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.6.tgz",
+      "integrity": "sha512-LxzdOvkYFsdL6ZT92igXthJIZLYKBSowtrM3oxfMdOwjv0dRWk6EK4PygNgXc0xwjH38BWMCSnktrOpKbec+Qw==",
+      "dev": true,
+      "requires": {
+        "optimist": "^0.6.1",
+        "source-map": "^0.1.40",
+        "uglify-js": "^2.6"
+      }
+    },
+    "handlebars-layouts": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/handlebars-layouts/-/handlebars-layouts-2.0.2.tgz",
+      "integrity": "sha1-9bLR0kBTJcR0GagRm9T4RxI/grI=",
+      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -141,7 +304,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore-walk": {
@@ -149,7 +312,7 @@
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.4"
       }
     },
     "inflight": {
@@ -157,8 +320,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -171,12 +334,39 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
+    "intl": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/intl/-/intl-0.1.4.tgz",
+      "integrity": "sha1-v1Z8YTn7utyEhhjbT1eOKASBLoA=",
+      "dev": true
+    },
+    "intl-messageformat": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-1.1.0.tgz",
+      "integrity": "sha1-9GoWjBvV4YOOy93agJoHVHJ/RCI=",
+      "dev": true,
+      "requires": {
+        "intl-messageformat-parser": "1.1.0"
+      }
+    },
+    "intl-messageformat-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.1.0.tgz",
+      "integrity": "sha1-6O2PMIU5ab8fW+3vDpRNKxBTQJs=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "isarray": {
@@ -184,12 +374,172 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "js-beautify": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.10.tgz",
+      "integrity": "sha1-TZU3FwJpk0SlFsomv1nwonu3Vxk=",
+      "dev": true,
+      "requires": {
+        "config-chain": "~1.1.5",
+        "mkdirp": "~0.5.0",
+        "nopt": "~3.0.1"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+      "integrity": "sha1-yhrNNCPsJ10SFAp7q1HbAVugs8A=",
+      "dev": true,
+      "requires": {
+        "argparse": "~1.0.2",
+        "esprima": "~2.2.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+          "integrity": "sha1-QpLB1o5Bc9gV+iKQ3Hr8ltgfzYM=",
+          "dev": true
+        }
+      }
+    },
+    "js2xmlparser": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-0.1.9.tgz",
+      "integrity": "sha1-LFFniOCUYGN/mkA9/te5JfcdI54=",
+      "dev": true
+    },
+    "jsdoc": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.3.3.tgz",
+      "integrity": "sha1-3fBPLnWSCghnwwtxZJ26F3CNaHE=",
+      "dev": true,
+      "requires": {
+        "async": "~0.9.0",
+        "catharsis": "~0.8.7",
+        "escape-string-regexp": "~1.0.2",
+        "esprima": "1.2.5",
+        "js2xmlparser": "~0.1.7",
+        "marked": "~0.3.2",
+        "requizzle": "~0.2.0",
+        "strip-json-comments": "~1.0.2",
+        "taffydb": "https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e",
+        "underscore": "~1.7.0",
+        "wrench": "~1.5.8"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        }
+      }
+    },
+    "jsdoc-baseline": {
+      "version": "git+https://github.com/hegemonic/jsdoc-baseline.git#d161c4136e12ca5d5674747d4b115067a6980185",
+      "from": "git+https://github.com/hegemonic/jsdoc-baseline.git#d161c4136e12ca5d5674747d4b115067a6980185",
+      "dev": true,
+      "requires": {
+        "deep-extend": "~0.4.0",
+        "escape-string-regexp": "~1.0.3",
+        "handlebars": "~3.0.3",
+        "handlebars-layouts": "~2.0.2",
+        "intl": "~0.1.4",
+        "intl-messageformat": "~1.1.0",
+        "js-beautify": "~1.5.5",
+        "js-yaml": "~3.3.0",
+        "spdx-license-list": "~2.0.0",
+        "underscore-contrib": "~0.3.0"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -202,8 +552,8 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.1.tgz",
       "integrity": "sha512-liT0Gjaz7OHXg2qsfefVFfryBE9uAsqVFWQ6wVf4KNMzI2edsrCDjdGDpTxRaykbxhSKHu/SDtRRcMEcCcTQ2g==",
       "requires": {
-        "safe-buffer": "5.1.1",
-        "yallist": "3.0.2"
+        "safe-buffer": "^5.1.1",
+        "yallist": "^3.0.0"
       }
     },
     "minizlib": {
@@ -211,7 +561,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
       "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
       "requires": {
-        "minipass": "2.3.1"
+        "minipass": "^2.2.1"
       }
     },
     "mkdirp": {
@@ -222,19 +572,94 @@
         "minimist": "0.0.8"
       }
     },
+    "mocha": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.1.0.tgz",
+      "integrity": "sha1-d3Uv5ZL7kJJ1aCevRs0+rhuDZxw=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.0.0",
+        "diff": "1.0.8",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.3",
+        "growl": "1.8.1",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+          "dev": true,
+          "requires": {
+            "ms": "0.6.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "~2.0.0",
+            "inherits": "2",
+            "minimatch": "~0.2.11"
+          }
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+          "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+          "dev": true
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mustache": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.2.1.tgz",
+      "integrity": "sha1-LEDKIcJ49TFQaCvPkJDkGjM5uHY=",
+      "dev": true
     },
     "needle": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
       "integrity": "sha512-t/ZswCM9JTWjAdXS9VpvqhI2Ct2sL2MdY4fUXqGJaGBk13ge99ObqRksRTbBE56K+wxUXwwfZYOuZHifFW9q+Q==",
       "requires": {
-        "debug": "2.6.9",
-        "iconv-lite": "0.4.23",
-        "sax": "1.2.4"
+        "debug": "^2.1.2",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
       }
     },
     "node-pre-gyp": {
@@ -242,16 +667,16 @@
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
       "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
       "requires": {
-        "detect-libc": "1.0.3",
-        "mkdirp": "0.5.1",
-        "needle": "2.2.1",
-        "nopt": "4.0.1",
-        "npm-packlist": "1.1.10",
-        "npmlog": "4.1.2",
-        "rc": "1.2.6",
-        "rimraf": "2.6.2",
-        "semver": "5.5.0",
-        "tar": "4.4.2"
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.0",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.1.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
       },
       "dependencies": {
         "safe-buffer": {
@@ -264,13 +689,13 @@
           "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.2.tgz",
           "integrity": "sha512-BfkE9CciGGgDsATqkikUHrQrraBCO+ke/1f6SFAEMnxyyfN9lxC+nW1NFWMpqH865DhHIy9vQi682gk1X7friw==",
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.3.1",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           }
         }
       }
@@ -280,8 +705,8 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "requires": {
-        "abbrev": "1.1.1",
-        "osenv": "0.1.5"
+        "abbrev": "1",
+        "osenv": "^0.1.4"
       }
     },
     "npm-bundled": {
@@ -294,19 +719,19 @@
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
       "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
       "requires": {
-        "ignore-walk": "3.0.1",
-        "npm-bundled": "1.0.3"
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
       }
     },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -324,7 +749,17 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "os-homedir": {
@@ -342,8 +777,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "path-is-absolute": {
@@ -356,15 +791,21 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
+    },
     "rc": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
       "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -379,13 +820,46 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "requizzle": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+      "dev": true,
+      "requires": {
+        "underscore": "~1.6.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        }
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -393,13 +867,13 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -421,19 +895,46 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+      "dev": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
+    },
+    "spdx-license-list": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-2.0.0.tgz",
+      "integrity": "sha1-djO3FtUGi5c9i+6Zg5kBdR02gb4=",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -441,7 +942,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -449,13 +950,69 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "taffydb": {
+      "version": "https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e",
+      "integrity": "sha512-iWx+oupEjIH7KA4mYZKlPS/C7by3/aVcFPmFq6P/DYeoa3m3NH0ojTuvrwBBkJcUPbLN2yAhFmcU2jRJpxQGnw==",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "dev": true
+    },
+    "underscore-contrib": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+      "dev": true,
+      "requires": {
+        "underscore": "1.6.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        }
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -465,20 +1022,75 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "wrench": {
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.9.tgz",
+      "integrity": "sha1-QRaRxjqbJTGxcAJnJ5veyiOyFCo=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
+      "integrity": "sha1-0gnE5N2h/JxFIUHvQcB39a399sQ=",
+      "dev": true,
+      "requires": {
+        "sax": "0.4.2"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
+          "integrity": "sha1-OfO2AXM9a+yXEFskKipA/Wl4rDw=",
+          "dev": true
+        }
+      }
+    },
+    "xmlbuilder": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+      "integrity": "sha1-F3bWXz/brUcKCNhgTN6xxOVA/4M=",
+      "dev": true
+    },
     "yallist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
       "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
     }
   }
 }

--- a/src/glib/base/html.h
+++ b/src/glib/base/html.h
@@ -344,7 +344,7 @@ private:
 public:
   TWebPg(): UrlStrV(), IpNumV(), HttpResp(){}
   TWebPg(const TStrV& _UrlStrV, const TStrV& _IpNumV, const PHttpResp& _HttpResp):
-    UrlStrV(_UrlStrV), IpNumV(_IpNumV), HttpResp(_HttpResp){}
+    UrlStrV(_UrlStrV), IpNumV(_IpNumV), HttpResp(_HttpResp), FetchMSecs(0){}
   static PWebPg New(const TStrV& UrlStrV, const TStrV& IpNumV, const PHttpResp& HttpResp){
     return new TWebPg(UrlStrV, IpNumV, HttpResp);}
   static PWebPg New(const TStrV& UrlStrV, const PHttpResp& HttpResp){

--- a/src/glib/mine/tokenizer.h
+++ b/src/glib/mine/tokenizer.h
@@ -40,7 +40,7 @@ public:
     static PTokenizer Load(TSIn& SIn);
 
 	virtual void GetTokens(const PSIn& SIn, TStrV& TokenV) const = 0;
-	void GetTokens(const TStr& Text, TStrV& TokenV) const;
+    virtual void GetTokens(const TStr& Text, TStrV& TokenV) const;
 	void GetTokens(const TStrV& TextV, TVec<TStrV>& TokenVV) const;
 };
 

--- a/src/qminer/qminer_core.cpp
+++ b/src/qminer/qminer_core.cpp
@@ -5592,6 +5592,10 @@ TIndex::TQmGixItemPos TIndex::TQmGixItemPos::Intersect(const TQmGixItemPos& Item
         const int Pos1 = GetPos(PosN1);
         for (int PosN2 = 0; PosN2 < PosLen2; PosN2++) {
             const int Pos2 = Item.GetPos(PosN2);
+            // if the value Pos2 is already in _Item skip it - each value should only appear once
+            if (_Item.IsIn(Pos2)) {
+                continue;
+            }
             // check if we are within the intersection, first simple case
             if (Pos1 < Pos2 && Pos2 <= (Pos1 + MaxDiff)) {
                 _Item.Add(Pos2); break;

--- a/src/qminer/qminer_core.h
+++ b/src/qminer/qminer_core.h
@@ -2574,8 +2574,8 @@ private:
     TUInt64V WordIdV;
     /// Comparison between field and value (for gix query)
     TQueryCmpType CmpType;
-    /// Max difference between words (for text position query)
-    TInt MaxPosDiff;
+    /// Max difference between individual words in WordIdV (for text position query)
+    TIntV MaxPosDiffV;
 
     /// Geographic coordinates (for location query)
     TFltPr Loc;
@@ -2621,7 +2621,7 @@ private:
     TUInt StoreId;
 
     /// Parse Value for leaf nodes (result stored in WordIdV)
-    void ParseWordStr(const TStr& WordStr, const TWPt<TIndexVoc>& IndexVoc);
+    void ParseWordStr(const TStr& WordStr, const TWPt<TIndexVoc>& IndexVoc, const int& MaxPosDiff = 1);
 
     /// Parse join query from json (can be one or an array of joins)
     TWPt<TStore> ParseJoins(const TWPt<TBase>& Base, const PJsonVal& JsonVal);
@@ -2634,6 +2634,7 @@ private:
     /// Parse conditions keys
     void ParseKeys(const TWPt<TBase>& Base, const TWPt<TStore>& Store,
         const PJsonVal& JsonVal, const bool& IgnoreOrP);
+    void InitMaxPosDiff(const int& MaxPosDiff);
     /// Constructor for parsing query from json
     TQueryItem(const TWPt<TBase>& Base, const PJsonVal& JsonVal);
     /// Construct for parsing query from json, where store is specified in advanced
@@ -2672,6 +2673,9 @@ public:
     /// Create new inverted index leaf query using positional index
     TQueryItem(const TWPt<TBase>& Base, const TStr& StoreNm, const TStr& KeyNm,
         const TStr& WordStr, const int& MaxPosDiff);
+    /// Create new inverted index leaf query using positional index and specific max position differences
+    TQueryItem(const TWPt<TBase>& Base, const TStr& StoreNm, const TStr& KeyNm,
+        const TUInt64V& WordIdV, const TIntV& _MaxPosDiffV);
     /// New leaf location query (limit always required, range used when positive)
     TQueryItem(const TWPt<TBase>& Base, const int& _KeyId,
         const TFltPr& _Loc, const int& _LocLimit, const double& _LocRadius);
@@ -2779,7 +2783,7 @@ public:
     bool IsWildChar() const { return (CmpType == oqctWildChar); }
 
     /// Get max difference between words in position search
-    int GetMaxPosDiff() const { return MaxPosDiff; }
+    const TIntV& GetMaxPosDiff() const { return MaxPosDiffV; }
 
     /// Get location (for location queries)
     const TFltPr& GetLoc() const { return Loc; }
@@ -3296,7 +3300,7 @@ private:
     void DoJoinQueryTiny(const int& KeyId, const TUInt64V& RecIdV, TUInt64IntKdV& RecIdFqV) const;
 
     /// Execute Position query. Result is vector of record ids and frequency of phrase occurences.
-    void DoQueryPos(const int& KeyId, const TUInt64V& WordIdV, const int& MaxDiff, TUInt64IntKdV& RecIdFqV) const;
+    void DoQueryPos(const int& KeyId, const TUInt64V& WordIdV, const TIntV& MaxDiffV, TUInt64IntKdV& RecIdFqV) const;
 
     /// method that computes the GixItemPos items for the provided list of words
     void ComputeWordItemPos(const int& KeyId, const TUInt64V& WordIdV, const uint64& RecId, TVec<TPair<TUInt64, TQmGixItemPos>>& WordIdPosPrV);
@@ -3425,7 +3429,7 @@ public:
 
     /// Search text position inverted index where given words are MaxDiff appart.
     PRecSet SearchTextPos(const TWPt<TBase>& Base, const int& KeyId,
-        const TUInt64V& WordIdV, const int& MaxDiff) const;
+        const TUInt64V& WordIdV, const TIntV& MaxDiffV) const;
 
     /// Do geo-location range (in meters) search
     PRecSet SearchGeoRange(const TWPt<TBase>& Base, const int& KeyId,

--- a/src/qminer/qminer_core.h
+++ b/src/qminer/qminer_core.h
@@ -3187,6 +3187,9 @@ private:
         /// Add new position to the item and return true if the item became full
         /// the positions are always added in increasing order - every added position should be higher than the last
         bool Add(const int& Pos);
+        // is the value Pos already in the array of PosV values? If value is not used yet, it has value 0
+        // which is a reserved value and we can simply check all values in the PosV
+        bool IsIn(const int& Pos) { return Pos == PosV.Pos1 || Pos == PosV.Pos2 || Pos == PosV.Pos3; }
         /// Intersect keeping bigger positions that are within MaxDiff difference:
         /// Assumes that this is before Item and we only keep position when Item
         /// position is <= MaxDiff ahead of this. This contains only positions that

--- a/src/qminer/qminer_core.h
+++ b/src/qminer/qminer_core.h
@@ -3341,6 +3341,8 @@ public:
     void IndexValue(const int& KeyId, const TStrV& WordStrV, const uint64& RecId);
     /// Index RecId under given Key. Tokenize and clean given free text to derive words.
     void IndexText(const int& KeyId, const TStr& TextStr, const uint64& RecId);
+    /// Index RecId under given Key. Use the tokens already provided
+    void IndexText(const int& KeyId, const TStrV& TokenV, const uint64& RecId);
     /// Index a join between RecId and JoinRecId
     void IndexJoin(const TWPt<TStore>& Store, const int& JoinId,
         const uint64& RecId, const uint64& JoinRecId, const int& JoinFq = 1);
@@ -3362,6 +3364,8 @@ public:
 
     /// Index RecId using given keys and words. Words are extracted by tokenizing the given string.
     void IndexTextPos(const int& KeyId, const TStr& TextStr, const uint64& RecId);
+    /// Index RecId using given keys and tokenized words. Words were already extracted using the tokenizer
+    void IndexTextPos(const int& KeyId, const TStrV& WordV, const uint64& RecId);
     /// Index RecId using given keys and words. Words are extracted by tokenizing the given string.
     void IndexTextPos(const int& KeyId, const TUInt64V& WordIdV, const uint64& RecId);
 

--- a/src/qminer/qminer_storage.h
+++ b/src/qminer/qminer_storage.h
@@ -766,7 +766,7 @@ private:
 
     /// Index a record using the given key
     void IndexKey(const TFieldIndexKey& Key, const TMemBase& RecMem,
-        const uint64& RecId, TRecSerializator& Serializator);
+        const uint64& RecId, TRecSerializator& Serializator, const PJsonVal& RecJson = nullptr);
     /// Delete existing index of a record based on a given key
     void DeindexKey(const TFieldIndexKey& Key, const TMemBase& RecMem,
         const uint64& RecId, TRecSerializator& Serializator);
@@ -784,7 +784,7 @@ public:
     /// Check if given field is used for indexing
     bool IsFieldIndexKey(const int& FieldId) const;
     /// Index new record
-    void IndexRec(const TMemBase& RecMem, const uint64& RecId, TRecSerializator& Serializator);
+    void IndexRec(const TMemBase& RecMem, const uint64& RecId, TRecSerializator& Serializator, const PJsonVal RecJson = nullptr);
     /// Deindex existing record
     void DeindexRec(const TMemBase& RecMem, const uint64& RecId, TRecSerializator& Serializator);
     /// Update index for existing record

--- a/test/nodejs/search.js
+++ b/test/nodejs/search.js
@@ -1549,6 +1549,7 @@ describe('Gix Position Tests', function () {
         "Kraft wins final Planica event and ski-jumping World Cup",
         "Germany, Norway neck-and-neck after the first series in Planica",
         "a a a b",
+        "a b c d e f g",
         "aa aa aa aa aa bb aa aa aa aa aa cc aa dd",
         "kk " + Array(1022).join("xx ") + "kk mm mm nn",
         "oo pp " + Array(1022).join("rr ") + "ss tt uu"
@@ -1657,6 +1658,13 @@ describe('Gix Position Tests', function () {
             assert.equal(base.search({ $from: "TestStore", Value: "ss rr" }).length, 0);
             assert.equal(base.search({ $from: "TestStore", Value: { $str: "ss rr", $diff: 2 } }).length, 1);
             assert.equal(base.search({ $from: "TestStore", Value: { $str: "ss rr", $diff: 3 } }).length, 1);
+
+            // there should be no matches if we reverse the order of query string and use positive $diff value
+            assert.equal(base.search({ $from: "TestStore", Value: { $str: "a c", $diff: 2 } }).length, 1);
+            assert.equal(base.search({ $from: "TestStore", Value: { $str: "c a", $diff: 2 } }).length, 0);
+            // if we have a negative $diff value then we get a match if the next word is behind or ahead the previous word
+            assert.equal(base.search({ $from: "TestStore", Value: { $str: "a c", $diff: -2 } }).length, 1);
+            assert.equal(base.search({ $from: "TestStore", Value: { $str: "c a", $diff: -2 } }).length, 1);
             // overlapping indices
             assert.equal(base.search({ $from: "TestStore", Value: "oo ss" }).length, 0);
             assert.equal(base.search({ $from: "TestStore", Value: "pp tt" }).length, 0);

--- a/test/nodejs/search.js
+++ b/test/nodejs/search.js
@@ -1548,6 +1548,7 @@ describe('Gix Position Tests', function () {
         "Kraft clinches ski jump title with final-event win",
         "Kraft wins final Planica event and ski-jumping World Cup",
         "Germany, Norway neck-and-neck after the first series in Planica",
+        "a a a b",
         "aa aa aa aa aa bb aa aa aa aa aa cc aa dd",
         "kk " + Array(1022).join("xx ") + "kk mm mm nn",
         "oo pp " + Array(1022).join("rr ") + "ss tt uu"
@@ -1645,6 +1646,8 @@ describe('Gix Position Tests', function () {
 
             assert.equal(base.search({ $from: "TestStore", Value: "xx" }).length, 1);
             assert.equal(base.search({ $from: "TestStore", Value: "xx" })[0].$fq, 1021);
+
+            assert.equal(base.search({ $from: "TestStore", Value: { $str: "a b", $diff: 4 } })[0].$fq, 1);
 
             // false positives (due to modulo positions)
             assert.equal(base.search({ $from: "TestStore", Value: "oo tt" }).length, 1);


### PR DESCRIPTION
I've added a feature that allows searches like "Barack Obama NEAR/4 elections". 

The existing search already allowed phrase search and specifying MaxPosDiff parameter. The parameter however doesn't allow different search differences inside the same phrase. The current modification simply builds a vector of allowed distances between words in the phrase. By default the allowed distance is 1, but you can provide your own list of word ids and allowed distances. 

@blazf: can you please review and let me know if this is an acceptable change before I add this change also on the side of ER.