### PR TITLE
Small fixes in unicode.h and clustering.cpp

### DIFF
--- a/src/glib/base/unicode.h
+++ b/src/glib/base/unicode.h
@@ -154,7 +154,7 @@ public:
 
     // The following wrappers around the UTF-8 encoder return a TStr containing
     // the UTF-8-encoded version of the input string.
-    template<typename TSrcVec> TStr EncodeUtf8Str(const TSrcVec& src, size_t srcIdx, const size_t srcCount) const { TVec<char> temp; EncodeUtf8(src, srcIdx, srcCount, temp); TStr retVal = &(temp[0]); return retVal; }
+    template<typename TSrcVec> TStr EncodeUtf8Str(const TSrcVec& src, size_t srcIdx, const size_t srcCount) const { TVec<char> temp; EncodeUtf8(src, srcIdx, srcCount, temp); temp.Add(0); TStr retVal = &(temp[0]); return retVal; }
     template<typename TSrcVec> TStr EncodeUtf8Str(const TSrcVec& src) const { TVec<char> temp; EncodeUtf8(src, temp); temp.Add(0); TStr retVal = &(temp[0]); return retVal; }
 
     //-----------------------------------------------------------------------

--- a/src/glib/mine/clustering.hpp
+++ b/src/glib/mine/clustering.hpp
@@ -819,7 +819,7 @@ namespace TClustering {
     inline void TDpMeans<TFltVV>::AddCentroid(const TFltVV& FtrVV, TFltVV& ClustDistVV, TFltV& NormC2,
             TFltV& TempK, TFltVV& TempDxK, TFltVV& TempDxK2, const int& InstN) {
         TFltV FtrV;  FtrVV.GetCol(InstN, FtrV);
-        CentroidVV.AddCol(FtrV);
+		this->CentroidVV.AddCol(FtrV); // access through 'this', otherwise MSVC complains; see https://stackoverflow.com/questions/4643074/why-do-i-have-to-access-template-base-class-members-through-the-this-pointer
         ClustDistVV.AddXDim();
         NormC2.Add(0);
         TempK.Add(0);
@@ -831,9 +831,9 @@ namespace TClustering {
     template<>
     inline void TDpMeans<TFltVV>::AddCentroid(const TVec<TIntFltKdV>& FtrVV, TFltVV& ClustDistVV,
             TFltV& NormC2, TFltV& TempK, TFltVV& TempDxK, TFltVV& TempDxK2, const int& InstN) {
-        TIntFltKdV FtrV; GetCol(FtrVV, InstN, FtrV);
-        TFltV DenseFtrV; TLinAlgTransform::ToVec(FtrV, DenseFtrV, GetDataDim(FtrVV));
-        CentroidVV.AddCol(DenseFtrV);
+        TIntFltKdV FtrV; this->GetCol(FtrVV, InstN, FtrV); 
+        TFltV DenseFtrV; TLinAlgTransform::ToVec(FtrV, DenseFtrV, this->GetDataDim(FtrVV)); 
+        this->CentroidVV.AddCol(DenseFtrV); 
         ClustDistVV.AddXDim();
         NormC2.Add(0);
         TempK.Add(0);
@@ -848,7 +848,7 @@ namespace TClustering {
             const int& InstN) {
         TFltV FtrV; FtrVV.GetCol(InstN, FtrV);
         TIntFltKdV SparseFtrV; TLinAlgTransform::ToSpVec(FtrV, SparseFtrV);
-        CentroidVV.Add(SparseFtrV);
+        this->CentroidVV.Add(SparseFtrV); 
         ClustDistVV.AddXDim();
         NormC2.Add(0);
         TempK.Add(0);
@@ -862,7 +862,7 @@ namespace TClustering {
             TFltVV& ClustDistVV, TFltV& NormC2, TFltV& TempK, TVec<TIntFltKdV>& TempDxK,
             TVec<TIntFltKdV>& TempDxK2, const int& InstN) {
         const TIntFltKdV& FtrV = FtrVV[InstN];
-        CentroidVV.Add(FtrV);
+        this->CentroidVV.Add(FtrV); 
         ClustDistVV.AddXDim();
         NormC2.Add(0);
         TempK.Add(0);


### PR DESCRIPTION
[unicode.h] One version of TUniCodec::EncodeUtf8Str forgot to add a null terminator before creating a TStr instance, resulting in strings with garbage at the end (and potentially a crash).

[clustering.hpp] In MSVC, methods of TDpMeans<TFltVV> in clustering.hpp don't see members inherited from TAbsKMeans<TFltVV> unless accessed through the 'this' pointer.